### PR TITLE
[SP-23] 회원 등록 API 명세서 작성

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,51 @@
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]
+= Jik-Ting Api Specification
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 4
+:author: Cupid
+:email: piq2255@gmail.com
+
+== Common Responses
+=== Common Status Codes
+```java
+# 성공
+status code: 200
+```
+
+=== Common Exceptions
+
+```java
+# 클라이언트 입력 예외
+status code: 400
+
+# 인증 예외
+status code: 401
+
+# 권한 예외
+status code: 403
+
+# NotFound 예외
+status code: 404
+
+# 서버 내부 예외
+status code: 500
+```
+
+== 기능
+
+=== 회원 관련 기능
+==== 회원가입
+----
+/api/v1/members
+----
+===== 성공
+.request
+include::{snippets}/signup-success/http-request.adoc[]
+
+.response
+include::{snippets}/signup-success/http-response.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -49,3 +49,9 @@ include::{snippets}/signup-success/http-request.adoc[]
 
 .response
 include::{snippets}/signup-success/http-response.adoc[]
+===== 실패
+.request
+include::{snippets}/signup-fail/http-request.adoc[]
+
+.response
+include::{snippets}/signup-fail/http-response.adoc[]

--- a/src/main/java/com/cupid/jikting/member/controller/MemberController.java
+++ b/src/main/java/com/cupid/jikting/member/controller/MemberController.java
@@ -1,0 +1,24 @@
+package com.cupid.jikting.member.controller;
+
+import com.cupid.jikting.member.dto.SignupRequest;
+import com.cupid.jikting.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/members")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping
+    public ResponseEntity<Void> signup(@RequestBody SignupRequest signupRequest) {
+        memberService.signup(signupRequest);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/cupid/jikting/member/dto/SignupRequest.java
+++ b/src/main/java/com/cupid/jikting/member/dto/SignupRequest.java
@@ -1,0 +1,15 @@
+package com.cupid.jikting.member.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SignupRequest {
+
+    private String username;
+    private String password;
+    private String name;
+    private String phone;
+}

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -1,0 +1,9 @@
+package com.cupid.jikting.member.service;
+
+import com.cupid.jikting.member.dto.SignupRequest;
+
+public class MemberService {
+
+    public void signup(SignupRequest signupRequest) {
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,5 @@
+server.servlet.context-path=/api/v1
+
 spring.datasource.url=jdbc:mysql://localhost:3306/cupid?serverTimezone=UTC&characterEncoding=UTF-8
 spring.datasource.username=root
 spring.datasource.password=root

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -14,7 +14,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(MemberController.class)
 public class MemberControllerTest extends ApiDocument {
 
-    public static final String CONTEXT_PATH = "/api/v1";
+    private static final String CONTEXT_PATH = "/api/v1";
     private static final String USERNAME = "아이디";
     private static final String PASSWORD = "비밀번호";
     private static final String NAME = "이름";

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -2,11 +2,15 @@ package com.cupid.jikting.member.controller;
 
 import com.cupid.jikting.ApiDocument;
 import com.cupid.jikting.member.dto.SignupRequest;
+import com.cupid.jikting.member.service.MemberService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -20,15 +24,25 @@ public class MemberControllerTest extends ApiDocument {
     private static final String NAME = "이름";
     private static final String PHONE = "전화번호";
 
-    @Test
-    void 회원가입_성공() throws Exception {
-        // given
-        SignupRequest signupRequest = SignupRequest.builder()
+    private SignupRequest signupRequest;
+
+    @MockBean
+    private MemberService memberService;
+
+    @BeforeEach
+    void setUp() {
+        signupRequest = SignupRequest.builder()
                 .username(USERNAME)
                 .password(PASSWORD)
                 .name(NAME)
                 .phone(PHONE)
                 .build();
+    }
+
+    @Test
+    void 회원가입_성공() throws Exception {
+        // given
+        willDoNothing().given(memberService).signup(any(SignupRequest.class));
         // when
         ResultActions resultActions = 회원가입_요청(signupRequest);
         // then

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -1,16 +1,20 @@
 package com.cupid.jikting.member.controller;
 
 import com.cupid.jikting.ApiDocument;
+import com.cupid.jikting.common.error.ApplicationError;
+import com.cupid.jikting.common.error.BadRequestException;
 import com.cupid.jikting.member.dto.SignupRequest;
 import com.cupid.jikting.member.service.MemberService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -49,6 +53,16 @@ public class MemberControllerTest extends ApiDocument {
         회원가입_요청_성공(resultActions);
     }
 
+    @Test
+    void 회원가입_실패() throws Exception {
+        // given
+        willThrow(new BadRequestException(ApplicationError.INVALID_FORMAT)).given(memberService).signup(any(SignupRequest.class));
+        // when
+        ResultActions resultActions = 회원가입_요청(signupRequest);
+        // then
+        회원가입_요청_실패(resultActions);
+    }
+
     private ResultActions 회원가입_요청(SignupRequest signupRequest) throws Exception {
         return mockMvc.perform(post(CONTEXT_PATH + "/members")
                 .contextPath(CONTEXT_PATH)
@@ -60,5 +74,11 @@ public class MemberControllerTest extends ApiDocument {
         resultActions.andExpect(status().isOk())
                 .andDo(print())
                 .andDo(toDocument("signup-success"));
+    }
+
+    private void 회원가입_요청_실패(ResultActions resultActions) throws Exception {
+        resultActions.andExpect(status().isBadRequest())
+                .andDo(print())
+                .andDo(toDocument("signup-fail"));
     }
 }

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -1,0 +1,50 @@
+package com.cupid.jikting.member.controller;
+
+import com.cupid.jikting.ApiDocument;
+import com.cupid.jikting.member.dto.SignupRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MemberController.class)
+public class MemberControllerTest extends ApiDocument {
+
+    public static final String CONTEXT_PATH = "/api/v1";
+    private static final String USERNAME = "아이디";
+    private static final String PASSWORD = "비밀번호";
+    private static final String NAME = "이름";
+    private static final String PHONE = "전화번호";
+
+    @Test
+    void 회원가입_성공() throws Exception {
+        // given
+        SignupRequest signupRequest = SignupRequest.builder()
+                .username(USERNAME)
+                .password(PASSWORD)
+                .name(NAME)
+                .phone(PHONE)
+                .build();
+        // when
+        ResultActions resultActions = 회원가입_요청(signupRequest);
+        // then
+        회원가입_요청_성공(resultActions);
+    }
+
+    private ResultActions 회원가입_요청(SignupRequest signupRequest) throws Exception {
+        return mockMvc.perform(post(CONTEXT_PATH + "/members")
+                .contextPath(CONTEXT_PATH)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(toJson(signupRequest)));
+    }
+
+    private void 회원가입_요청_성공(ResultActions resultActions) throws Exception {
+        resultActions.andExpect(status().isOk())
+                .andDo(print())
+                .andDo(toDocument("signup-success"));
+    }
+}


### PR DESCRIPTION
## Issue

closed #3 
[SP-23](https://soma-cupid.atlassian.net/browse/SP-23?atlOrigin=eyJpIjoiN2NlNGIzMTU1ODIzNDY0YTgzM2RjNDA2NDI2YmExMTAiLCJwIjoiaiJ9)

## 요구사항

- [ ] JWT 토큰 적용
- [x] 회원 등록 성공 API 명세서 작성
- [x] 회원 등록 실패 API 명세서 작성

## 변경사항

- `application.properties`에 context-path 추가
- 회원가입 MVC 테스트를 수행하는 `MemberControllerTest` 추가
- 회원가입 요청을 받는 `MemberController` 추가
- 회원가입 로직을 수행하는 `MemberService` 추가
- 회원가입 요청 DTO `SignupRequest` 추가
- API 명세서를 작성하는 `index.adoc` 추가

## 리뷰 우선순위

🙂 보통

[SP-23]: https://soma-cupid.atlassian.net/browse/SP-23?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ