### PR TITLE
[SP-29] 미팅팀 조회 API 명세서 수정

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -77,7 +77,7 @@ include::{snippets}/update-member-fail/http-response.adoc[]
 === 추천 관련 기능
 ==== 추천 팀 조회
 ----
-/api/v1/recommends/{teamId}
+/api/v1/recommends/teams/{teamId}
 ----
 ===== 성공
 .request

--- a/src/main/java/com/cupid/jikting/recommend/controller/RecommendController.java
+++ b/src/main/java/com/cupid/jikting/recommend/controller/RecommendController.java
@@ -1,6 +1,6 @@
 package com.cupid.jikting.recommend.controller;
 
-import com.cupid.jikting.recommend.dto.RecommendedTeamResponse;
+import com.cupid.jikting.recommend.dto.RecommendResponse;
 import com.cupid.jikting.recommend.service.RecommendService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -16,7 +16,7 @@ public class RecommendController {
     private final RecommendService recommendService;
 
     @GetMapping("/teams/{teamId}")
-    public ResponseEntity<List<RecommendedTeamResponse>> getRecommendedTeam(@PathVariable Long teamId) {
+    public ResponseEntity<List<RecommendResponse>> getRecommendedTeam(@PathVariable Long teamId) {
         return ResponseEntity.ok().body(recommendService.getRecommendedTeam(teamId));
     }
 

--- a/src/main/java/com/cupid/jikting/recommend/controller/RecommendController.java
+++ b/src/main/java/com/cupid/jikting/recommend/controller/RecommendController.java
@@ -13,8 +13,8 @@ public class RecommendController {
 
     private final RecommendService recommendService;
 
-    @GetMapping("/{teamId}")
-    public ResponseEntity<RecommendedTeamResponse> getRecommendedTeam(@PathVariable Long teamId) {
+    @GetMapping("/teams/{teamId}")
+    public ResponseEntity<List<RecommendedTeamResponse>> getRecommendedTeam(@PathVariable Long teamId) {
         return ResponseEntity.ok().body(recommendService.getRecommendedTeam(teamId));
     }
 

--- a/src/main/java/com/cupid/jikting/recommend/controller/RecommendController.java
+++ b/src/main/java/com/cupid/jikting/recommend/controller/RecommendController.java
@@ -6,6 +6,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/recommends")

--- a/src/main/java/com/cupid/jikting/recommend/dto/RecommendResponse.java
+++ b/src/main/java/com/cupid/jikting/recommend/dto/RecommendResponse.java
@@ -8,7 +8,7 @@ import java.util.List;
 @Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class RecommendedTeamResponse {
+public class RecommendResponse {
 
     private Long recommendId;
     private List<MemberResponse> members;

--- a/src/main/java/com/cupid/jikting/recommend/service/RecommendService.java
+++ b/src/main/java/com/cupid/jikting/recommend/service/RecommendService.java
@@ -1,6 +1,6 @@
 package com.cupid.jikting.recommend.service;
 
-import com.cupid.jikting.recommend.dto.RecommendedTeamResponse;
+import com.cupid.jikting.recommend.dto.RecommendResponse;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -8,7 +8,7 @@ import java.util.List;
 @Service
 public class RecommendService {
 
-    public List<RecommendedTeamResponse> getRecommendedTeam(Long teamId) {
+    public List<RecommendResponse> getRecommendedTeam(Long teamId) {
         return null;
     }
 

--- a/src/main/java/com/cupid/jikting/recommend/service/RecommendService.java
+++ b/src/main/java/com/cupid/jikting/recommend/service/RecommendService.java
@@ -3,10 +3,12 @@ package com.cupid.jikting.recommend.service;
 import com.cupid.jikting.recommend.dto.RecommendedTeamResponse;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 public class RecommendService {
 
-    public RecommendedTeamResponse getRecommendedTeam(Long teamId) {
+    public List<RecommendedTeamResponse> getRecommendedTeam(Long teamId) {
         return null;
     }
 

--- a/src/test/java/com/cupid/jikting/recommend/controller/RecommendControllerTest.java
+++ b/src/test/java/com/cupid/jikting/recommend/controller/RecommendControllerTest.java
@@ -7,7 +7,7 @@ import com.cupid.jikting.common.error.ApplicationException;
 import com.cupid.jikting.common.error.NotFoundException;
 import com.cupid.jikting.recommend.dto.ImageResponse;
 import com.cupid.jikting.recommend.dto.MemberResponse;
-import com.cupid.jikting.recommend.dto.RecommendedTeamResponse;
+import com.cupid.jikting.recommend.dto.RecommendResponse;
 import com.cupid.jikting.recommend.service.RecommendService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -43,7 +43,7 @@ public class RecommendControllerTest extends ApiDocument {
     private static final Long ID = 1L;
     private static final boolean TRUE = true;
 
-    private List<RecommendedTeamResponse> recommendedTeamResponses;
+    private List<RecommendResponse> recommendResponses;
     private ApplicationException teamNotFoundException;
 
     @MockBean
@@ -75,13 +75,13 @@ public class RecommendControllerTest extends ApiDocument {
                         .images(imageResponses)
                         .build())
                 .collect(Collectors.toList());
-        RecommendedTeamResponse recommendedTeamResponse = RecommendedTeamResponse.builder()
+        RecommendResponse recommendResponse = RecommendResponse.builder()
                 .recommendId(ID)
                 .members(memberResponses)
                 .personalities(personalities)
                 .build();
-        recommendedTeamResponses = IntStream.rangeClosed(0, 2)
-                .mapToObj(n -> recommendedTeamResponse)
+        this.recommendResponses = IntStream.rangeClosed(0, 2)
+                .mapToObj(n -> recommendResponse)
                 .collect(Collectors.toList());
         teamNotFoundException = new NotFoundException(ApplicationError.TEAM_NOT_FOUND);
     }
@@ -89,7 +89,7 @@ public class RecommendControllerTest extends ApiDocument {
     @Test
     void 추천팀_조회_성공() throws Exception {
         //given
-        willReturn(recommendedTeamResponses).given(recommendService).getRecommendedTeam(anyLong());
+        willReturn(recommendResponses).given(recommendService).getRecommendedTeam(anyLong());
         //when
         ResultActions resultActions = 추천팀_조회_요청();
         //then
@@ -134,7 +134,7 @@ public class RecommendControllerTest extends ApiDocument {
     private void 추천팀_조회_요청_성공(ResultActions resultActions) throws Exception {
         printAndMakeSnippet(resultActions
                         .andExpect(status().isOk())
-                        .andExpect(content().json(toJson(recommendedTeamResponses))),
+                        .andExpect(content().json(toJson(recommendResponses))),
                 "get-recommended-team-success");
     }
 

--- a/src/test/java/com/cupid/jikting/recommend/controller/RecommendControllerTest.java
+++ b/src/test/java/com/cupid/jikting/recommend/controller/RecommendControllerTest.java
@@ -43,7 +43,7 @@ public class RecommendControllerTest extends ApiDocument {
     private static final Long ID = 1L;
     private static final boolean TRUE = true;
 
-    private RecommendedTeamResponse recommendedTeamResponse;
+    private List<RecommendedTeamResponse> recommendedTeamResponses;
     private ApplicationException teamNotFoundException;
 
     @MockBean
@@ -75,18 +75,21 @@ public class RecommendControllerTest extends ApiDocument {
                         .images(imageResponses)
                         .build())
                 .collect(Collectors.toList());
-        recommendedTeamResponse = RecommendedTeamResponse.builder()
+        RecommendedTeamResponse recommendedTeamResponse = RecommendedTeamResponse.builder()
                 .recommendId(ID)
                 .members(memberResponses)
                 .personalities(personalities)
                 .build();
+        recommendedTeamResponses = IntStream.rangeClosed(0, 2)
+                .mapToObj(n -> recommendedTeamResponse)
+                .collect(Collectors.toList());
         teamNotFoundException = new NotFoundException(ApplicationError.TEAM_NOT_FOUND);
     }
 
     @Test
     void 추천팀_조회_성공() throws Exception {
         //given
-        willReturn(recommendedTeamResponse).given(recommendService).getRecommendedTeam(anyLong());
+        willReturn(recommendedTeamResponses).given(recommendService).getRecommendedTeam(anyLong());
         //when
         ResultActions resultActions = 추천팀_조회_요청();
         //then
@@ -131,7 +134,7 @@ public class RecommendControllerTest extends ApiDocument {
     private void 추천팀_조회_요청_성공(ResultActions resultActions) throws Exception {
         printAndMakeSnippet(resultActions
                         .andExpect(status().isOk())
-                        .andExpect(content().json(toJson(recommendedTeamResponse))),
+                        .andExpect(content().json(toJson(recommendedTeamResponses))),
                 "get-recommended-team-success");
     }
 

--- a/src/test/java/com/cupid/jikting/recommend/controller/RecommendControllerTest.java
+++ b/src/test/java/com/cupid/jikting/recommend/controller/RecommendControllerTest.java
@@ -124,7 +124,7 @@ public class RecommendControllerTest extends ApiDocument {
     }
 
     private ResultActions 추천팀_조회_요청() throws Exception {
-        return mockMvc.perform(get(CONTEXT_PATH + DOMAIN_ROOT_PATH + SLASH + ID)
+        return mockMvc.perform(get(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/teams" + SLASH + ID)
                 .contextPath(CONTEXT_PATH));
     }
 


### PR DESCRIPTION
## Issue

closed #13
[SP-29](https://soma-cupid.atlassian.net/browse/SP-29?atlOrigin=eyJpIjoiMzhlODViM2U0ZDA5NGMyZGJkZmYxZTEzOGI0NjkwYzMiLCJwIjoiaiJ9)

## 요구사항

- [x] 미팅팀 조회 api path 수정
- [x] 미팅팀 조회 response List로 감싸기

## 변경사항

- `index.adoc` 추천팀 조회 api 경로 변경
- RecommendController 추천팀 조회 api 경로 변경
- RecommendController 추천팀 조회 response 변경
- RecommendControllerTest 추천팀 조회 api 경로 변경
- RecommendControllerTest 추천팀 조회 response 변경
- RecommendService getRecommendedTeam return 변경

## 리뷰 우선순위

🙂 보통


[SP-29]: https://soma-cupid.atlassian.net/browse/SP-29?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ