### PR TITLE
[SP-117] 받은 호감 목록 조회 API 명세서 작성

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -81,16 +81,16 @@ include::{snippets}/update-member-fail/http-response.adoc[]
 ----
 ===== 성공
 .request
-include::{snippets}/get-recommended-team-success/http-request.adoc[]
+include::{snippets}/get-recommends-success/http-request.adoc[]
 
 .response
-include::{snippets}/get-recommended-team-success/http-response.adoc[]
+include::{snippets}/get-recommends-success/http-response.adoc[]
 ===== 실패
 .request
-include::{snippets}/get-recommended-team-fail/http-request.adoc[]
+include::{snippets}/get-recommends-fail/http-request.adoc[]
 
 .response
-include::{snippets}/get-recommended-team-fail/http-response.adoc[]
+include::{snippets}/get-recommends-fail/http-response.adoc[]
 
 ==== 호감 보내기
 ----

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -108,3 +108,20 @@ include::{snippets}/send-like-fail/http-request.adoc[]
 
 .response
 include::{snippets}/send-like-fail/http-response.adoc[]
+
+==== 받은 호감 목록 조회
+----
+/api/v1/meetings/likes/received
+----
+===== 성공
+.request
+include::{snippets}/get-received-likes-success/http-request.adoc[]
+
+.response
+include::{snippets}/get-received-likes-success/http-response.adoc[]
+===== 실패
+.request
+include::{snippets}/get-received-likes-fail/http-request.adoc[]
+
+.response
+include::{snippets}/get-received-likes-fail/http-response.adoc[]

--- a/src/main/java/com/cupid/jikting/meeting/controller/MeetingController.java
+++ b/src/main/java/com/cupid/jikting/meeting/controller/MeetingController.java
@@ -21,5 +21,4 @@ public class MeetingController {
     public ResponseEntity<List<TeamProfileResponse>> getReceivedLikes() {
         return ResponseEntity.ok().body(meetingService.getReceivedLikes());
     }
-
 }

--- a/src/main/java/com/cupid/jikting/meeting/controller/MeetingController.java
+++ b/src/main/java/com/cupid/jikting/meeting/controller/MeetingController.java
@@ -1,0 +1,25 @@
+package com.cupid.jikting.meeting.controller;
+
+import com.cupid.jikting.meeting.dto.TeamProfileResponse;
+import com.cupid.jikting.meeting.service.MeetingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/meetings")
+public class MeetingController {
+
+    private final MeetingService meetingService;
+
+    @GetMapping("/likes/received")
+    public ResponseEntity<List<TeamProfileResponse>> getReceivedLikes() {
+        return ResponseEntity.ok().body(meetingService.getReceivedLikes());
+    }
+
+}

--- a/src/main/java/com/cupid/jikting/meeting/dto/TeamProfileResponse.java
+++ b/src/main/java/com/cupid/jikting/meeting/dto/TeamProfileResponse.java
@@ -1,0 +1,16 @@
+package com.cupid.jikting.meeting.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TeamProfileResponse {
+
+    private String name;
+    private List<String> keywords;
+    private List<String> imageUrls;
+}

--- a/src/main/java/com/cupid/jikting/meeting/service/MeetingService.java
+++ b/src/main/java/com/cupid/jikting/meeting/service/MeetingService.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 @Service
 public class MeetingService {
+
     public List<TeamProfileResponse> getReceivedLikes() {
         return null;
     }

--- a/src/main/java/com/cupid/jikting/meeting/service/MeetingService.java
+++ b/src/main/java/com/cupid/jikting/meeting/service/MeetingService.java
@@ -1,0 +1,13 @@
+package com.cupid.jikting.meeting.service;
+
+import com.cupid.jikting.meeting.dto.TeamProfileResponse;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class MeetingService {
+    public List<TeamProfileResponse> getReceivedLikes() {
+        return null;
+    }
+}

--- a/src/test/java/com/cupid/jikting/meeting/controller/MeetingControllerTest.java
+++ b/src/test/java/com/cupid/jikting/meeting/controller/MeetingControllerTest.java
@@ -37,7 +37,7 @@ public class MeetingControllerTest extends ApiDocument {
     private ApplicationException teamNotFoundException;
 
     @MockBean
-    MeetingService meetingService;
+    private MeetingService meetingService;
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/com/cupid/jikting/meeting/controller/MeetingControllerTest.java
+++ b/src/test/java/com/cupid/jikting/meeting/controller/MeetingControllerTest.java
@@ -1,0 +1,100 @@
+package com.cupid.jikting.meeting.controller;
+
+import com.cupid.jikting.ApiDocument;
+import com.cupid.jikting.common.dto.ErrorResponse;
+import com.cupid.jikting.common.error.ApplicationError;
+import com.cupid.jikting.common.error.ApplicationException;
+import com.cupid.jikting.common.error.NotFoundException;
+import com.cupid.jikting.meeting.dto.TeamProfileResponse;
+import com.cupid.jikting.meeting.service.MeetingService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.mockito.BDDMockito.willReturn;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MeetingController.class)
+public class MeetingControllerTest extends ApiDocument {
+
+    private static final String CONTEXT_PATH = "/api/v1";
+    private static final String DOMAIN_ROOT_PATH = "/meetings";
+    private static final String LIKE_PATH = "/likes";
+    private static final String KEYWORD = "키워드";
+    private static final String URL = "http://test-url";
+    private static final String NAME = "팀명";
+
+    private List<TeamProfileResponse> teamProfileResponses;
+    private ApplicationException teamNotFoundException;
+
+    @MockBean
+    MeetingService meetingService;
+
+    @BeforeEach
+    void setUp() {
+        List<String> keywords = IntStream.rangeClosed(1, 3)
+                .mapToObj(n -> KEYWORD + n)
+                .collect(Collectors.toList());
+        List<String> imageUrls = IntStream.rangeClosed(1, 3)
+                .mapToObj(n -> URL + n)
+                .collect(Collectors.toList());
+        TeamProfileResponse teamProfileResponse = TeamProfileResponse.builder()
+                .name(NAME)
+                .keywords(keywords)
+                .imageUrls(imageUrls)
+                .build();
+        teamProfileResponses = IntStream.rangeClosed(0, 2)
+                .mapToObj(n -> teamProfileResponse)
+                .collect(Collectors.toList());
+        teamNotFoundException = new NotFoundException(ApplicationError.TEAM_NOT_FOUND);
+    }
+
+    @Test
+    void 받은_호감_목록_조회_성공() throws Exception {
+        //given
+        willReturn(teamProfileResponses).given(meetingService).getReceivedLikes();
+        //when
+        ResultActions resultActions = 받은_호감_목록_조회_요청();
+        //then
+        받은_호감_목록_조회_요청_성공(resultActions);
+    }
+
+    @Test
+    void 받은_호감_목록_조회_실패() throws Exception {
+        //given
+        willThrow(teamNotFoundException).given(meetingService).getReceivedLikes();
+        //when
+        ResultActions resultActions = 받은_호감_목록_조회_요청();
+        //then
+        받은_호감_목록_조회_요청_실패(resultActions);
+    }
+
+    private ResultActions 받은_호감_목록_조회_요청() throws Exception {
+        ResultActions resultActions = mockMvc.perform(get(CONTEXT_PATH + DOMAIN_ROOT_PATH + LIKE_PATH + "/received")
+                .contextPath(CONTEXT_PATH));
+        return resultActions;
+    }
+
+    private void 받은_호감_목록_조회_요청_성공(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isOk())
+                        .andExpect(content().json(toJson(teamProfileResponses))),
+                "get-received-likes-success");
+    }
+
+    private void 받은_호감_목록_조회_요청_실패(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isBadRequest())
+                        .andExpect(content().json(toJson(ErrorResponse.from(teamNotFoundException)))),
+                "get-received-likes-fail");
+    }
+}

--- a/src/test/java/com/cupid/jikting/recommend/controller/RecommendControllerTest.java
+++ b/src/test/java/com/cupid/jikting/recommend/controller/RecommendControllerTest.java
@@ -132,14 +132,14 @@ public class RecommendControllerTest extends ApiDocument {
         printAndMakeSnippet(resultActions
                         .andExpect(status().isOk())
                         .andExpect(content().json(toJson(recommendedTeamResponse))),
-                "get-recommended-team-success");
+                "get-recommends-success");
     }
 
     private void 추천팀_조회_요청_실패(ResultActions resultActions) throws Exception {
         printAndMakeSnippet(resultActions
                         .andExpect(status().isBadRequest())
                         .andExpect(content().json(toJson(ErrorResponse.from(teamNotFoundException)))),
-                "get-recommended-team-fail");
+                "get-recommends-fail");
     }
 
     private ResultActions 호감_보내기_요청() throws Exception {


### PR DESCRIPTION
## Issue

closed #16
[SP-117](https://soma-cupid.atlassian.net/browse/SP-117?atlOrigin=eyJpIjoiZjNiYzQwNzUwMWMwNDM0Yjk5NjUxMWVmODA2OWU3MzUiLCJwIjoiaiJ9)

## 요구사항

- [x] 받은 호감 목록 조회 성공 API 명세서 작성
- [x] 받은 호감 목록 조회 실패 API 명세서 작성

## 변경사항

- `MeetingController` 추가
- `MeetingService` 추가
- 팀 프로필 응답 DTO `TeamProfileResponse` 추가
- `MeetingControllerTest` 추가

## 리뷰 우선순위

🙂 보통

## 코멘트

받은 호감 조회 및 보낸 호감 조회를 meeting domain으로 했는데 like domain이 나을까요?

[SP-117]: https://soma-cupid.atlassian.net/browse/SP-117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ