### PR TITLE
[SP-121] 보낸 호감 목록 조회 API 명세서 작성

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -90,6 +90,40 @@ include::{snippets}/update-member-fail/http-request.adoc[]
 .response
 include::{snippets}/update-member-fail/http-response.adoc[]
 
+=== 팀 관련 기능
+==== 받은 호감 목록 조회
+----
+/api/v1/teams/{teamId}/likes/received
+----
+===== 성공
+.request
+include::{snippets}/get-received-likes-success/http-request.adoc[]
+
+.response
+include::{snippets}/get-received-likes-success/http-response.adoc[]
+===== 실패
+.request
+include::{snippets}/get-received-likes-fail/http-request.adoc[]
+
+.response
+include::{snippets}/get-received-likes-fail/http-response.adoc[]
+==== 보낸 호감 목록 조회
+----
+/api/v1/teams/{teamId}/likes/sent
+----
+===== 성공
+.request
+include::{snippets}/get-sent-likes-success/http-request.adoc[]
+
+.response
+include::{snippets}/get-sent-likes-success/http-response.adoc[]
+===== 실패
+.request
+include::{snippets}/get-sent-likes-fail/http-request.adoc[]
+
+.response
+include::{snippets}/get-sent-likes-fail/http-response.adoc[]
+
 === 추천 관련 기능
 ==== 추천 팀 조회
 ----
@@ -125,36 +159,3 @@ include::{snippets}/send-like-fail/http-request.adoc[]
 .response
 include::{snippets}/send-like-fail/http-response.adoc[]
 
-=== 미팅 관련 기능
-==== 받은 호감 목록 조회
-----
-/api/v1/meetings/likes/received
-----
-===== 성공
-.request
-include::{snippets}/get-received-likes-success/http-request.adoc[]
-
-.response
-include::{snippets}/get-received-likes-success/http-response.adoc[]
-===== 실패
-.request
-include::{snippets}/get-received-likes-fail/http-request.adoc[]
-
-.response
-include::{snippets}/get-received-likes-fail/http-response.adoc[]
-==== 보낸 호감 목록 조회
-----
-/api/v1/meetings/likes/sent
-----
-===== 성공
-.request
-include::{snippets}/get-sent-likes-success/http-request.adoc[]
-
-.response
-include::{snippets}/get-sent-likes-success/http-response.adoc[]
-===== 실패
-.request
-include::{snippets}/get-sent-likes-fail/http-request.adoc[]
-
-.response
-include::{snippets}/get-sent-likes-fail/http-response.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -125,6 +125,7 @@ include::{snippets}/send-like-fail/http-request.adoc[]
 .response
 include::{snippets}/send-like-fail/http-response.adoc[]
 
+=== 미팅 관련 기능
 ==== 받은 호감 목록 조회
 ----
 /api/v1/meetings/likes/received
@@ -141,3 +142,19 @@ include::{snippets}/get-received-likes-fail/http-request.adoc[]
 
 .response
 include::{snippets}/get-received-likes-fail/http-response.adoc[]
+==== 보낸 호감 목록 조회
+----
+/api/v1/meetings/likes/sent
+----
+===== 성공
+.request
+include::{snippets}/get-sent-likes-success/http-request.adoc[]
+
+.response
+include::{snippets}/get-sent-likes-success/http-response.adoc[]
+===== 실패
+.request
+include::{snippets}/get-sent-likes-fail/http-request.adoc[]
+
+.response
+include::{snippets}/get-sent-likes-fail/http-response.adoc[]

--- a/src/main/java/com/cupid/jikting/meeting/controller/MeetingController.java
+++ b/src/main/java/com/cupid/jikting/meeting/controller/MeetingController.java
@@ -21,4 +21,9 @@ public class MeetingController {
     public ResponseEntity<List<TeamProfileResponse>> getReceivedLikes() {
         return ResponseEntity.ok().body(meetingService.getReceivedLikes());
     }
+
+    @GetMapping("/likes/sent")
+    public ResponseEntity<List<TeamProfileResponse>> getSentLikes() {
+        return ResponseEntity.ok().body(meetingService.getSentLikes());
+    }
 }

--- a/src/main/java/com/cupid/jikting/meeting/service/MeetingService.java
+++ b/src/main/java/com/cupid/jikting/meeting/service/MeetingService.java
@@ -11,4 +11,8 @@ public class MeetingService {
     public List<TeamProfileResponse> getReceivedLikes() {
         return null;
     }
+
+    public List<TeamProfileResponse> getSentLikes() {
+        return null;
+    }
 }

--- a/src/main/java/com/cupid/jikting/team/controller/TeamController.java
+++ b/src/main/java/com/cupid/jikting/team/controller/TeamController.java
@@ -18,13 +18,13 @@ public class TeamController {
 
     private final TeamService teamService;
 
-    @GetMapping("/likes/received")
-    public ResponseEntity<List<TeamProfileResponse>> getReceivedLikes() {
-        return ResponseEntity.ok().body(meetingService.getReceivedLikes());
+    @GetMapping("/{teamId}/likes/received")
+    public ResponseEntity<List<TeamProfileResponse>> getReceivedLikes(@PathVariable Long teamId) {
+        return ResponseEntity.ok().body(teamService.getReceivedLikes(teamId));
     }
 
-    @GetMapping("/likes/sent")
-    public ResponseEntity<List<TeamProfileResponse>> getSentLikes() {
-        return ResponseEntity.ok().body(meetingService.getSentLikes());
+    @GetMapping("/{teamId}/likes/sent")
+    public ResponseEntity<List<TeamProfileResponse>> getSentLikes(@PathVariable Long teamId) {
+        return ResponseEntity.ok().body(teamService.getSentLikes(teamId));
     }
 }

--- a/src/main/java/com/cupid/jikting/team/controller/TeamController.java
+++ b/src/main/java/com/cupid/jikting/team/controller/TeamController.java
@@ -1,10 +1,11 @@
-package com.cupid.jikting.meeting.controller;
+package com.cupid.jikting.team.controller;
 
-import com.cupid.jikting.meeting.dto.TeamProfileResponse;
-import com.cupid.jikting.meeting.service.MeetingService;
+import com.cupid.jikting.team.dto.TeamProfileResponse;
+import com.cupid.jikting.team.service.TeamService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -12,10 +13,10 @@ import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/meetings")
-public class MeetingController {
+@RequestMapping("/teams")
+public class TeamController {
 
-    private final MeetingService meetingService;
+    private final TeamService teamService;
 
     @GetMapping("/likes/received")
     public ResponseEntity<List<TeamProfileResponse>> getReceivedLikes() {

--- a/src/main/java/com/cupid/jikting/team/dto/TeamProfileResponse.java
+++ b/src/main/java/com/cupid/jikting/team/dto/TeamProfileResponse.java
@@ -1,4 +1,4 @@
-package com.cupid.jikting.meeting.dto;
+package com.cupid.jikting.team.dto;
 
 import lombok.*;
 

--- a/src/main/java/com/cupid/jikting/team/service/TeamService.java
+++ b/src/main/java/com/cupid/jikting/team/service/TeamService.java
@@ -1,12 +1,12 @@
-package com.cupid.jikting.meeting.service;
+package com.cupid.jikting.team.service;
 
-import com.cupid.jikting.meeting.dto.TeamProfileResponse;
+import com.cupid.jikting.team.dto.TeamProfileResponse;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
 @Service
-public class MeetingService {
+public class TeamService {
 
     public List<TeamProfileResponse> getReceivedLikes() {
         return null;

--- a/src/main/java/com/cupid/jikting/team/service/TeamService.java
+++ b/src/main/java/com/cupid/jikting/team/service/TeamService.java
@@ -8,11 +8,11 @@ import java.util.List;
 @Service
 public class TeamService {
 
-    public List<TeamProfileResponse> getReceivedLikes() {
+    public List<TeamProfileResponse> getReceivedLikes(Long teamId) {
         return null;
     }
 
-    public List<TeamProfileResponse> getSentLikes() {
+    public List<TeamProfileResponse> getSentLikes(Long teamId) {
         return null;
     }
 }

--- a/src/test/java/com/cupid/jikting/meeting/controller/MeetingControllerTest.java
+++ b/src/test/java/com/cupid/jikting/meeting/controller/MeetingControllerTest.java
@@ -78,6 +78,26 @@ public class MeetingControllerTest extends ApiDocument {
         받은_호감_목록_조회_요청_실패(resultActions);
     }
 
+    @Test
+    void 보낸_호감_목록_조회_성공() throws Exception {
+        //given
+        willReturn(teamProfileResponses).given(meetingService).getSentLikes();
+        //when
+        ResultActions resultActions = 보낸_호감_목록_조회_요청();
+        //then
+        보낸_호감_목록_조회_요청_성공(resultActions);
+    }
+
+    @Test
+    void 보낸_호감_목록_조회_실패() throws Exception {
+        //given
+        willThrow(teamNotFoundException).given(meetingService).getSentLikes();
+        //when
+        ResultActions resultActions = 보낸_호감_목록_조회_요청();
+        //then
+        보낸_호감_목록_조회_요청_실패(resultActions);
+    }
+
     private ResultActions 받은_호감_목록_조회_요청() throws Exception {
         ResultActions resultActions = mockMvc.perform(get(CONTEXT_PATH + DOMAIN_ROOT_PATH + LIKE_PATH + "/received")
                 .contextPath(CONTEXT_PATH));
@@ -96,5 +116,25 @@ public class MeetingControllerTest extends ApiDocument {
                         .andExpect(status().isBadRequest())
                         .andExpect(content().json(toJson(ErrorResponse.from(teamNotFoundException)))),
                 "get-received-likes-fail");
+    }
+
+    private ResultActions 보낸_호감_목록_조회_요청() throws Exception {
+        ResultActions resultActions = mockMvc.perform(get(CONTEXT_PATH + DOMAIN_ROOT_PATH + LIKE_PATH + "/sent")
+                .contextPath(CONTEXT_PATH));
+        return resultActions;
+    }
+
+    private void 보낸_호감_목록_조회_요청_성공(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isOk())
+                        .andExpect(content().json(toJson(teamProfileResponses))),
+                "get-sent-likes-success");
+    }
+
+    private void 보낸_호감_목록_조회_요청_실패(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isBadRequest())
+                        .andExpect(content().json(toJson(ErrorResponse.from(teamNotFoundException)))),
+                "get-sent-likes-fail");
     }
 }

--- a/src/test/java/com/cupid/jikting/recommend/controller/RecommendControllerTest.java
+++ b/src/test/java/com/cupid/jikting/recommend/controller/RecommendControllerTest.java
@@ -134,9 +134,8 @@ public class RecommendControllerTest extends ApiDocument {
     private void 추천팀_조회_요청_성공(ResultActions resultActions) throws Exception {
         printAndMakeSnippet(resultActions
                         .andExpect(status().isOk())
-                        .andExpect(content().json(toJson(recommendedTeamResponse))),
-                "get-recommends-success");
                         .andExpect(content().json(toJson(recommendResponses))),
+                "get-recommends-success");
     }
 
     private void 추천팀_조회_요청_실패(ResultActions resultActions) throws Exception {

--- a/src/test/java/com/cupid/jikting/recommend/controller/RecommendControllerTest.java
+++ b/src/test/java/com/cupid/jikting/recommend/controller/RecommendControllerTest.java
@@ -31,7 +31,7 @@ public class RecommendControllerTest extends ApiDocument {
 
     private static final String CONTEXT_PATH = "/api/v1";
     private static final String DOMAIN_ROOT_PATH = "/recommends";
-    private static final String SLASH = "/";
+    private static final String PATH_DELIMITER = "/";
     private static final String HOBBY = "취미";
     private static final String PERSONALITY = "성격";
     private static final String URL = "http://test-url";
@@ -127,7 +127,7 @@ public class RecommendControllerTest extends ApiDocument {
     }
 
     private ResultActions 추천팀_조회_요청() throws Exception {
-        return mockMvc.perform(get(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/teams" + SLASH + ID)
+        return mockMvc.perform(get(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/teams" + PATH_DELIMITER + ID)
                 .contextPath(CONTEXT_PATH));
     }
 
@@ -146,7 +146,7 @@ public class RecommendControllerTest extends ApiDocument {
     }
 
     private ResultActions 호감_보내기_요청() throws Exception {
-        return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH + SLASH + ID + "/like")
+        return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH + PATH_DELIMITER + ID + "/like")
                 .contextPath(CONTEXT_PATH));
     }
 

--- a/src/test/java/com/cupid/jikting/team/controller/TeamControllerTest.java
+++ b/src/test/java/com/cupid/jikting/team/controller/TeamControllerTest.java
@@ -31,6 +31,8 @@ public class TeamControllerTest extends ApiDocument {
     private static final String CONTEXT_PATH = "/api/v1";
     private static final String DOMAIN_ROOT_PATH = "/teams";
     private static final String LIKE_PATH = "/likes";
+    private static final String SLASH = "/";
+    private static final String ID = "1";
     private static final String KEYWORD = "키워드";
     private static final String URL = "http://test-url";
     private static final String NAME = "팀명";
@@ -63,7 +65,7 @@ public class TeamControllerTest extends ApiDocument {
     @Test
     void 받은_호감_목록_조회_성공() throws Exception {
         //given
-        willReturn(teamProfileResponses).given(meetingService).getReceivedLikes();
+        willReturn(teamProfileResponses).given(teamService).getReceivedLikes(anyLong());
         //when
         ResultActions resultActions = 받은_호감_목록_조회_요청();
         //then
@@ -73,7 +75,7 @@ public class TeamControllerTest extends ApiDocument {
     @Test
     void 받은_호감_목록_조회_실패() throws Exception {
         //given
-        willThrow(teamNotFoundException).given(meetingService).getReceivedLikes();
+        willThrow(teamNotFoundException).given(teamService).getReceivedLikes(anyLong());
         //when
         ResultActions resultActions = 받은_호감_목록_조회_요청();
         //then
@@ -83,7 +85,7 @@ public class TeamControllerTest extends ApiDocument {
     @Test
     void 보낸_호감_목록_조회_성공() throws Exception {
         //given
-        willReturn(teamProfileResponses).given(meetingService).getSentLikes();
+        willReturn(teamProfileResponses).given(teamService).getSentLikes(anyLong());
         //when
         ResultActions resultActions = 보낸_호감_목록_조회_요청();
         //then
@@ -93,7 +95,7 @@ public class TeamControllerTest extends ApiDocument {
     @Test
     void 보낸_호감_목록_조회_실패() throws Exception {
         //given
-        willThrow(teamNotFoundException).given(meetingService).getSentLikes();
+        willThrow(teamNotFoundException).given(teamService).getSentLikes(anyLong());
         //when
         ResultActions resultActions = 보낸_호감_목록_조회_요청();
         //then

--- a/src/test/java/com/cupid/jikting/team/controller/TeamControllerTest.java
+++ b/src/test/java/com/cupid/jikting/team/controller/TeamControllerTest.java
@@ -30,7 +30,7 @@ public class TeamControllerTest extends ApiDocument {
     private static final String CONTEXT_PATH = "/api/v1";
     private static final String DOMAIN_ROOT_PATH = "/teams";
     private static final String LIKE_PATH = "/likes";
-    private static final String SLASH = "/";
+    private static final String PATH_DELIMITER = "/";
     private static final String ID = "1";
     private static final String KEYWORD = "키워드";
     private static final String URL = "http://test-url";
@@ -102,7 +102,7 @@ public class TeamControllerTest extends ApiDocument {
     }
 
     private ResultActions 받은_호감_목록_조회_요청() throws Exception {
-        ResultActions resultActions = mockMvc.perform(get(CONTEXT_PATH + DOMAIN_ROOT_PATH + SLASH + ID + LIKE_PATH + "/received")
+        ResultActions resultActions = mockMvc.perform(get(CONTEXT_PATH + DOMAIN_ROOT_PATH + PATH_DELIMITER + ID + LIKE_PATH + "/received")
                 .contextPath(CONTEXT_PATH));
         return resultActions;
     }
@@ -122,7 +122,7 @@ public class TeamControllerTest extends ApiDocument {
     }
 
     private ResultActions 보낸_호감_목록_조회_요청() throws Exception {
-        ResultActions resultActions = mockMvc.perform(get(CONTEXT_PATH + DOMAIN_ROOT_PATH + SLASH + ID + LIKE_PATH + "/sent")
+        ResultActions resultActions = mockMvc.perform(get(CONTEXT_PATH + DOMAIN_ROOT_PATH + PATH_DELIMITER + ID + LIKE_PATH + "/sent")
                 .contextPath(CONTEXT_PATH));
         return resultActions;
     }

--- a/src/test/java/com/cupid/jikting/team/controller/TeamControllerTest.java
+++ b/src/test/java/com/cupid/jikting/team/controller/TeamControllerTest.java
@@ -1,12 +1,13 @@
-package com.cupid.jikting.meeting.controller;
+package com.cupid.jikting.team.controller;
 
 import com.cupid.jikting.ApiDocument;
 import com.cupid.jikting.common.dto.ErrorResponse;
 import com.cupid.jikting.common.error.ApplicationError;
 import com.cupid.jikting.common.error.ApplicationException;
 import com.cupid.jikting.common.error.NotFoundException;
-import com.cupid.jikting.meeting.dto.TeamProfileResponse;
-import com.cupid.jikting.meeting.service.MeetingService;
+import com.cupid.jikting.team.dto.TeamProfileResponse;
+import com.cupid.jikting.team.service.TeamService;
+import com.cupid.jikting.team.controller.TeamController;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -17,17 +18,18 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.willReturn;
 import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(MeetingController.class)
-public class MeetingControllerTest extends ApiDocument {
+@WebMvcTest(TeamController.class)
+public class TeamControllerTest extends ApiDocument {
 
     private static final String CONTEXT_PATH = "/api/v1";
-    private static final String DOMAIN_ROOT_PATH = "/meetings";
+    private static final String DOMAIN_ROOT_PATH = "/teams";
     private static final String LIKE_PATH = "/likes";
     private static final String KEYWORD = "키워드";
     private static final String URL = "http://test-url";
@@ -37,7 +39,7 @@ public class MeetingControllerTest extends ApiDocument {
     private ApplicationException teamNotFoundException;
 
     @MockBean
-    private MeetingService meetingService;
+    private TeamService teamService;
 
     @BeforeEach
     void setUp() {
@@ -99,7 +101,7 @@ public class MeetingControllerTest extends ApiDocument {
     }
 
     private ResultActions 받은_호감_목록_조회_요청() throws Exception {
-        ResultActions resultActions = mockMvc.perform(get(CONTEXT_PATH + DOMAIN_ROOT_PATH + LIKE_PATH + "/received")
+        ResultActions resultActions = mockMvc.perform(get(CONTEXT_PATH + DOMAIN_ROOT_PATH + SLASH + ID + LIKE_PATH + "/received")
                 .contextPath(CONTEXT_PATH));
         return resultActions;
     }
@@ -119,7 +121,7 @@ public class MeetingControllerTest extends ApiDocument {
     }
 
     private ResultActions 보낸_호감_목록_조회_요청() throws Exception {
-        ResultActions resultActions = mockMvc.perform(get(CONTEXT_PATH + DOMAIN_ROOT_PATH + LIKE_PATH + "/sent")
+        ResultActions resultActions = mockMvc.perform(get(CONTEXT_PATH + DOMAIN_ROOT_PATH + SLASH + ID + LIKE_PATH + "/sent")
                 .contextPath(CONTEXT_PATH));
         return resultActions;
     }

--- a/src/test/java/com/cupid/jikting/team/controller/TeamControllerTest.java
+++ b/src/test/java/com/cupid/jikting/team/controller/TeamControllerTest.java
@@ -7,7 +7,6 @@ import com.cupid.jikting.common.error.ApplicationException;
 import com.cupid.jikting.common.error.NotFoundException;
 import com.cupid.jikting.team.dto.TeamProfileResponse;
 import com.cupid.jikting.team.service.TeamService;
-import com.cupid.jikting.team.controller.TeamController;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;


### PR DESCRIPTION
## Issue

closed #19
[SP-121](https://soma-cupid.atlassian.net/browse/SP-121?atlOrigin=eyJpIjoiMDQ4NGE4ZDMwYTYzNDRjNDhmNjcwMTI2MjFmYWFiMmMiLCJwIjoiaiJ9)

## 요구사항

- [x] 보낸 호감 목록 조회 성공 API 명세서 작성
- [x] 보낸 호감 목록 조회 실패 API 명세서 작성

## 변경사항

- `asciidocs` 보낸 호감 목록 조회 api 추가
- `RecommnedControllerTest` 충돌 해결할때 중복으로 발생한 코드 삭제

## 리뷰 우선순위

🙂 보통

## 코멘트

[SP-121]: https://soma-cupid.atlassian.net/browse/SP-121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ