### PR TITLE
[SP-129] 회원 프로필 조회 API 명세서 작성

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -83,6 +83,12 @@ include::{snippets}/get-member-profile-success/http-request.adoc[]
 
 .response
 include::{snippets}/get-member-profile-success/http-response.adoc[]
+===== 실패
+.request
+include::{snippets}/get-member-profile-fail/http-request.adoc[]
+
+.response
+include::{snippets}/get-member-profile-fail/http-response.adoc[]
 
 ==== 회원 수정
 ----

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -39,7 +39,7 @@ status code: 500
 == 기능
 
 === 회원 관련 기능
-==== 회원가입
+==== 회원 가입
 ----
 /api/v1/members
 ----
@@ -56,7 +56,7 @@ include::{snippets}/signup-fail/http-request.adoc[]
 .response
 include::{snippets}/signup-fail/http-response.adoc[]
 
-==== 회원조회
+==== 회원 조회
 ----
 /api/v1/members
 ----
@@ -84,7 +84,7 @@ include::{snippets}/get-member-profile-success/http-request.adoc[]
 .response
 include::{snippets}/get-member-profile-success/http-response.adoc[]
 
-==== 회원수정
+==== 회원 수정
 ----
 /api/v1/members
 ----

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -73,6 +73,17 @@ include::{snippets}/get-member-fail/http-request.adoc[]
 .response
 include::{snippets}/get-member-fail/http-response.adoc[]
 
+==== 회원 프로필 조회
+----
+/api/v1/members/profile
+----
+===== 성공
+.request
+include::{snippets}/get-member-profile-success/http-request.adoc[]
+
+.response
+include::{snippets}/get-member-profile-success/http-response.adoc[]
+
 ==== 회원수정
 ----
 /api/v1/members

--- a/src/main/java/com/cupid/jikting/member/controller/MemberController.java
+++ b/src/main/java/com/cupid/jikting/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.cupid.jikting.member.controller;
 
+import com.cupid.jikting.member.dto.MemberProfileResponse;
 import com.cupid.jikting.member.dto.MemberResponse;
 import com.cupid.jikting.member.dto.MemberUpdateRequest;
 import com.cupid.jikting.member.dto.SignupRequest;
@@ -24,6 +25,11 @@ public class MemberController {
     @GetMapping
     public ResponseEntity<MemberResponse> get() {
         return ResponseEntity.ok().body(memberService.get(1L));
+    }
+
+    @GetMapping("/profile")
+    public ResponseEntity<MemberProfileResponse> getProfile() {
+        return ResponseEntity.ok().body(memberService.getProfile(1L));
     }
 
     @PatchMapping

--- a/src/main/java/com/cupid/jikting/member/dto/ImageResponse.java
+++ b/src/main/java/com/cupid/jikting/member/dto/ImageResponse.java
@@ -1,0 +1,13 @@
+package com.cupid.jikting.member.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ImageResponse {
+
+    private String url;
+    private String sequence;
+}

--- a/src/main/java/com/cupid/jikting/member/dto/MemberProfileResponse.java
+++ b/src/main/java/com/cupid/jikting/member/dto/MemberProfileResponse.java
@@ -1,0 +1,25 @@
+package com.cupid.jikting.member.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberProfileResponse {
+
+    private List<ImageResponse> images;
+    private int age;
+    private int height;
+    private String gender;
+    private String address;
+    private String mbti;
+    private boolean isSmoke;
+    private String drinkStatus;
+    private String college;
+    private List<String> personalities;
+    private List<String> hobbies;
+    private String description;
+}

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.cupid.jikting.member.service;
 
+import com.cupid.jikting.member.dto.MemberProfileResponse;
 import com.cupid.jikting.member.dto.MemberResponse;
 import com.cupid.jikting.member.dto.MemberUpdateRequest;
 import com.cupid.jikting.member.dto.SignupRequest;
@@ -12,6 +13,10 @@ public class MemberService {
     }
 
     public MemberResponse get(Long memberId) {
+        return null;
+    }
+
+    public MemberProfileResponse getProfile(Long memberId) {
         return null;
     }
 

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -81,6 +81,9 @@ public class MemberControllerTest extends ApiDocument {
                 .name(NAME)
                 .phone(PHONE)
                 .build();
+        memberUpdateRequest = MemberUpdateRequest.builder()
+                .nickname(NICKNAME)
+                .build();
         memberResponse = MemberResponse.builder()
                 .nickname(NICKNAME)
                 .company(COMPANY)

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -155,6 +155,16 @@ public class MemberControllerTest extends ApiDocument {
     }
 
     @Test
+    void 회원프로필조회_실패() throws Exception {
+        // given
+        willThrow(memberNotFoundException).given(memberService).getProfile(anyLong());
+        // when
+        ResultActions resultActions = 회원프로필조회_요청();
+        // then
+        회원프로필조회_요청_실패(resultActions);
+    }
+
+    @Test
     void 회원수정_성공() throws Exception {
         // given
         willDoNothing().given(memberService).update(any(MemberUpdateRequest.class));
@@ -223,6 +233,13 @@ public class MemberControllerTest extends ApiDocument {
                         .andExpect(status().isOk())
                         .andExpect(content().json(toJson(memberProfileResponse))),
                 "get-member-profile-success");
+    }
+
+    private void 회원프로필조회_요청_실패(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isBadRequest())
+                        .andExpect(content().json(toJson(ErrorResponse.from(memberNotFoundException)))),
+                "get-member-profile-fail");
     }
 
     private ResultActions 회원수정_요청(MemberUpdateRequest memberUpdateRequest) throws Exception {

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -6,9 +6,7 @@ import com.cupid.jikting.common.error.ApplicationError;
 import com.cupid.jikting.common.error.ApplicationException;
 import com.cupid.jikting.common.error.BadRequestException;
 import com.cupid.jikting.common.error.NotFoundException;
-import com.cupid.jikting.member.dto.MemberResponse;
-import com.cupid.jikting.member.dto.MemberUpdateRequest;
-import com.cupid.jikting.member.dto.SignupRequest;
+import com.cupid.jikting.member.dto.*;
 import com.cupid.jikting.member.service.MemberService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -16,6 +14,10 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -36,10 +38,23 @@ public class MemberControllerTest extends ApiDocument {
     private static final String NICKNAME = "닉네임";
     private static final String COMPANY = "직장";
     private static final String IMAGE_URL = "사진 URL";
+    private static final int AGE = 21;
+    private static final int HEIGHT = 168;
+    private static final String GENDER = "성별";
+    private static final String ADDRESS = "거주지";
+    private static final String MBTI = "MBTI";
+    private static final String DRINK_STATUS = "음주여부";
+    private static final boolean IS_SMOKE = false;
+    private static final String COLLEGE = "출신학교(선택사항 - 없을 시 빈 문자열)";
+    private static final String PERSONALITY = "성격";
+    private static final String HOBBY = "취미";
+    private static final String DESCRIPTION = "한줄 소개(선택사항 - 없을 시 빈 문자열)";
+    private static final String SEQUENCE = "순서";
 
     private SignupRequest signupRequest;
     private MemberUpdateRequest memberUpdateRequest;
     private MemberResponse memberResponse;
+    private MemberProfileResponse memberProfileResponse;
     private ApplicationException invalidFormatException;
     private ApplicationException memberNotFoundException;
 
@@ -48,6 +63,18 @@ public class MemberControllerTest extends ApiDocument {
 
     @BeforeEach
     void setUp() {
+        List<ImageResponse> images = IntStream.rangeClosed(1, 3)
+                .mapToObj(n -> ImageResponse.builder()
+                        .url(IMAGE_URL)
+                        .sequence(SEQUENCE)
+                        .build())
+                .collect(Collectors.toList());
+        List<String> personalities = IntStream.rangeClosed(1, 3)
+                .mapToObj(n -> PERSONALITY + n)
+                .collect(Collectors.toList());
+        List<String> hobbies = IntStream.rangeClosed(1, 3)
+                .mapToObj(n -> HOBBY + n)
+                .collect(Collectors.toList());
         signupRequest = SignupRequest.builder()
                 .username(USERNAME)
                 .password(PASSWORD)
@@ -59,8 +86,19 @@ public class MemberControllerTest extends ApiDocument {
                 .company(COMPANY)
                 .imageUrl(IMAGE_URL)
                 .build();
-        memberUpdateRequest = MemberUpdateRequest.builder()
-                .nickname(NICKNAME)
+        memberProfileResponse = MemberProfileResponse.builder()
+                .images(images)
+                .age(AGE)
+                .height(HEIGHT)
+                .gender(GENDER)
+                .address(ADDRESS)
+                .mbti(MBTI)
+                .drinkStatus(DRINK_STATUS)
+                .isSmoke(IS_SMOKE)
+                .college(COLLEGE)
+                .personalities(personalities)
+                .hobbies(hobbies)
+                .description(DESCRIPTION)
                 .build();
         invalidFormatException = new BadRequestException(ApplicationError.INVALID_FORMAT);
         memberNotFoundException = new NotFoundException(ApplicationError.MEMBER_NOT_FOUND);
@@ -104,6 +142,16 @@ public class MemberControllerTest extends ApiDocument {
         ResultActions resultActions = 회원조회_요청();
         // then
         회원조회_요청_실패(resultActions);
+    }
+
+    @Test
+    void 회원프로필조회_성공() throws Exception {
+        // given
+        willReturn(memberProfileResponse).given(memberService).getProfile(anyLong());
+        // when
+        ResultActions resultActions = 회원프로필조회_요청();
+        // then
+        회원프로필조회_요청_성공(resultActions);
     }
 
     @Test
@@ -163,6 +211,18 @@ public class MemberControllerTest extends ApiDocument {
                         .andExpect(status().isBadRequest())
                         .andExpect(content().json(toJson(ErrorResponse.from(memberNotFoundException)))),
                 "get-member-fail");
+    }
+
+    private ResultActions 회원프로필조회_요청() throws Exception {
+        return mockMvc.perform(get(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/profile")
+                .contextPath(CONTEXT_PATH));
+    }
+
+    private void 회원프로필조회_요청_성공(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isOk())
+                        .andExpect(content().json(toJson(memberProfileResponse))),
+                "get-member-profile-success");
     }
 
     private ResultActions 회원수정_요청(MemberUpdateRequest memberUpdateRequest) throws Exception {


### PR DESCRIPTION
## Issue

closed #17 
[SP-129](https://soma-cupid.atlassian.net/browse/SP-129?atlOrigin=eyJpIjoiNWIxYmVlMzFhM2UyNDcwYjk5Y2Y4MDdlNjMxNzUzMzMiLCJwIjoiaiJ9)

## 요구사항

- [x] 회원 프로필 조회 성공 API 명세서 작성
- [x] 회원 프로필 조회 실패 API 명세서 작성

## 변경사항

- 회원 프로필 조회 로직을 `MemberController` 및 `MemberService`에 추가
- 회원 프로필 조회 응답 DTO `MemberResponse` 추가
- 회원 프로필 이미지 조회 응답 DTO `ImageResponse` 추가
- `MemberControllerTest` 응답 DTO 초기화 순서 수정
- `index.adoc` 회원 프로필 조회 추가
- `index.adoc` 회원 관련 기능 제목 띄어쓰기 수정

## 리뷰 우선순위

🙂 보통

[SP-129]: https://soma-cupid.atlassian.net/browse/SP-129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ