### PR TITLE
[SP-28] 회원 비밀번호 수정 API 명세서 작성

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -124,6 +124,9 @@ include::{snippets}/update-member-password-not-found-member-fail/http-request.ad
 .response - 회원을 찾을 수 없음
 include::{snippets}/update-member-password-not-found-member-fail/http-response.adoc[]
 
+.response - 기존 비밀번호 불일치
+include::{snippets}/update-member-password-not-equal-fail/http-response.adoc[]
+
 === 추천 관련 기능
 ==== 추천 팀 조회
 ----

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -107,6 +107,17 @@ include::{snippets}/update-member-fail/http-request.adoc[]
 .response
 include::{snippets}/update-member-fail/http-response.adoc[]
 
+==== 회원 비밀번호 수정
+----
+/api/v1/members
+----
+===== 성공
+.request
+include::{snippets}/update-member-password-success/http-request.adoc[]
+
+.response
+include::{snippets}/update-member-password-success/http-response.adoc[]
+
 === 추천 관련 기능
 ==== 추천 팀 조회
 ----

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -117,6 +117,12 @@ include::{snippets}/update-member-password-success/http-request.adoc[]
 
 .response
 include::{snippets}/update-member-password-success/http-response.adoc[]
+===== 실패
+.request
+include::{snippets}/update-member-password-not-found-member-fail/http-request.adoc[]
+
+.response - 회원을 찾을 수 없음
+include::{snippets}/update-member-password-not-found-member-fail/http-response.adoc[]
 
 === 추천 관련 기능
 ==== 추천 팀 조회

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -127,6 +127,9 @@ include::{snippets}/update-member-password-not-found-member-fail/http-response.a
 .response - 기존 비밀번호 불일치
 include::{snippets}/update-member-password-not-equal-fail/http-response.adoc[]
 
+.response - 비밀번호 양식 불일치
+include::{snippets}/update-member-password-wrong-form-fail/http-response.adoc[]
+
 === 추천 관련 기능
 ==== 추천 팀 조회
 ----

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -109,7 +109,7 @@ include::{snippets}/update-member-fail/http-response.adoc[]
 
 ==== 회원 비밀번호 수정
 ----
-/api/v1/members
+/api/v1/members/password
 ----
 ===== 성공
 .request

--- a/src/main/java/com/cupid/jikting/common/error/ApplicationError.java
+++ b/src/main/java/com/cupid/jikting/common/error/ApplicationError.java
@@ -22,6 +22,7 @@ public enum ApplicationError {
     DUPLICATE_USERNAME(HttpStatus.BAD_REQUEST, "U004", "해당 아이디가 이미 존재합니다."),
     DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "U005", "해당 닉네임이 이미 존재합니다."),
     INVALID_COMPANY(HttpStatus.BAD_REQUEST, "U006", "지원하지 않는 회사입니다."),
+    NOT_EQUAL_ID_OR_PASSWORD(HttpStatus.BAD_REQUEST, "U007", "아이디 또는 비밀번호가 일치하지 않습니다."),
 
     TEAM_NOT_FOUND(HttpStatus.BAD_REQUEST, "T001", "팀을 찾을 수 없습니다."),
     GENDER_MISMATCH(HttpStatus.BAD_REQUEST, "T002", "해당 성별은 팀에 참여할 수 없습니다."),

--- a/src/main/java/com/cupid/jikting/member/controller/MemberController.java
+++ b/src/main/java/com/cupid/jikting/member/controller/MemberController.java
@@ -1,9 +1,6 @@
 package com.cupid.jikting.member.controller;
 
-import com.cupid.jikting.member.dto.MemberProfileResponse;
-import com.cupid.jikting.member.dto.MemberResponse;
-import com.cupid.jikting.member.dto.MemberUpdateRequest;
-import com.cupid.jikting.member.dto.SignupRequest;
+import com.cupid.jikting.member.dto.*;
 import com.cupid.jikting.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -35,6 +32,12 @@ public class MemberController {
     @PatchMapping
     public ResponseEntity<Void> update(@RequestBody MemberUpdateRequest memberUpdateRequest) {
         memberService.update(memberUpdateRequest);
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/password")
+    public ResponseEntity<Void> updatePassword(@RequestBody MemberPasswordUpdateRequest memberPasswordUpdateRequest) {
+        memberService.updatePassword(memberPasswordUpdateRequest);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/cupid/jikting/member/controller/MemberController.java
+++ b/src/main/java/com/cupid/jikting/member/controller/MemberController.java
@@ -36,8 +36,8 @@ public class MemberController {
     }
 
     @PatchMapping("/password")
-    public ResponseEntity<Void> updatePassword(@RequestBody MemberPasswordUpdateRequest memberPasswordUpdateRequest) {
-        memberService.updatePassword(memberPasswordUpdateRequest);
+    public ResponseEntity<Void> updatePassword(@RequestBody PasswordUpdateRequest passwordUpdateRequest) {
+        memberService.updatePassword(passwordUpdateRequest);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/cupid/jikting/member/dto/MemberPasswordUpdateRequest.java
+++ b/src/main/java/com/cupid/jikting/member/dto/MemberPasswordUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.cupid.jikting.member.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberPasswordUpdateRequest {
+
+    private String password;
+    private String newPassword;
+}

--- a/src/main/java/com/cupid/jikting/member/dto/PasswordUpdateRequest.java
+++ b/src/main/java/com/cupid/jikting/member/dto/PasswordUpdateRequest.java
@@ -6,7 +6,7 @@ import lombok.*;
 @Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class MemberPasswordUpdateRequest {
+public class PasswordUpdateRequest {
 
     private String password;
     private String newPassword;

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -20,6 +20,6 @@ public class MemberService {
     public void update(MemberUpdateRequest memberUpdateRequest) {
     }
 
-    public void updatePassword(MemberPasswordUpdateRequest memberPasswordUpdateRequest) {
+    public void updatePassword(PasswordUpdateRequest passwordUpdateRequest) {
     }
 }

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -1,9 +1,6 @@
 package com.cupid.jikting.member.service;
 
-import com.cupid.jikting.member.dto.MemberProfileResponse;
-import com.cupid.jikting.member.dto.MemberResponse;
-import com.cupid.jikting.member.dto.MemberUpdateRequest;
-import com.cupid.jikting.member.dto.SignupRequest;
+import com.cupid.jikting.member.dto.*;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -21,5 +18,8 @@ public class MemberService {
     }
 
     public void update(MemberUpdateRequest memberUpdateRequest) {
+    }
+
+    public void updatePassword(MemberPasswordUpdateRequest memberPasswordUpdateRequest) {
     }
 }

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -51,7 +51,7 @@ public class MemberControllerTest extends ApiDocument {
 
     private SignupRequest signupRequest;
     private MemberUpdateRequest memberUpdateRequest;
-    private MemberPasswordUpdateRequest memberPasswordUpdateRequest;
+    private PasswordUpdateRequest passwordUpdateRequest;
     private MemberResponse memberResponse;
     private MemberProfileResponse memberProfileResponse;
     private ApplicationException invalidFormatException;
@@ -85,7 +85,7 @@ public class MemberControllerTest extends ApiDocument {
         memberUpdateRequest = MemberUpdateRequest.builder()
                 .nickname(NICKNAME)
                 .build();
-        memberPasswordUpdateRequest = MemberPasswordUpdateRequest.builder()
+        passwordUpdateRequest = PasswordUpdateRequest.builder()
                 .password(PASSWORD)
                 .newPassword(NEW_PASSWORD)
                 .build();
@@ -197,7 +197,7 @@ public class MemberControllerTest extends ApiDocument {
     @Test
     void 회원_비밀번호_수정_성공() throws Exception {
         // given
-        willDoNothing().given(memberService).updatePassword(any(MemberPasswordUpdateRequest.class));
+        willDoNothing().given(memberService).updatePassword(any(PasswordUpdateRequest.class));
         // when
         ResultActions resultActions = 회원_비밀번호_수정_요청();
         // then
@@ -207,7 +207,7 @@ public class MemberControllerTest extends ApiDocument {
     @Test
     void 회원_비밀번호_수정_회원정보찾기_실패() throws Exception {
         // given
-        willThrow(memberNotFoundException).given(memberService).updatePassword(any(MemberPasswordUpdateRequest.class));
+        willThrow(memberNotFoundException).given(memberService).updatePassword(any(PasswordUpdateRequest.class));
         // when
         ResultActions resultActions = 회원_비밀번호_수정_요청();
         // then
@@ -217,7 +217,7 @@ public class MemberControllerTest extends ApiDocument {
     @Test
     void 회원_비밀번호_수정_비밀번호불일치_실패() throws Exception {
         // given
-        willThrow(passwordNotEqualException).given(memberService).updatePassword(any(MemberPasswordUpdateRequest.class));
+        willThrow(passwordNotEqualException).given(memberService).updatePassword(any(PasswordUpdateRequest.class));
         // when
         ResultActions resultActions = 회원_비밀번호_수정_요청();
         // then
@@ -227,7 +227,7 @@ public class MemberControllerTest extends ApiDocument {
     @Test
     void 회원_비밀번호_수정_비밀번호양식불일치_실패() throws Exception {
         // given
-        willThrow(wrongFormException).given(memberService).updatePassword(any(MemberPasswordUpdateRequest.class));
+        willThrow(wrongFormException).given(memberService).updatePassword(any(PasswordUpdateRequest.class));
         // when
         ResultActions resultActions = 회원_비밀번호_수정_요청();
         // then
@@ -316,7 +316,7 @@ public class MemberControllerTest extends ApiDocument {
         return mockMvc.perform(patch(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/password")
                 .contextPath(CONTEXT_PATH)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(toJson(memberPasswordUpdateRequest)));
+                .content(toJson(passwordUpdateRequest)));
     }
 
     private void 회원_비밀번호_수정_요청_성공(ResultActions resultActions) throws Exception {

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -50,9 +50,11 @@ public class MemberControllerTest extends ApiDocument {
     private static final String HOBBY = "취미";
     private static final String DESCRIPTION = "한줄 소개(선택사항 - 없을 시 빈 문자열)";
     private static final String SEQUENCE = "순서";
+    private static final String NEW_PASSWORD = "새 비밀번호";
 
     private SignupRequest signupRequest;
     private MemberUpdateRequest memberUpdateRequest;
+    private MemberPasswordUpdateRequest memberPasswordUpdateRequest;
     private MemberResponse memberResponse;
     private MemberProfileResponse memberProfileResponse;
     private ApplicationException invalidFormatException;
@@ -83,6 +85,10 @@ public class MemberControllerTest extends ApiDocument {
                 .build();
         memberUpdateRequest = MemberUpdateRequest.builder()
                 .nickname(NICKNAME)
+                .build();
+        memberPasswordUpdateRequest = MemberPasswordUpdateRequest.builder()
+                .password(PASSWORD)
+                .newPassword(NEW_PASSWORD)
                 .build();
         memberResponse = MemberResponse.builder()
                 .nickname(NICKNAME)
@@ -187,6 +193,16 @@ public class MemberControllerTest extends ApiDocument {
         회원_수정_요청_실패(resultActions);
     }
 
+    @Test
+    void 회원_비밀번호_수정_성공() throws Exception {
+        // given
+        willDoNothing().given(memberService).updatePassword(any(MemberPasswordUpdateRequest.class));
+        // when
+        ResultActions resultActions = 회원_비밀번호_수정_요청();
+        // then
+        회원_비밀번호_수정_요청_성공(resultActions);
+    }
+
     private ResultActions 회원_가입_요청(SignupRequest signupRequest) throws Exception {
         return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH)
                 .contextPath(CONTEXT_PATH)
@@ -263,5 +279,18 @@ public class MemberControllerTest extends ApiDocument {
                         .andExpect(status().isBadRequest())
                         .andExpect(content().json(toJson(ErrorResponse.from(memberNotFoundException)))),
                 "update-member-fail");
+    }
+
+    private ResultActions 회원_비밀번호_수정_요청() throws Exception {
+        return mockMvc.perform(patch(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/password")
+                .contextPath(CONTEXT_PATH)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(toJson(memberPasswordUpdateRequest)));
+    }
+
+    private void 회원_비밀번호_수정_요청_성공(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isOk()),
+                "update-member-password-success");
     }
 }

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -2,10 +2,7 @@ package com.cupid.jikting.member.controller;
 
 import com.cupid.jikting.ApiDocument;
 import com.cupid.jikting.common.dto.ErrorResponse;
-import com.cupid.jikting.common.error.ApplicationError;
-import com.cupid.jikting.common.error.ApplicationException;
-import com.cupid.jikting.common.error.BadRequestException;
-import com.cupid.jikting.common.error.NotFoundException;
+import com.cupid.jikting.common.error.*;
 import com.cupid.jikting.member.dto.*;
 import com.cupid.jikting.member.service.MemberService;
 import org.junit.jupiter.api.BeforeEach;
@@ -59,6 +56,7 @@ public class MemberControllerTest extends ApiDocument {
     private MemberProfileResponse memberProfileResponse;
     private ApplicationException invalidFormatException;
     private ApplicationException memberNotFoundException;
+    private ApplicationException passwordNotEqualException;
 
     @MockBean
     private MemberService memberService;
@@ -111,6 +109,7 @@ public class MemberControllerTest extends ApiDocument {
                 .build();
         invalidFormatException = new BadRequestException(ApplicationError.INVALID_FORMAT);
         memberNotFoundException = new NotFoundException(ApplicationError.MEMBER_NOT_FOUND);
+        passwordNotEqualException = new NotEqualException(ApplicationError.NOT_EQUAL_ID_OR_PASSWORD);
     }
 
     @Test
@@ -213,6 +212,16 @@ public class MemberControllerTest extends ApiDocument {
         회원_비밀번호_수정_요청_회원정보찾기_실패(resultActions);
     }
 
+    @Test
+    void 회원_비밀번호_수정_비밀번호불일치_실패() throws Exception {
+        // given
+        willThrow(passwordNotEqualException).given(memberService).updatePassword(any(MemberPasswordUpdateRequest.class));
+        // when
+        ResultActions resultActions = 회원_비밀번호_수정_요청();
+        // then
+        회원_비밀번호_수정_요청_비밀번호불일치_실패(resultActions);
+    }
+
     private ResultActions 회원_가입_요청(SignupRequest signupRequest) throws Exception {
         return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH)
                 .contextPath(CONTEXT_PATH)
@@ -309,5 +318,12 @@ public class MemberControllerTest extends ApiDocument {
                         .andExpect(status().isBadRequest())
                         .andExpect(content().json(toJson(ErrorResponse.from(memberNotFoundException)))),
                 "update-member-password-not-found-member-fail");
+    }
+
+    private void 회원_비밀번호_수정_요청_비밀번호불일치_실패(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isBadRequest())
+                        .andExpect(content().json(toJson(ErrorResponse.from(passwordNotEqualException)))),
+                "update-member-password-not-equal-fail");
     }
 }

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -108,157 +108,157 @@ public class MemberControllerTest extends ApiDocument {
     }
 
     @Test
-    void 회원가입_성공() throws Exception {
+    void 회원_가입_성공() throws Exception {
         // given
         willDoNothing().given(memberService).signup(any(SignupRequest.class));
         // when
-        ResultActions resultActions = 회원가입_요청(signupRequest);
+        ResultActions resultActions = 회원_가입_요청(signupRequest);
         // then
-        회원가입_요청_성공(resultActions);
+        회원_가입_요청_성공(resultActions);
     }
 
     @Test
-    void 회원가입_실패() throws Exception {
+    void 회원_가입_실패() throws Exception {
         // given
         willThrow(invalidFormatException).given(memberService).signup(any(SignupRequest.class));
         // when
-        ResultActions resultActions = 회원가입_요청(signupRequest);
+        ResultActions resultActions = 회원_가입_요청(signupRequest);
         // then
-        회원가입_요청_실패(resultActions);
+        회원_가입_요청_실패(resultActions);
     }
 
     @Test
-    void 회원조회_성공() throws Exception {
+    void 회원_조회_성공() throws Exception {
         // given
         willReturn(memberResponse).given(memberService).get(anyLong());
         // when
-        ResultActions resultActions = 회원조회_요청();
+        ResultActions resultActions = 회원_조회_요청();
         // then
-        회원조회_요청_성공(resultActions);
+        회원_조회_요청_성공(resultActions);
     }
 
     @Test
-    void 회원조회_실패() throws Exception {
+    void 회원_조회_실패() throws Exception {
         // given
         willThrow(memberNotFoundException).given(memberService).get(anyLong());
         // when
-        ResultActions resultActions = 회원조회_요청();
+        ResultActions resultActions = 회원_조회_요청();
         // then
-        회원조회_요청_실패(resultActions);
+        회원_조회_요청_실패(resultActions);
     }
 
     @Test
-    void 회원프로필조회_성공() throws Exception {
+    void 회원_프로필_조회_성공() throws Exception {
         // given
         willReturn(memberProfileResponse).given(memberService).getProfile(anyLong());
         // when
-        ResultActions resultActions = 회원프로필조회_요청();
+        ResultActions resultActions = 회원_프로필_조회_요청();
         // then
-        회원프로필조회_요청_성공(resultActions);
+        회원_프로필_조회_요청_성공(resultActions);
     }
 
     @Test
-    void 회원프로필조회_실패() throws Exception {
+    void 회원_프로필_조회_실패() throws Exception {
         // given
         willThrow(memberNotFoundException).given(memberService).getProfile(anyLong());
         // when
-        ResultActions resultActions = 회원프로필조회_요청();
+        ResultActions resultActions = 회원_프로필_조회_요청();
         // then
-        회원프로필조회_요청_실패(resultActions);
+        회원_프로필_조회_요청_실패(resultActions);
     }
 
     @Test
-    void 회원수정_성공() throws Exception {
+    void 회원_수정_성공() throws Exception {
         // given
         willDoNothing().given(memberService).update(any(MemberUpdateRequest.class));
         // when
-        ResultActions resultActions = 회원수정_요청(memberUpdateRequest);
+        ResultActions resultActions = 회원_수정_요청(memberUpdateRequest);
         // then
-        회원수정_요청_성공(resultActions);
+        회원_수정_요청_성공(resultActions);
     }
 
     @Test
-    void 회원수정_실패() throws Exception {
+    void 회원_수정_실패() throws Exception {
         // given
         willThrow(memberNotFoundException).given(memberService).update(any(MemberUpdateRequest.class));
         // when
-        ResultActions resultActions = 회원수정_요청(memberUpdateRequest);
+        ResultActions resultActions = 회원_수정_요청(memberUpdateRequest);
         // then
-        회원수정_요청_실패(resultActions);
+        회원_수정_요청_실패(resultActions);
     }
 
-    private ResultActions 회원가입_요청(SignupRequest signupRequest) throws Exception {
+    private ResultActions 회원_가입_요청(SignupRequest signupRequest) throws Exception {
         return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH)
                 .contextPath(CONTEXT_PATH)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(toJson(signupRequest)));
     }
 
-    private void 회원가입_요청_성공(ResultActions resultActions) throws Exception {
+    private void 회원_가입_요청_성공(ResultActions resultActions) throws Exception {
         printAndMakeSnippet(resultActions
                         .andExpect(status().isOk()),
                 "signup-success");
     }
 
-    private void 회원가입_요청_실패(ResultActions resultActions) throws Exception {
+    private void 회원_가입_요청_실패(ResultActions resultActions) throws Exception {
         printAndMakeSnippet(resultActions
                         .andExpect(status().isBadRequest())
                         .andExpect(content().json(toJson(ErrorResponse.from(invalidFormatException)))),
                 "signup-fail");
     }
 
-    private ResultActions 회원조회_요청() throws Exception {
+    private ResultActions 회원_조회_요청() throws Exception {
         return mockMvc.perform(get(CONTEXT_PATH + DOMAIN_ROOT_PATH)
                 .contextPath(CONTEXT_PATH));
     }
 
-    private void 회원조회_요청_성공(ResultActions resultActions) throws Exception {
+    private void 회원_조회_요청_성공(ResultActions resultActions) throws Exception {
         printAndMakeSnippet(resultActions
                         .andExpect(status().isOk())
                         .andExpect(content().json(toJson(memberResponse))),
                 "get-member-success");
     }
 
-    private void 회원조회_요청_실패(ResultActions resultActions) throws Exception {
+    private void 회원_조회_요청_실패(ResultActions resultActions) throws Exception {
         printAndMakeSnippet(resultActions
                         .andExpect(status().isBadRequest())
                         .andExpect(content().json(toJson(ErrorResponse.from(memberNotFoundException)))),
                 "get-member-fail");
     }
 
-    private ResultActions 회원프로필조회_요청() throws Exception {
+    private ResultActions 회원_프로필_조회_요청() throws Exception {
         return mockMvc.perform(get(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/profile")
                 .contextPath(CONTEXT_PATH));
     }
 
-    private void 회원프로필조회_요청_성공(ResultActions resultActions) throws Exception {
+    private void 회원_프로필_조회_요청_성공(ResultActions resultActions) throws Exception {
         printAndMakeSnippet(resultActions
                         .andExpect(status().isOk())
                         .andExpect(content().json(toJson(memberProfileResponse))),
                 "get-member-profile-success");
     }
 
-    private void 회원프로필조회_요청_실패(ResultActions resultActions) throws Exception {
+    private void 회원_프로필_조회_요청_실패(ResultActions resultActions) throws Exception {
         printAndMakeSnippet(resultActions
                         .andExpect(status().isBadRequest())
                         .andExpect(content().json(toJson(ErrorResponse.from(memberNotFoundException)))),
                 "get-member-profile-fail");
     }
 
-    private ResultActions 회원수정_요청(MemberUpdateRequest memberUpdateRequest) throws Exception {
+    private ResultActions 회원_수정_요청(MemberUpdateRequest memberUpdateRequest) throws Exception {
         return mockMvc.perform(patch(CONTEXT_PATH + DOMAIN_ROOT_PATH)
                 .contextPath(CONTEXT_PATH)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(toJson(memberUpdateRequest)));
     }
 
-    private void 회원수정_요청_성공(ResultActions resultActions) throws Exception {
+    private void 회원_수정_요청_성공(ResultActions resultActions) throws Exception {
         printAndMakeSnippet(resultActions
                         .andExpect(status().isOk()),
                 "update-member-success");
     }
 
-    private void 회원수정_요청_실패(ResultActions resultActions) throws Exception {
+    private void 회원_수정_요청_실패(ResultActions resultActions) throws Exception {
         printAndMakeSnippet(resultActions
                         .andExpect(status().isBadRequest())
                         .andExpect(content().json(toJson(ErrorResponse.from(memberNotFoundException)))),

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -203,6 +203,16 @@ public class MemberControllerTest extends ApiDocument {
         회원_비밀번호_수정_요청_성공(resultActions);
     }
 
+    @Test
+    void 회원_비밀번호_수정_회원정보찾기_실패() throws Exception {
+        // given
+        willThrow(memberNotFoundException).given(memberService).updatePassword(any(MemberPasswordUpdateRequest.class));
+        // when
+        ResultActions resultActions = 회원_비밀번호_수정_요청();
+        // then
+        회원_비밀번호_수정_요청_회원정보찾기_실패(resultActions);
+    }
+
     private ResultActions 회원_가입_요청(SignupRequest signupRequest) throws Exception {
         return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH)
                 .contextPath(CONTEXT_PATH)
@@ -292,5 +302,12 @@ public class MemberControllerTest extends ApiDocument {
         printAndMakeSnippet(resultActions
                         .andExpect(status().isOk()),
                 "update-member-password-success");
+    }
+
+    private void 회원_비밀번호_수정_요청_회원정보찾기_실패(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isBadRequest())
+                        .andExpect(content().json(toJson(ErrorResponse.from(memberNotFoundException)))),
+                "update-member-password-not-found-member-fail");
     }
 }

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -57,6 +57,7 @@ public class MemberControllerTest extends ApiDocument {
     private ApplicationException invalidFormatException;
     private ApplicationException memberNotFoundException;
     private ApplicationException passwordNotEqualException;
+    private ApplicationException wrongFormException;
 
     @MockBean
     private MemberService memberService;
@@ -110,6 +111,7 @@ public class MemberControllerTest extends ApiDocument {
         invalidFormatException = new BadRequestException(ApplicationError.INVALID_FORMAT);
         memberNotFoundException = new NotFoundException(ApplicationError.MEMBER_NOT_FOUND);
         passwordNotEqualException = new NotEqualException(ApplicationError.NOT_EQUAL_ID_OR_PASSWORD);
+        wrongFormException = new WrongFromException(ApplicationError.INVALID_FORMAT);
     }
 
     @Test
@@ -222,6 +224,16 @@ public class MemberControllerTest extends ApiDocument {
         회원_비밀번호_수정_요청_비밀번호불일치_실패(resultActions);
     }
 
+    @Test
+    void 회원_비밀번호_수정_비밀번호양식불일치_실패() throws Exception {
+        // given
+        willThrow(wrongFormException).given(memberService).updatePassword(any(MemberPasswordUpdateRequest.class));
+        // when
+        ResultActions resultActions = 회원_비밀번호_수정_요청();
+        // then
+        회원_비밀번호_수정_요청_비밀번호양식불일치_실패(resultActions);
+    }
+
     private ResultActions 회원_가입_요청(SignupRequest signupRequest) throws Exception {
         return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH)
                 .contextPath(CONTEXT_PATH)
@@ -325,5 +337,12 @@ public class MemberControllerTest extends ApiDocument {
                         .andExpect(status().isBadRequest())
                         .andExpect(content().json(toJson(ErrorResponse.from(passwordNotEqualException)))),
                 "update-member-password-not-equal-fail");
+    }
+
+    private void 회원_비밀번호_수정_요청_비밀번호양식불일치_실패(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isBadRequest())
+                        .andExpect(content().json(toJson(ErrorResponse.from(wrongFormException)))),
+                "update-member-password-wrong-form-fail");
     }
 }


### PR DESCRIPTION
## Issue

closed #23 
[SP-28](https://soma-cupid.atlassian.net/browse/SP-28?atlOrigin=eyJpIjoiMTYxYjUwZmNlNTE4NDU4YWExZDY5ZWI2YmQ0MGNlYTUiLCJwIjoiaiJ9)

## 요구사항

- [x] 회원 비밀번호 수정 성공 API 명세서 작성
- [x] 회원 비밀번호 수정 실패 API 명세서 작성

## 변경사항

- 회원 비밀번호 수정 로직을 `MemberController` 및 `MemberService`에 추가
- 회원 비밀번호 수정 요청 DTO `MemberPasswordUpdateRequest` 추가
- `ApplicationError` 아이디 혹은 비밀번호 불일치 추가
- `index.adoc` 회원 비밀번호 수정 추가

## 리뷰 우선순위

🙂 보통

## 코멘트

비밀번호 수정 실패에 대한 케이스를 아래 세 가지로 나누어 작성했습니다.

1. 비밀번호를 수정하려는 사용자를 찾을 수 없음
2. 기존 비밀번호가 일치하지 않음
3. 새 비밀번호가 비밀번호 양식에 맞지 않음

[SP-28]: https://soma-cupid.atlassian.net/browse/SP-28?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ