### PR TITLE
[SP-109] 회원 프로필 수정 API 명세서 작성

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -107,6 +107,17 @@ include::{snippets}/update-member-fail/http-request.adoc[]
 .response
 include::{snippets}/update-member-fail/http-response.adoc[]
 
+==== 회원 프로필 수정
+----
+/api/v1/members/profile
+----
+===== 성공
+.request
+include::{snippets}/update-member-profile-success/http-request.adoc[]
+
+.response
+include::{snippets}/update-member-profile-success/http-response.adoc[]
+
 === 팀 관련 기능
 ==== 받은 호감 목록 조회
 ----

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -117,6 +117,12 @@ include::{snippets}/update-member-profile-success/http-request.adoc[]
 
 .response
 include::{snippets}/update-member-profile-success/http-response.adoc[]
+===== 실패
+.request
+include::{snippets}/update-member-profile-fail/http-request.adoc[]
+
+.response
+include::{snippets}/update-member-profile-fail/http-response.adoc[]
 
 === 팀 관련 기능
 ==== 받은 호감 목록 조회

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -90,22 +90,22 @@ include::{snippets}/get-member-profile-fail/http-request.adoc[]
 .response
 include::{snippets}/get-member-profile-fail/http-response.adoc[]
 
-==== 회원 수정
+==== 회원 닉네임 수정
 ----
 /api/v1/members
 ----
 ===== 성공
 .request
-include::{snippets}/update-member-success/http-request.adoc[]
+include::{snippets}/update-member-nickname-success/http-request.adoc[]
 
 .response
-include::{snippets}/update-member-success/http-response.adoc[]
+include::{snippets}/update-member-nickname-success/http-response.adoc[]
 ===== 실패
 .request
-include::{snippets}/update-member-fail/http-request.adoc[]
+include::{snippets}/update-member-nickname-fail/http-request.adoc[]
 
 .response
-include::{snippets}/update-member-fail/http-response.adoc[]
+include::{snippets}/update-member-nickname-fail/http-response.adoc[]
 
 ==== 회원 프로필 수정
 ----

--- a/src/main/java/com/cupid/jikting/member/controller/MemberController.java
+++ b/src/main/java/com/cupid/jikting/member/controller/MemberController.java
@@ -1,9 +1,6 @@
 package com.cupid.jikting.member.controller;
 
-import com.cupid.jikting.member.dto.MemberProfileResponse;
-import com.cupid.jikting.member.dto.MemberResponse;
-import com.cupid.jikting.member.dto.MemberUpdateRequest;
-import com.cupid.jikting.member.dto.SignupRequest;
+import com.cupid.jikting.member.dto.*;
 import com.cupid.jikting.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -35,6 +32,12 @@ public class MemberController {
     @PatchMapping
     public ResponseEntity<Void> update(@RequestBody MemberUpdateRequest memberUpdateRequest) {
         memberService.update(memberUpdateRequest);
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/profile")
+    public ResponseEntity<Void> updateProfile(@RequestBody MemberProfileUpdateRequest memberProfileUpdateRequest) {
+        memberService.updateProfile(memberProfileUpdateRequest);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/cupid/jikting/member/dto/MemberProfileUpdateRequest.java
+++ b/src/main/java/com/cupid/jikting/member/dto/MemberProfileUpdateRequest.java
@@ -1,0 +1,25 @@
+package com.cupid.jikting.member.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberProfileUpdateRequest {
+
+    private int age;
+    private int height;
+    private String mbti;
+    private String address;
+    private String gender;
+    private String college;
+    private boolean isSmoke;
+    private String drinkStatus;
+    private String description;
+    private List<String> personalities;
+    private List<String> hobbies;
+    private List<ImageResponse> images;
+}

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -1,9 +1,6 @@
 package com.cupid.jikting.member.service;
 
-import com.cupid.jikting.member.dto.MemberProfileResponse;
-import com.cupid.jikting.member.dto.MemberResponse;
-import com.cupid.jikting.member.dto.MemberUpdateRequest;
-import com.cupid.jikting.member.dto.SignupRequest;
+import com.cupid.jikting.member.dto.*;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -21,5 +18,8 @@ public class MemberService {
     }
 
     public void update(MemberUpdateRequest memberUpdateRequest) {
+    }
+
+    public void updateProfile(MemberProfileUpdateRequest memberProfileUpdateRequest) {
     }
 }

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -112,7 +112,7 @@ public class MemberControllerTest extends ApiDocument {
         // given
         willDoNothing().given(memberService).signup(any(SignupRequest.class));
         // when
-        ResultActions resultActions = 회원가입_요청(signupRequest);
+        ResultActions resultActions = 회원가입_요청();
         // then
         회원가입_요청_성공(resultActions);
     }
@@ -122,7 +122,7 @@ public class MemberControllerTest extends ApiDocument {
         // given
         willThrow(invalidFormatException).given(memberService).signup(any(SignupRequest.class));
         // when
-        ResultActions resultActions = 회원가입_요청(signupRequest);
+        ResultActions resultActions = 회원가입_요청();
         // then
         회원가입_요청_실패(resultActions);
     }
@@ -172,7 +172,7 @@ public class MemberControllerTest extends ApiDocument {
         // given
         willDoNothing().given(memberService).update(any(MemberUpdateRequest.class));
         // when
-        ResultActions resultActions = 회원수정_요청(memberUpdateRequest);
+        ResultActions resultActions = 회원수정_요청();
         // then
         회원수정_요청_성공(resultActions);
     }
@@ -182,12 +182,12 @@ public class MemberControllerTest extends ApiDocument {
         // given
         willThrow(memberNotFoundException).given(memberService).update(any(MemberUpdateRequest.class));
         // when
-        ResultActions resultActions = 회원수정_요청(memberUpdateRequest);
+        ResultActions resultActions = 회원수정_요청();
         // then
         회원수정_요청_실패(resultActions);
     }
 
-    private ResultActions 회원가입_요청(SignupRequest signupRequest) throws Exception {
+    private ResultActions 회원가입_요청() throws Exception {
         return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH)
                 .contextPath(CONTEXT_PATH)
                 .contentType(MediaType.APPLICATION_JSON)
@@ -245,7 +245,7 @@ public class MemberControllerTest extends ApiDocument {
                 "get-member-profile-fail");
     }
 
-    private ResultActions 회원수정_요청(MemberUpdateRequest memberUpdateRequest) throws Exception {
+    private ResultActions 회원수정_요청() throws Exception {
         return mockMvc.perform(patch(CONTEXT_PATH + DOMAIN_ROOT_PATH)
                 .contextPath(CONTEXT_PATH)
                 .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -212,6 +212,16 @@ public class MemberControllerTest extends ApiDocument {
         회원_프로필_수정_요청_성공(resultActions);
     }
 
+    @Test
+    void 회원_프로필_수정_실패() throws Exception {
+        // given
+        willThrow(memberNotFoundException).given(memberService).updateProfile(any(MemberProfileUpdateRequest.class));
+        // when
+        ResultActions resultActions = 회원_프로필_수정_요청();
+        // then
+        회원_프로필_수정_요청_실패(resultActions);
+    }
+
     private ResultActions 회원가입_요청() throws Exception {
         return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH)
                 .contextPath(CONTEXT_PATH)
@@ -301,5 +311,12 @@ public class MemberControllerTest extends ApiDocument {
         printAndMakeSnippet(resultActions
                         .andExpect(status().isOk()),
                 "update-member-profile-success");
+    }
+
+    private void 회원_프로필_수정_요청_실패(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isBadRequest())
+                        .andExpect(content().json(toJson(ErrorResponse.from(memberNotFoundException)))),
+                "update-member-profile-fail");
     }
 }

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -53,6 +53,7 @@ public class MemberControllerTest extends ApiDocument {
 
     private SignupRequest signupRequest;
     private MemberUpdateRequest memberUpdateRequest;
+    private MemberProfileUpdateRequest memberProfileUpdateRequest;
     private MemberResponse memberResponse;
     private MemberProfileResponse memberProfileResponse;
     private ApplicationException invalidFormatException;
@@ -83,6 +84,20 @@ public class MemberControllerTest extends ApiDocument {
                 .build();
         memberUpdateRequest = MemberUpdateRequest.builder()
                 .nickname(NICKNAME)
+                .build();
+        memberProfileUpdateRequest = MemberProfileUpdateRequest.builder()
+                .images(images)
+                .age(AGE)
+                .height(HEIGHT)
+                .gender(GENDER)
+                .address(ADDRESS)
+                .mbti(MBTI)
+                .drinkStatus(DRINK_STATUS)
+                .isSmoke(IS_SMOKE)
+                .college(COLLEGE)
+                .personalities(personalities)
+                .hobbies(hobbies)
+                .description(DESCRIPTION)
                 .build();
         memberResponse = MemberResponse.builder()
                 .nickname(NICKNAME)
@@ -187,6 +202,16 @@ public class MemberControllerTest extends ApiDocument {
         회원수정_요청_실패(resultActions);
     }
 
+    @Test
+    void 회원_프로필_수정_성공() throws Exception {
+        // given
+        willDoNothing().given(memberService).updateProfile(any(MemberProfileUpdateRequest.class));
+        // when
+        ResultActions resultActions = 회원_프로필_수정_요청();
+        // then
+        회원_프로필_수정_요청_성공(resultActions);
+    }
+
     private ResultActions 회원가입_요청() throws Exception {
         return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH)
                 .contextPath(CONTEXT_PATH)
@@ -263,5 +288,18 @@ public class MemberControllerTest extends ApiDocument {
                         .andExpect(status().isBadRequest())
                         .andExpect(content().json(toJson(ErrorResponse.from(memberNotFoundException)))),
                 "update-member-fail");
+    }
+
+    private ResultActions 회원_프로필_수정_요청() throws Exception {
+        return mockMvc.perform(patch(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/profile")
+                .contextPath(CONTEXT_PATH)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(toJson(memberProfileUpdateRequest)));
+    }
+
+    private void 회원_프로필_수정_요청_성공(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isOk()),
+                "update-member-profile-success");
     }
 }

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -183,23 +183,23 @@ public class MemberControllerTest extends ApiDocument {
     }
 
     @Test
-    void 회원수정_성공() throws Exception {
+    void 회원_닉네임_수정_성공() throws Exception {
         // given
         willDoNothing().given(memberService).update(any(MemberUpdateRequest.class));
         // when
-        ResultActions resultActions = 회원수정_요청();
+        ResultActions resultActions = 회원_닉네임수정_요청();
         // then
-        회원수정_요청_성공(resultActions);
+        회원_닉네임수정_요청_성공(resultActions);
     }
 
     @Test
-    void 회원수정_실패() throws Exception {
+    void 회원_닉네임수정_실패() throws Exception {
         // given
         willThrow(memberNotFoundException).given(memberService).update(any(MemberUpdateRequest.class));
         // when
-        ResultActions resultActions = 회원수정_요청();
+        ResultActions resultActions = 회원_닉네임수정_요청();
         // then
-        회원수정_요청_실패(resultActions);
+        회원_닉네임수정_요청_실패(resultActions);
     }
 
     @Test
@@ -280,24 +280,24 @@ public class MemberControllerTest extends ApiDocument {
                 "get-member-profile-fail");
     }
 
-    private ResultActions 회원수정_요청() throws Exception {
+    private ResultActions 회원_닉네임수정_요청() throws Exception {
         return mockMvc.perform(patch(CONTEXT_PATH + DOMAIN_ROOT_PATH)
                 .contextPath(CONTEXT_PATH)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(toJson(memberUpdateRequest)));
     }
 
-    private void 회원수정_요청_성공(ResultActions resultActions) throws Exception {
+    private void 회원_닉네임수정_요청_성공(ResultActions resultActions) throws Exception {
         printAndMakeSnippet(resultActions
                         .andExpect(status().isOk()),
-                "update-member-success");
+                "update-member-nickname-success");
     }
 
-    private void 회원수정_요청_실패(ResultActions resultActions) throws Exception {
+    private void 회원_닉네임수정_요청_실패(ResultActions resultActions) throws Exception {
         printAndMakeSnippet(resultActions
                         .andExpect(status().isBadRequest())
                         .andExpect(content().json(toJson(ErrorResponse.from(memberNotFoundException)))),
-                "update-member-fail");
+                "update-member-nickname-fail");
     }
 
     private ResultActions 회원_프로필_수정_요청() throws Exception {


### PR DESCRIPTION
## Issue

closed #25 
[SP-109](https://soma-cupid.atlassian.net/browse/SP-109?atlOrigin=eyJpIjoiN2Q1NDA3YWU5ZTQzNDk0OTgwOGUzZWQ0YmNiOWFjY2MiLCJwIjoiaiJ9)

## 요구사항

- [x] 회원 프로필 수정 성공 API 명세서 작성
- [x] 회원 프로필 수정 실패 API 명세서 작성

## 변경사항

- 회원 프로필 수정 로직을 `MemberController` 및 `MemberService`에 추가
- 회원 프로필 수정 요청 DTO `MemberProfileUpdateRequest` 추가
- `index.adoc` 회원 프로필 수정 추가
- `MemberControllerTest` 회원 등록 및 회원 수정 요청 메소드 파라미터 삭제

## 리뷰 우선순위

🙂 보통

[SP-109]: https://soma-cupid.atlassian.net/browse/SP-109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ