### PR TITLE
[SP-27] 회원 삭제 API 명세서 작성

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -164,6 +164,9 @@ include::{snippets}/update-member-password-not-found-member-fail/http-request.ad
 .response - 회원을 찾을 수 없음
 include::{snippets}/delete-member-not-found-member-fail/http-response.adoc[]
 
+.response - 비밀번호 불일치
+include::{snippets}/delete-member-not-equal-password-fail/http-response.adoc[]
+
 === 팀 관련 기능
 ==== 받은 호감 목록 조회
 ----

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -147,6 +147,17 @@ include::{snippets}/update-member-password-not-equal-fail/http-response.adoc[]
 .response - 비밀번호 양식 불일치
 include::{snippets}/update-member-password-wrong-form-fail/http-response.adoc[]
 
+==== 회원 탈퇴
+----
+/api/v1/members
+----
+===== 성공
+.request
+include::{snippets}/delete-member-success/http-request.adoc[]
+
+.response
+include::{snippets}/delete-member-success/http-response.adoc[]
+
 === 팀 관련 기능
 ==== 받은 호감 목록 조회
 ----

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -142,7 +142,7 @@ include::{snippets}/update-member-password-not-found-member-fail/http-request.ad
 include::{snippets}/update-member-password-not-found-member-fail/http-response.adoc[]
 
 .response - 기존 비밀번호 불일치
-include::{snippets}/update-member-password-not-equal-fail/http-response.adoc[]
+include::{snippets}/update-member-password-not-equal-password-fail/http-response.adoc[]
 
 .response - 비밀번호 양식 불일치
 include::{snippets}/update-member-password-wrong-form-fail/http-response.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -157,6 +157,12 @@ include::{snippets}/delete-member-success/http-request.adoc[]
 
 .response
 include::{snippets}/delete-member-success/http-response.adoc[]
+===== 실패
+.request
+include::{snippets}/update-member-password-not-found-member-fail/http-request.adoc[]
+
+.response - 회원을 찾을 수 없음
+include::{snippets}/delete-member-not-found-member-fail/http-response.adoc[]
 
 === 팀 관련 기능
 ==== 받은 호감 목록 조회

--- a/src/main/java/com/cupid/jikting/member/controller/MemberController.java
+++ b/src/main/java/com/cupid/jikting/member/controller/MemberController.java
@@ -46,4 +46,10 @@ public class MemberController {
         memberService.updatePassword(passwordUpdateRequest);
         return ResponseEntity.ok().build();
     }
+
+    @DeleteMapping
+    public ResponseEntity<Void> withdraw(@RequestBody PasswordRequest passwordRequest) {
+        memberService.withdraw(1L, passwordRequest);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/cupid/jikting/member/controller/MemberController.java
+++ b/src/main/java/com/cupid/jikting/member/controller/MemberController.java
@@ -47,7 +47,7 @@ public class MemberController {
         return ResponseEntity.ok().build();
     }
 
-    @DeleteMapping
+    @PostMapping("/withdraw")
     public ResponseEntity<Void> withdraw(@RequestBody PasswordRequest passwordRequest) {
         memberService.withdraw(1L, passwordRequest);
         return ResponseEntity.ok().build();

--- a/src/main/java/com/cupid/jikting/member/dto/PasswordRequest.java
+++ b/src/main/java/com/cupid/jikting/member/dto/PasswordRequest.java
@@ -1,0 +1,12 @@
+package com.cupid.jikting.member.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PasswordRequest {
+
+    private String password;
+}

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -25,4 +25,7 @@ public class MemberService {
 
     public void updatePassword(PasswordUpdateRequest passwordUpdateRequest) {
     }
+
+    public void withdraw(Long memberId, PasswordRequest passwordRequest) {
+    }
 }

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -425,7 +425,7 @@ public class MemberControllerTest extends ApiDocument {
         printAndMakeSnippet(resultActions
                         .andExpect(status().isBadRequest())
                         .andExpect(content().json(toJson(ErrorResponse.from(passwordNotEqualException)))),
-                "update-member-password-not-equal-fail");
+                "update-member-password-not-equal-password-fail");
     }
 
     private void 회원_비밀번호_수정_요청_비밀번호양식불일치_실패(ResultActions resultActions) throws Exception {

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -283,6 +283,16 @@ public class MemberControllerTest extends ApiDocument {
         회원_탈퇴_요청_성공(resultActions);
     }
 
+    @Test
+    void 회원_탈퇴_회원정보찾기_실패() throws Exception {
+        // given
+        willThrow(memberNotFoundException).given(memberService).withdraw(anyLong(), any(PasswordRequest.class));
+        // when
+        ResultActions resultActions = 회원_탈퇴_요청();
+        // then
+        회원_탈퇴_요청_회원정보찾기_실패(resultActions);
+    }
+
     private ResultActions 회원_가입_요청() throws Exception {
         return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH)
                 .contextPath(CONTEXT_PATH)
@@ -426,5 +436,12 @@ public class MemberControllerTest extends ApiDocument {
         printAndMakeSnippet(resultActions
                         .andExpect(status().isOk()),
                 "delete-member-success");
+    }
+
+    private void 회원_탈퇴_요청_회원정보찾기_실패(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isBadRequest())
+                        .andExpect(content().json(toJson(ErrorResponse.from(memberNotFoundException)))),
+                "delete-member-not-found-member-fail");
     }
 }

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -53,6 +53,7 @@ public class MemberControllerTest extends ApiDocument {
     private NicknameUpdateRequest nicknameUpdateRequest;
     private MemberProfileUpdateRequest memberProfileUpdateRequest;
     private PasswordUpdateRequest passwordUpdateRequest;
+    private PasswordRequest passwordRequest;
     private MemberResponse memberResponse;
     private MemberProfileResponse memberProfileResponse;
     private ApplicationException invalidFormatException;
@@ -103,6 +104,9 @@ public class MemberControllerTest extends ApiDocument {
         passwordUpdateRequest = PasswordUpdateRequest.builder()
                 .password(PASSWORD)
                 .newPassword(NEW_PASSWORD)
+                .build();
+        passwordRequest = PasswordRequest.builder()
+                .password(PASSWORD)
                 .build();
         memberResponse = MemberResponse.builder()
                 .nickname(NICKNAME)
@@ -269,6 +273,16 @@ public class MemberControllerTest extends ApiDocument {
         회원_비밀번호_수정_요청_비밀번호양식불일치_실패(resultActions);
     }
 
+    @Test
+    void 회원_탈퇴_성공() throws Exception {
+        // given
+        willDoNothing().given(memberService).withdraw(anyLong(), any(PasswordRequest.class));
+        // when
+        ResultActions resultActions = 회원_탈퇴_요청();
+        // then
+        회원_탈퇴_요청_성공(resultActions);
+    }
+
     private ResultActions 회원_가입_요청() throws Exception {
         return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH)
                 .contextPath(CONTEXT_PATH)
@@ -399,5 +413,18 @@ public class MemberControllerTest extends ApiDocument {
                         .andExpect(status().isBadRequest())
                         .andExpect(content().json(toJson(ErrorResponse.from(wrongFormException)))),
                 "update-member-password-wrong-form-fail");
+    }
+
+    private ResultActions 회원_탈퇴_요청() throws Exception {
+        return mockMvc.perform(delete(CONTEXT_PATH + DOMAIN_ROOT_PATH)
+                .contextPath(CONTEXT_PATH)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(toJson(passwordRequest)));
+    }
+
+    private void 회원_탈퇴_요청_성공(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isOk()),
+                "delete-member-success");
     }
 }

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -293,6 +293,16 @@ public class MemberControllerTest extends ApiDocument {
         회원_탈퇴_요청_회원정보찾기_실패(resultActions);
     }
 
+    @Test
+    void 회원_탈퇴_비밀번호불일치_실패() throws Exception {
+        // given
+        willThrow(passwordNotEqualException).given(memberService).withdraw(anyLong(), any(PasswordRequest.class));
+        // when
+        ResultActions resultActions = 회원_탈퇴_요청();
+        // then
+        회원_탈퇴_요청_비밀번호불일치_실패(resultActions);
+    }
+
     private ResultActions 회원_가입_요청() throws Exception {
         return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH)
                 .contextPath(CONTEXT_PATH)
@@ -443,5 +453,12 @@ public class MemberControllerTest extends ApiDocument {
                         .andExpect(status().isBadRequest())
                         .andExpect(content().json(toJson(ErrorResponse.from(memberNotFoundException)))),
                 "delete-member-not-found-member-fail");
+    }
+
+    private void 회원_탈퇴_요청_비밀번호불일치_실패(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isBadRequest())
+                        .andExpect(content().json(toJson(ErrorResponse.from(passwordNotEqualException)))),
+                "delete-member-not-equal-password-fail");
     }
 }

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -436,7 +436,7 @@ public class MemberControllerTest extends ApiDocument {
     }
 
     private ResultActions 회원_탈퇴_요청() throws Exception {
-        return mockMvc.perform(delete(CONTEXT_PATH + DOMAIN_ROOT_PATH)
+        return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/withdraw")
                 .contextPath(CONTEXT_PATH)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(toJson(passwordRequest)));


### PR DESCRIPTION
## Issue

closed #30
[SP-27](https://soma-cupid.atlassian.net/browse/SP-27?atlOrigin=eyJpIjoiYjlkZWI2OGJjMWQzNDY5NDhkMzAyYTA1NWFjZmI3YjkiLCJwIjoiaiJ9)

## 요구사항

- [x] 회원 삭제 성공 API 명세서 작성
- [x] 회원 삭제 실패 API 명세서 작성

## 변경사항

- 회원 삭제 로직을 `MemberController` 및 `MemberService`에 추가
- 회원 삭제 요청 DTO `PasswordRequest` 추가
- `index.adoc` 회원 삭제 추가
-  `MemberControllerTest` 및 `index.adoc` 회원 비밀번호 수정 기존비밀번호불일치 실패 스니펫 제목 수정

## 리뷰 우선순위

🙂 보통

## 코멘트

- 삭제 실패에 대한 케이스를 아래 두 가지로 나누어 작성했습니다.

    1. 비밀번호를 수정하려는 사용자를 찾을 수 없음
    2. 비밀번호가 일치하지 않음

- 회원 탈퇴 HTTP 메소드를 `DELETE`를 사용하지 않은 이유
    https://github.com/SWM-Cupid/jikting-backend/issues/30#issuecomment-1615747346

- 회원 탈퇴 시 Request로 password를 받는데, 비밀번호 재설정과 중복으로 사용될 수 있을 것 같아 `PasswordRequest`로 네이밍했는데 두 DTO의 사용을 명확하게 하기 위해 `WithdrawRequest`와 `PasswordReset`으로 나누는 게 더 좋은 방법일까요? 용태님 생각이 궁금합니다!

[SP-27]: https://soma-cupid.atlassian.net/browse/SP-27?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ