### PR TITLE
[SP-110] 아이디 찾기 인증 API 명세서 작성

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -157,6 +157,12 @@ include::{snippets}/search-username-verify-success/http-request.adoc[]
 
 .response
 include::{snippets}/search-username-verify-success/http-response.adoc[]
+===== 실패
+.request
+include::{snippets}/search-username-verify-fail/http-request.adoc[]
+
+.response
+include::{snippets}/search-username-verify-fail/http-response.adoc[]
 
 === 팀 관련 기능
 ==== 받은 호감 목록 조회

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -147,6 +147,17 @@ include::{snippets}/update-member-password-not-equal-fail/http-response.adoc[]
 .response - 비밀번호 양식 불일치
 include::{snippets}/update-member-password-wrong-form-fail/http-response.adoc[]
 
+==== 아이디 찾기 전화번호 인증 성공
+----
+/api/v1/members/password
+----
+===== 성공
+.request
+include::{snippets}/search-username-verify-success/http-request.adoc[]
+
+.response
+include::{snippets}/search-username-verify-success/http-response.adoc[]
+
 === 팀 관련 기능
 ==== 받은 호감 목록 조회
 ----

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -147,9 +147,9 @@ include::{snippets}/update-member-password-not-equal-fail/http-response.adoc[]
 .response - 비밀번호 양식 불일치
 include::{snippets}/update-member-password-wrong-form-fail/http-response.adoc[]
 
-==== 아이디 찾기 전화번호 인증 성공
+==== 아이디 찾기 전화번호 인증
 ----
-/api/v1/members/password
+/api/v1/members/search/username/verification
 ----
 ===== 성공
 .request

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -147,7 +147,7 @@ include::{snippets}/update-member-password-not-equal-fail/http-response.adoc[]
 .response - 비밀번호 양식 불일치
 include::{snippets}/update-member-password-wrong-form-fail/http-response.adoc[]
 
-==== 아이디 찾기 전화번호 인증
+==== 아이디 찾기 인증
 ----
 /api/v1/members/search/username/verification
 ----

--- a/src/main/java/com/cupid/jikting/common/error/ApplicationError.java
+++ b/src/main/java/com/cupid/jikting/common/error/ApplicationError.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ApplicationError {
 
-    INVALID_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "C001", "인증번호가 일치하지 않습니다."),
+    VERIFICATION_CODE_NOT_EQUAL(HttpStatus.BAD_REQUEST, "C001", "인증번호가 일치하지 않습니다."),
     INVALID_FORMAT(HttpStatus.BAD_REQUEST, "C002", "잘못된 양식입니다."),
     INVALID_AUTHORITY(HttpStatus.BAD_REQUEST, "C003", "잘못된 권한입니다."),
     INVALID_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "C004", "지원하지 않는 파일 확장자입니다."),

--- a/src/main/java/com/cupid/jikting/member/controller/MemberController.java
+++ b/src/main/java/com/cupid/jikting/member/controller/MemberController.java
@@ -46,4 +46,9 @@ public class MemberController {
         memberService.updatePassword(passwordUpdateRequest);
         return ResponseEntity.ok().build();
     }
+
+    @PostMapping("/search/username/verification")
+    public ResponseEntity<UsernameResponse> verifyForSearchUsername(@RequestBody VerificationRequest verificationRequest) {
+        return ResponseEntity.ok().body(memberService.verifyForSearchUsername(verificationRequest));
+    }
 }

--- a/src/main/java/com/cupid/jikting/member/dto/UsernameResponse.java
+++ b/src/main/java/com/cupid/jikting/member/dto/UsernameResponse.java
@@ -1,0 +1,12 @@
+package com.cupid.jikting.member.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UsernameResponse {
+
+    private String username;
+}

--- a/src/main/java/com/cupid/jikting/member/dto/VerificationRequest.java
+++ b/src/main/java/com/cupid/jikting/member/dto/VerificationRequest.java
@@ -1,0 +1,12 @@
+package com.cupid.jikting.member.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class VerificationRequest {
+
+    private String verificationCode;
+}

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -25,4 +25,8 @@ public class MemberService {
 
     public void updatePassword(PasswordUpdateRequest passwordUpdateRequest) {
     }
+
+    public UsernameResponse verifyForSearchUsername(VerificationRequest verificationRequest) {
+        return null;
+    }
 }

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -48,13 +48,16 @@ public class MemberControllerTest extends ApiDocument {
     private static final String DESCRIPTION = "한줄 소개(선택사항 - 없을 시 빈 문자열)";
     private static final String SEQUENCE = "순서";
     private static final String NEW_PASSWORD = "새 비밀번호";
+    private static final String VERIFICATION_CODE = "인증번호";
 
     private SignupRequest signupRequest;
     private NicknameUpdateRequest nicknameUpdateRequest;
     private MemberProfileUpdateRequest memberProfileUpdateRequest;
     private PasswordUpdateRequest passwordUpdateRequest;
+    private VerificationRequest verificationRequest;
     private MemberResponse memberResponse;
     private MemberProfileResponse memberProfileResponse;
+    private UsernameResponse usernameResponse;
     private ApplicationException invalidFormatException;
     private ApplicationException memberNotFoundException;
     private ApplicationException passwordNotEqualException;
@@ -104,6 +107,9 @@ public class MemberControllerTest extends ApiDocument {
                 .password(PASSWORD)
                 .newPassword(NEW_PASSWORD)
                 .build();
+        verificationRequest = VerificationRequest.builder()
+                .verificationCode(VERIFICATION_CODE)
+                .build();
         memberResponse = MemberResponse.builder()
                 .nickname(NICKNAME)
                 .company(COMPANY)
@@ -122,6 +128,9 @@ public class MemberControllerTest extends ApiDocument {
                 .personalities(personalities)
                 .hobbies(hobbies)
                 .description(DESCRIPTION)
+                .build();
+        usernameResponse = UsernameResponse.builder()
+                .username(USERNAME)
                 .build();
         invalidFormatException = new BadRequestException(ApplicationError.INVALID_FORMAT);
         memberNotFoundException = new NotFoundException(ApplicationError.MEMBER_NOT_FOUND);
@@ -269,6 +278,16 @@ public class MemberControllerTest extends ApiDocument {
         회원_비밀번호_수정_요청_비밀번호양식불일치_실패(resultActions);
     }
 
+    @Test
+    void 아이디_찾기_전화번호_인증_성공() throws Exception {
+        // given
+        willReturn(usernameResponse).given(memberService).verifyForSearchUsername(any(VerificationRequest.class));
+        // when
+        ResultActions resultActions = 아이디_찾기_전화번호_인증_요청();
+        // then
+        아이디_찾기_전화번호_인증_요청_성공(resultActions);
+    }
+
     private ResultActions 회원_가입_요청() throws Exception {
         return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH)
                 .contextPath(CONTEXT_PATH)
@@ -399,5 +418,19 @@ public class MemberControllerTest extends ApiDocument {
                         .andExpect(status().isBadRequest())
                         .andExpect(content().json(toJson(ErrorResponse.from(wrongFormException)))),
                 "update-member-password-wrong-form-fail");
+    }
+
+    private ResultActions 아이디_찾기_전화번호_인증_요청() throws Exception {
+        return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/search/username/verification")
+                .contextPath(CONTEXT_PATH)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(toJson(verificationRequest)));
+    }
+
+    private void 아이디_찾기_전화번호_인증_요청_성공(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isOk())
+                        .andExpect(content().json(toJson(usernameResponse))),
+                "search-username-verify-success");
     }
 }

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -281,23 +281,23 @@ public class MemberControllerTest extends ApiDocument {
     }
 
     @Test
-    void 아이디_찾기_전화번호_인증_성공() throws Exception {
+    void 아이디_찾기_인증_성공() throws Exception {
         // given
         willReturn(usernameResponse).given(memberService).verifyForSearchUsername(any(VerificationRequest.class));
         // when
-        ResultActions resultActions = 아이디_찾기_전화번호_인증_요청();
+        ResultActions resultActions = 아이디_찾기_인증_요청();
         // then
-        아이디_찾기_전화번호_인증_요청_성공(resultActions);
+        아이디_찾기_인증_요청_성공(resultActions);
     }
 
     @Test
-    void 아이디_찾기_전화번호_인증_실패() throws Exception {
+    void 아이디_찾기_인증_실패() throws Exception {
         // given
         willThrow(verificationCodeNotEqualException).given(memberService).verifyForSearchUsername(any(VerificationRequest.class));
         // when
-        ResultActions resultActions = 아이디_찾기_전화번호_인증_요청();
+        ResultActions resultActions = 아이디_찾기_인증_요청();
         // then
-        아이디_찾기_전화번호_인증_요청_실패(resultActions);
+        아이디_찾기_인증_요청_실패(resultActions);
     }
 
     private ResultActions 회원_가입_요청() throws Exception {
@@ -432,21 +432,21 @@ public class MemberControllerTest extends ApiDocument {
                 "update-member-password-wrong-form-fail");
     }
 
-    private ResultActions 아이디_찾기_전화번호_인증_요청() throws Exception {
+    private ResultActions 아이디_찾기_인증_요청() throws Exception {
         return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/search/username/verification")
                 .contextPath(CONTEXT_PATH)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(toJson(verificationRequest)));
     }
 
-    private void 아이디_찾기_전화번호_인증_요청_성공(ResultActions resultActions) throws Exception {
+    private void 아이디_찾기_인증_요청_성공(ResultActions resultActions) throws Exception {
         printAndMakeSnippet(resultActions
                         .andExpect(status().isOk())
                         .andExpect(content().json(toJson(usernameResponse))),
                 "search-username-verify-success");
     }
 
-    private void 아이디_찾기_전화번호_인증_요청_실패(ResultActions resultActions) throws Exception {
+    private void 아이디_찾기_인증_요청_실패(ResultActions resultActions) throws Exception {
         printAndMakeSnippet(resultActions
                         .andExpect(status().isBadRequest())
                         .andExpect(content().json(toJson(ErrorResponse.from(verificationCodeNotEqualException)))),

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -62,6 +62,7 @@ public class MemberControllerTest extends ApiDocument {
     private ApplicationException memberNotFoundException;
     private ApplicationException passwordNotEqualException;
     private ApplicationException wrongFormException;
+    private ApplicationException verificationCodeNotEqualException;
 
     @MockBean
     private MemberService memberService;
@@ -136,6 +137,7 @@ public class MemberControllerTest extends ApiDocument {
         memberNotFoundException = new NotFoundException(ApplicationError.MEMBER_NOT_FOUND);
         passwordNotEqualException = new NotEqualException(ApplicationError.NOT_EQUAL_ID_OR_PASSWORD);
         wrongFormException = new WrongFromException(ApplicationError.INVALID_FORMAT);
+        verificationCodeNotEqualException = new BadRequestException(ApplicationError.VERIFICATION_CODE_NOT_EQUAL);
     }
 
     @Test
@@ -288,6 +290,16 @@ public class MemberControllerTest extends ApiDocument {
         아이디_찾기_전화번호_인증_요청_성공(resultActions);
     }
 
+    @Test
+    void 아이디_찾기_전화번호_인증_실패() throws Exception {
+        // given
+        willThrow(verificationCodeNotEqualException).given(memberService).verifyForSearchUsername(any(VerificationRequest.class));
+        // when
+        ResultActions resultActions = 아이디_찾기_전화번호_인증_요청();
+        // then
+        아이디_찾기_전화번호_인증_요청_실패(resultActions);
+    }
+
     private ResultActions 회원_가입_요청() throws Exception {
         return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH)
                 .contextPath(CONTEXT_PATH)
@@ -432,5 +444,12 @@ public class MemberControllerTest extends ApiDocument {
                         .andExpect(status().isOk())
                         .andExpect(content().json(toJson(usernameResponse))),
                 "search-username-verify-success");
+    }
+
+    private void 아이디_찾기_전화번호_인증_요청_실패(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isBadRequest())
+                        .andExpect(content().json(toJson(ErrorResponse.from(verificationCodeNotEqualException)))),
+                "search-username-verify-fail");
     }
 }


### PR DESCRIPTION
## Issue

closed #34 
[SP-110](https://soma-cupid.atlassian.net/browse/SP-110?atlOrigin=eyJpIjoiOWQxZDYyYmQzMjg2NGM3NzljMzUzM2ZhMzlkYjJkZTkiLCJwIjoiaiJ9)

## 요구사항

- [x] 아이디 찾기 인증 성공 API 명세서 작성
- [x] 아이디 찾기 인증 실패 API 명세서 작성

## 변경사항

- 아이디 찾기 인증 로직을 `MemberController` 및 `MemberService`에 추가
- 아이디 찾기 인증 요청 DTO `VerificationRequest` 추가
- 아이디 응답 DTO `UsernameResponse` 추가
- `index.adoc` 아이디 찾기 인증 추가
- `ApplicationError` 인증번호 불일치 에러 네이밍 수정

## 리뷰 우선순위

🙂 보통

[SP-110]: https://soma-cupid.atlassian.net/browse/SP-110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ