### PR TITLE
[SP-113] 비밀번호 재설정 인증 API 명세서 작성

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -180,6 +180,12 @@ include::{snippets}/reset-password-verify-success/http-request.adoc[]
 
 .response
 include::{snippets}/reset-password-verify-success/http-response.adoc[]
+===== 실패
+.request
+include::{snippets}/reset-password-verify-fail/http-request.adoc[]
+
+.response
+include::{snippets}/reset-password-verify-fail/http-response.adoc[]
 
 === 추천 관련 기능
 ==== 추천 팀 조회

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -170,6 +170,17 @@ include::{snippets}/update-member-image-invalid-file-extension-fail/http-respons
 .response - 파일 크기 미지원
 include::{snippets}/update-member-image-invalid-file-size-fail/http-response.adoc[]
 
+==== 비밀번호 재설정 인증
+----
+/api/v1/members/reset/password/verification
+----
+===== 성공
+.request
+include::{snippets}/reset-password-verify-success/http-request.adoc[]
+
+.response
+include::{snippets}/reset-password-verify-success/http-response.adoc[]
+
 === 추천 관련 기능
 ==== 추천 팀 조회
 ----

--- a/src/main/java/com/cupid/jikting/common/error/ApplicationError.java
+++ b/src/main/java/com/cupid/jikting/common/error/ApplicationError.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ApplicationError {
 
-    INVALID_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "C001", "인증번호가 일치하지 않습니다."),
+    VERIFICATION_CODE_NOT_EQUAL(HttpStatus.BAD_REQUEST, "C001", "인증번호가 일치하지 않습니다."),
     INVALID_FORMAT(HttpStatus.BAD_REQUEST, "C002", "잘못된 양식입니다."),
     INVALID_AUTHORITY(HttpStatus.BAD_REQUEST, "C003", "잘못된 권한입니다."),
     INVALID_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "C004", "지원하지 않는 파일 확장자입니다."),

--- a/src/main/java/com/cupid/jikting/member/controller/MemberController.java
+++ b/src/main/java/com/cupid/jikting/member/controller/MemberController.java
@@ -53,4 +53,10 @@ public class MemberController {
         memberService.updateImage(multipartFile);
         return ResponseEntity.ok().build();
     }
+
+    @PostMapping("/reset/password/verification")
+    public ResponseEntity<Void> verifyForResetPassword(@RequestBody VerificationRequest verificationRequest) {
+        memberService.verifyForResetPassword(verificationRequest);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/cupid/jikting/member/dto/VerificationRequest.java
+++ b/src/main/java/com/cupid/jikting/member/dto/VerificationRequest.java
@@ -1,0 +1,12 @@
+package com.cupid.jikting.member.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class VerificationRequest {
+
+    private String verificationCode;
+}

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -29,4 +29,7 @@ public class MemberService {
 
     public void updateImage(MultipartFile multipartFile) {
     }
+
+    public void verifyForResetPassword(VerificationRequest verificationRequest) {
+    }
 }

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -69,6 +69,7 @@ public class MemberControllerTest extends ApiDocument {
     private ApplicationException wrongFormException;
     private ApplicationException wrongFileExtensionException;
     private ApplicationException wrongFileSizeException;
+    private ApplicationException verificationCodeNotEqualException;
 
     @MockBean
     private MemberService memberService;
@@ -142,6 +143,7 @@ public class MemberControllerTest extends ApiDocument {
         wrongFormException = new WrongFromException(ApplicationError.INVALID_FORMAT);
         wrongFileExtensionException = new WrongFromException(ApplicationError.INVALID_FILE_EXTENSION);
         wrongFileSizeException = new WrongFromException(ApplicationError.INVALID_FILE_SIZE);
+        verificationCodeNotEqualException = new BadRequestException(ApplicationError.VERIFICATION_CODE_NOT_EQUAL);
     }
 
     @Test
@@ -334,6 +336,16 @@ public class MemberControllerTest extends ApiDocument {
         비밀번호_재설정_인증_요청_성공(resultActions);
     }
 
+    @Test
+    void 비밀번호_재설정_인증_실패() throws Exception {
+        // given
+        willThrow(verificationCodeNotEqualException).given(memberService).verifyForResetPassword(any(VerificationRequest.class));
+        // when
+        ResultActions resultActions = 비밀번호_재설정_인증_요청();
+        // then
+        비밀번호_재설정_인증_요청_실패(resultActions);
+    }
+
     private ResultActions 회원_가입_요청() throws Exception {
         return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH)
                 .contextPath(CONTEXT_PATH)
@@ -511,5 +523,12 @@ public class MemberControllerTest extends ApiDocument {
         printAndMakeSnippet(resultActions
                         .andExpect(status().isOk()),
                 "reset-password-verify-success");
+    }
+
+    private void 비밀번호_재설정_인증_요청_실패(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isBadRequest())
+                        .andExpect(content().json(toJson(ErrorResponse.from(verificationCodeNotEqualException)))),
+                "reset-password-verify-fail");
     }
 }

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -54,11 +54,13 @@ public class MemberControllerTest extends ApiDocument {
     private static final String ORIGINAL_FILENAME = "image.png";
     private static final String CONTENT_TYPE = "image/png";
     private static final String IMAGE_FILE = "이미지 파일";
+    private static final String VERIFICATION_CODE = "인증번호";
 
     private SignupRequest signupRequest;
     private NicknameUpdateRequest nicknameUpdateRequest;
     private MemberProfileUpdateRequest memberProfileUpdateRequest;
     private PasswordUpdateRequest passwordUpdateRequest;
+    private VerificationRequest verificationRequest;
     private MemberResponse memberResponse;
     private MemberProfileResponse memberProfileResponse;
     private ApplicationException invalidFormatException;
@@ -111,6 +113,9 @@ public class MemberControllerTest extends ApiDocument {
         passwordUpdateRequest = PasswordUpdateRequest.builder()
                 .password(PASSWORD)
                 .newPassword(NEW_PASSWORD)
+                .build();
+        verificationRequest = VerificationRequest.builder()
+                .verificationCode(VERIFICATION_CODE)
                 .build();
         memberResponse = MemberResponse.builder()
                 .nickname(NICKNAME)
@@ -319,6 +324,16 @@ public class MemberControllerTest extends ApiDocument {
         회원_이미지_수정_요청_파일크기미지원_실패(resultActions);
     }
 
+    @Test
+    void 비밀번호_재설정_인증_성공() throws Exception {
+        // given
+        willDoNothing().given(memberService).verifyForResetPassword(any(VerificationRequest.class));
+        // when
+        ResultActions resultActions = 비밀번호_재설정_인증_요청();
+        // then
+        비밀번호_재설정_인증_요청_성공(resultActions);
+    }
+
     private ResultActions 회원_가입_요청() throws Exception {
         return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH)
                 .contextPath(CONTEXT_PATH)
@@ -483,5 +498,18 @@ public class MemberControllerTest extends ApiDocument {
                         .andExpect(status().isBadRequest())
                         .andExpect(content().json(toJson(ErrorResponse.from(wrongFileSizeException)))),
                 "update-member-image-invalid-file-size-fail");
+    }
+
+    private ResultActions 비밀번호_재설정_인증_요청() throws Exception {
+        return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/reset/password/verification")
+                .contextPath(CONTEXT_PATH)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(toJson(verificationRequest)));
+    }
+
+    private void 비밀번호_재설정_인증_요청_성공(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isOk()),
+                "reset-password-verify-success");
     }
 }


### PR DESCRIPTION
## Issue

closed #38 
[SP-113](https://soma-cupid.atlassian.net/browse/SP-113?atlOrigin=eyJpIjoiNjM5MzY2N2U2NWI1NGQ3MDkwNWY0ZmU0NDI5OWU4OGYiLCJwIjoiaiJ9)

## 요구사항

- [x] 비밀번호 재설정 인증 성공 API 명세서 작성
- [x] 비밀번호 재설정 인증 실패 API 명세서 작성

## 변경사항

- 비밀번호 재설정 인증 로직을 `MemberController` 및 `MemberService`에 추가
- 비밀번호 재설정 인증 요청 DTO `VerificationRequest` 추가
- `index.adoc` 비밀번호 재설정 인증 추가
- `ApplicationError` 인증번호 불일치 에러 네이밍 수정

## 리뷰 우선순위

🙂 보통

[SP-113]: https://soma-cupid.atlassian.net/browse/SP-113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ