### PR TITLE
[SP-120] 받은 호감 거절 API 명세서 작성

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -309,3 +309,19 @@ include::{snippets}/accept-like-fail/http-request.adoc[]
 
 .response
 include::{snippets}/accept-like-fail/http-response.adoc[]
+==== 받은 호감 거절
+----
+/api/v1/likes/{likeId}/decline
+----
+===== 성공
+.request
+include::{snippets}/decline-like-success/http-request.adoc[]
+
+.response
+include::{snippets}/decline-like-success/http-response.adoc[]
+===== 실패
+.request
+include::{snippets}/decline-like-fail/http-request.adoc[]
+
+.response
+include::{snippets}/decline-like-fail/http-response.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -311,17 +311,17 @@ include::{snippets}/accept-like-fail/http-request.adoc[]
 include::{snippets}/accept-like-fail/http-response.adoc[]
 ==== 받은 호감 거절
 ----
-/api/v1/likes/{likeId}/decline
+/api/v1/likes/{likeId}/reject
 ----
 ===== 성공
 .request
-include::{snippets}/decline-like-success/http-request.adoc[]
+include::{snippets}/reject-like-success/http-request.adoc[]
 
 .response
-include::{snippets}/decline-like-success/http-response.adoc[]
+include::{snippets}/reject-like-success/http-response.adoc[]
 ===== 실패
 .request
-include::{snippets}/decline-like-fail/http-request.adoc[]
+include::{snippets}/reject-like-fail/http-request.adoc[]
 
 .response
-include::{snippets}/decline-like-fail/http-response.adoc[]
+include::{snippets}/reject-like-fail/http-response.adoc[]

--- a/src/main/java/com/cupid/jikting/chatting/service/ChattingService.java
+++ b/src/main/java/com/cupid/jikting/chatting/service/ChattingService.java
@@ -1,7 +1,0 @@
-package com.cupid.jikting.chatting.service;
-
-import org.springframework.stereotype.Service;
-
-@Service
-public class ChattingService {
-}

--- a/src/main/java/com/cupid/jikting/chatting/service/ChattingService.java
+++ b/src/main/java/com/cupid/jikting/chatting/service/ChattingService.java
@@ -1,0 +1,7 @@
+package com.cupid.jikting.chatting.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class ChattingService {
+}

--- a/src/main/java/com/cupid/jikting/like/controller/LikeController.java
+++ b/src/main/java/com/cupid/jikting/like/controller/LikeController.java
@@ -30,4 +30,10 @@ public class LikeController {
         likeService.acceptLike(likeId);
         return ResponseEntity.ok().build();
     }
+
+    @PostMapping("/{likeId}/decline")
+    public ResponseEntity<Void> declineLike(@PathVariable Long likeId) {
+        likeService.declineLike(likeId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/cupid/jikting/like/controller/LikeController.java
+++ b/src/main/java/com/cupid/jikting/like/controller/LikeController.java
@@ -31,9 +31,9 @@ public class LikeController {
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping("/{likeId}/decline")
-    public ResponseEntity<Void> declineLike(@PathVariable Long likeId) {
-        likeService.declineLike(likeId);
+    @PostMapping("/{likeId}/reject")
+    public ResponseEntity<Void> rejectLike(@PathVariable Long likeId) {
+        likeService.rejectLike(likeId);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/cupid/jikting/like/service/LikeService.java
+++ b/src/main/java/com/cupid/jikting/like/service/LikeService.java
@@ -19,6 +19,6 @@ public class LikeService {
     public void acceptLike(Long likeId) {
     }
 
-    public void declineLike(Long likeId) {
+    public void rejectLike(Long likeId) {
     }
 }

--- a/src/main/java/com/cupid/jikting/like/service/LikeService.java
+++ b/src/main/java/com/cupid/jikting/like/service/LikeService.java
@@ -18,4 +18,7 @@ public class LikeService {
 
     public void acceptLike(Long likeId) {
     }
+
+    public void declineLike(Long likeId) {
+    }
 }

--- a/src/test/java/com/cupid/jikting/like/controller/LikeControllerTest.java
+++ b/src/test/java/com/cupid/jikting/like/controller/LikeControllerTest.java
@@ -124,7 +124,7 @@ public class LikeControllerTest extends ApiDocument {
     @Test
     void 받은_호감_거절_성공() throws Exception {
         //given
-        willDoNothing().given(likeService).declineLike(anyLong());
+        willDoNothing().given(likeService).rejectLike(anyLong());
         //when
         ResultActions resultActions = 받은_호감_거절_요청();
         //then
@@ -134,7 +134,7 @@ public class LikeControllerTest extends ApiDocument {
     @Test
     void 받은_호감_거절_실패() throws Exception {
         //given
-        willThrow(teamNotFoundException).given(likeService).declineLike(anyLong());
+        willThrow(teamNotFoundException).given(likeService).rejectLike(anyLong());
         //when
         ResultActions resultActions = 받은_호감_거절_요청();
         //then
@@ -198,20 +198,20 @@ public class LikeControllerTest extends ApiDocument {
     }
 
     private ResultActions 받은_호감_거절_요청() throws Exception {
-        return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH + PATH_DELIMITER + ID + "/decline")
+        return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH + PATH_DELIMITER + ID + "/reject")
                 .contextPath(CONTEXT_PATH));
     }
 
     private void 받은_호감_거절_요청_성공(ResultActions resultActions) throws Exception {
         printAndMakeSnippet(resultActions
                         .andExpect(status().isOk()),
-                "decline-like-success");
+                "reject-like-success");
     }
 
     private void 받은_호감_거절_요청_실패(ResultActions resultActions) throws Exception {
         printAndMakeSnippet(resultActions
                         .andExpect(status().isBadRequest())
                         .andExpect(content().json(toJson(ErrorResponse.from(teamNotFoundException)))),
-                "decline-like-fail");
+                "reject-like-fail");
     }
 }

--- a/src/test/java/com/cupid/jikting/like/controller/LikeControllerTest.java
+++ b/src/test/java/com/cupid/jikting/like/controller/LikeControllerTest.java
@@ -121,6 +121,26 @@ public class LikeControllerTest extends ApiDocument {
         받은_호감_수락_요청_실패(resultActions);
     }
 
+    @Test
+    void 받은_호감_거절_성공() throws Exception {
+        //given
+        willDoNothing().given(likeService).declineLike(anyLong());
+        //when
+        ResultActions resultActions = 받은_호감_거절_요청();
+        //then
+        받은_호감_거절_요청_성공(resultActions);
+    }
+
+    @Test
+    void 받은_호감_거절_실패() throws Exception {
+        //given
+        willThrow(teamNotFoundException).given(likeService).declineLike(anyLong());
+        //when
+        ResultActions resultActions = 받은_호감_거절_요청();
+        //then
+        받은_호감_거절_요청_실패(resultActions);
+    }
+
     private ResultActions 받은_호감_목록_조회_요청() throws Exception {
         ResultActions resultActions = mockMvc.perform(get(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/received")
                 .contextPath(CONTEXT_PATH));
@@ -178,5 +198,23 @@ public class LikeControllerTest extends ApiDocument {
                         .andExpect(status().isBadRequest())
                         .andExpect(content().json(toJson(ErrorResponse.from(teamNotFoundException)))),
                 "accept-like-fail");
+    }
+
+    private ResultActions 받은_호감_거절_요청() throws Exception {
+        return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH + PATH_DELIMITER + ID + "/decline")
+                .contextPath(CONTEXT_PATH));
+    }
+
+    private void 받은_호감_거절_요청_성공(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isOk()),
+                "decline-like-success");
+    }
+
+    private void 받은_호감_거절_요청_실패(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isBadRequest())
+                        .andExpect(content().json(toJson(ErrorResponse.from(teamNotFoundException)))),
+                "decline-like-fail");
     }
 }

--- a/src/test/java/com/cupid/jikting/like/controller/LikeControllerTest.java
+++ b/src/test/java/com/cupid/jikting/like/controller/LikeControllerTest.java
@@ -142,9 +142,8 @@ public class LikeControllerTest extends ApiDocument {
     }
 
     private ResultActions 받은_호감_목록_조회_요청() throws Exception {
-        ResultActions resultActions = mockMvc.perform(get(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/received")
+        return mockMvc.perform(get(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/received")
                 .contextPath(CONTEXT_PATH));
-        return resultActions;
     }
 
     private void 받은_호감_목록_조회_요청_성공(ResultActions resultActions) throws Exception {
@@ -162,9 +161,8 @@ public class LikeControllerTest extends ApiDocument {
     }
 
     private ResultActions 보낸_호감_목록_조회_요청() throws Exception {
-        ResultActions resultActions = mockMvc.perform(get(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/sent")
+        return mockMvc.perform(get(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/sent")
                 .contextPath(CONTEXT_PATH));
-        return resultActions;
     }
 
     private void 보낸_호감_목록_조회_요청_성공(ResultActions resultActions) throws Exception {
@@ -182,9 +180,8 @@ public class LikeControllerTest extends ApiDocument {
     }
 
     private ResultActions 받은_호감_수락_요청() throws Exception {
-        ResultActions resultActions = mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH + PATH_DELIMITER + ID + "/accept")
+        return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH + PATH_DELIMITER + ID + "/accept")
                 .contextPath(CONTEXT_PATH));
-        return resultActions;
     }
 
     private void 받은_호감_수락_요청_성공(ResultActions resultActions) throws Exception {


### PR DESCRIPTION
## Issue

closed #41 
[SP-120](https://soma-cupid.atlassian.net/browse/SP-120?atlOrigin=eyJpIjoiZGQyZGM0M2M5NDE4NGNiNGI3YmM4NDcxYmYxMzlkMTIiLCJwIjoiaiJ9)

## 요구사항

- [x] 받은 호감 거절 성공 API 명세서 작성
- [x] 받은 호감 거절 실패 API 명세서 작성

## 변경사항

- `LikeController` 및 `LikeService`에 받은 호감 거절 추가
- `LikeControllerTest`에 받은 호감 거절 테스트 추가
- `LikeControllerTest`에 resultAction 리턴하는 메서드들 인라인 리턴으로 수정
- `index.adoc`에 받은 호감 거절 api 추가

## 리뷰 우선순위

🙂 보통

[SP-120]: https://soma-cupid.atlassian.net/browse/SP-120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ