### PR TITLE
[SP-35] 비밀번호 재설정 API 문서 작성

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -268,6 +268,12 @@ include::{snippets}/reset-password-success/http-request.adoc[]
 
 .response
 include::{snippets}/reset-password-success/http-response.adoc[]
+===== 실패
+.request
+include::{snippets}/reset-password-not-found-member-fail/http-request.adoc[]
+
+.response - 회원을 찾을 수 없음
+include::{snippets}/reset-password-not-found-member-fail/http-response.adoc[]
 
 === 추천 관련 기능
 ==== 추천 팀 조회

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -226,7 +226,7 @@ include::{snippets}/search-username-verify-fail/http-response.adoc[]
 
 ==== 비밀번호 재설정 인증번호 발급
 ----
-/api/v1/members/reset/password/code
+/api/v1/members/password/reset/code
 ----
 ===== 성공
 .request
@@ -243,7 +243,7 @@ include::{snippets}/reset-password-create-verification-code-fail/http-response.a
 
 ==== 비밀번호 재설정 인증
 ----
-/api/v1/members/reset/password/verification
+/api/v1/members/password/reset/verification
 ----
 ===== 성공
 .request

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -275,6 +275,9 @@ include::{snippets}/reset-password-not-found-member-fail/http-request.adoc[]
 .response - 회원을 찾을 수 없음
 include::{snippets}/reset-password-not-found-member-fail/http-response.adoc[]
 
+.response - 비밀번호 양식 불일치
+include::{snippets}/reset-password-wrong-form-fail/http-response.adoc[]
+
 === 추천 관련 기능
 ==== 추천 팀 조회
 ----

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -258,6 +258,17 @@ include::{snippets}/reset-password-verify-fail/http-request.adoc[]
 .response
 include::{snippets}/reset-password-verify-fail/http-response.adoc[]
 
+==== 비밀번호 재설정
+----
+/api/v1/members/password/reset
+----
+===== 성공
+.request
+include::{snippets}/reset-password-success/http-request.adoc[]
+
+.response
+include::{snippets}/reset-password-success/http-response.adoc[]
+
 === 추천 관련 기능
 ==== 추천 팀 조회
 ----

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -192,7 +192,7 @@ include::{snippets}/delete-member-not-equal-password-fail/http-response.adoc[]
 
 ==== 아이디 찾기 인증번호 발급
 ----
-/api/v1/members/search/username/code
+/api/v1/members/username/search/code
 ----
 ===== 성공
 .request
@@ -209,7 +209,7 @@ include::{snippets}/search-username-create-verification-code-fail/http-response.
 
 ==== 아이디 찾기 인증
 ----
-/api/v1/members/search/username/verification
+/api/v1/members/username/search/verification
 ----
 ===== 성공
 .request

--- a/src/main/java/com/cupid/jikting/common/error/WrongFormException.java
+++ b/src/main/java/com/cupid/jikting/common/error/WrongFormException.java
@@ -1,0 +1,8 @@
+package com.cupid.jikting.common.error;
+
+public class WrongFormException extends ApplicationException {
+
+    public WrongFormException(ApplicationError error) {
+        super(error);
+    }
+}

--- a/src/main/java/com/cupid/jikting/common/error/WrongFromException.java
+++ b/src/main/java/com/cupid/jikting/common/error/WrongFromException.java
@@ -1,8 +1,0 @@
-package com.cupid.jikting.common.error;
-
-public class WrongFromException extends ApplicationException {
-
-    public WrongFromException(ApplicationError error) {
-        super(error);
-    }
-}

--- a/src/main/java/com/cupid/jikting/member/controller/MemberController.java
+++ b/src/main/java/com/cupid/jikting/member/controller/MemberController.java
@@ -84,8 +84,8 @@ public class MemberController {
     }
 
     @PatchMapping("/password/reset")
-    public ResponseEntity<Void> resetPassword(@RequestBody PasswordRequest passwordRequest) {
-        memberService.resetPassword(passwordRequest);
+    public ResponseEntity<Void> resetPassword(@RequestBody PasswordResetRequest passwordResetRequest) {
+        memberService.resetPassword(passwordResetRequest);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/cupid/jikting/member/controller/MemberController.java
+++ b/src/main/java/com/cupid/jikting/member/controller/MemberController.java
@@ -72,8 +72,8 @@ public class MemberController {
     }
 
     @PostMapping("/reset/password/code")
-    public ResponseEntity<Void> createVerificationCodeForResetPassword(@RequestBody PasswordResetRequest passwordResetRequest) {
-        memberService.createVerificationCodeForResetPassword(passwordResetRequest);
+    public ResponseEntity<Void> createVerificationCodeForResetPassword(@RequestBody PasswordResetVerificationCodeRequest passwordResetVerificationCodeRequest) {
+        memberService.createVerificationCodeForResetPassword(passwordResetVerificationCodeRequest);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/cupid/jikting/member/controller/MemberController.java
+++ b/src/main/java/com/cupid/jikting/member/controller/MemberController.java
@@ -82,4 +82,10 @@ public class MemberController {
         memberService.verifyForResetPassword(verificationRequest);
         return ResponseEntity.ok().build();
     }
+
+    @PatchMapping("/password/reset")
+    public ResponseEntity<Void> resetPassword(@RequestBody PasswordRequest passwordRequest) {
+        memberService.resetPassword(passwordRequest);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/cupid/jikting/member/controller/MemberController.java
+++ b/src/main/java/com/cupid/jikting/member/controller/MemberController.java
@@ -60,13 +60,13 @@ public class MemberController {
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping("/search/username/code")
+    @PostMapping("/username/search/code")
     public ResponseEntity<Void> createVerificationCodeForSearchUsername(@RequestBody UsernameSearchVerificationCodeRequest usernameSearchVerificationCodeRequest) {
         memberService.createVerificationCodeForSearchUsername(usernameSearchVerificationCodeRequest);
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping("/search/username/verification")
+    @PostMapping("/username/search/verification")
     public ResponseEntity<UsernameResponse> verifyForSearchUsername(@RequestBody VerificationRequest verificationRequest) {
         return ResponseEntity.ok().body(memberService.verifyForSearchUsername(verificationRequest));
     }

--- a/src/main/java/com/cupid/jikting/member/controller/MemberController.java
+++ b/src/main/java/com/cupid/jikting/member/controller/MemberController.java
@@ -71,13 +71,13 @@ public class MemberController {
         return ResponseEntity.ok().body(memberService.verifyForSearchUsername(verificationRequest));
     }
 
-    @PostMapping("/reset/password/code")
+    @PostMapping("/password/reset/code")
     public ResponseEntity<Void> createVerificationCodeForResetPassword(@RequestBody PasswordResetVerificationCodeRequest passwordResetVerificationCodeRequest) {
         memberService.createVerificationCodeForResetPassword(passwordResetVerificationCodeRequest);
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping("/reset/password/verification")
+    @PostMapping("/password/reset/verification")
     public ResponseEntity<Void> verifyForResetPassword(@RequestBody VerificationRequest verificationRequest) {
         memberService.verifyForResetPassword(verificationRequest);
         return ResponseEntity.ok().build();

--- a/src/main/java/com/cupid/jikting/member/controller/MemberController.java
+++ b/src/main/java/com/cupid/jikting/member/controller/MemberController.java
@@ -55,8 +55,8 @@ public class MemberController {
     }
 
     @PostMapping("/withdraw")
-    public ResponseEntity<Void> withdraw(@RequestBody PasswordRequest passwordRequest) {
-        memberService.withdraw(1L, passwordRequest);
+    public ResponseEntity<Void> withdraw(@RequestBody WithdrawRequest withdrawRequest) {
+        memberService.withdraw(1L, withdrawRequest);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/cupid/jikting/member/controller/MemberController.java
+++ b/src/main/java/com/cupid/jikting/member/controller/MemberController.java
@@ -61,8 +61,8 @@ public class MemberController {
     }
 
     @PostMapping("/search/username/code")
-    public ResponseEntity<Void> createVerificationCodeForSearchUsername(@RequestBody UsernameSearchRequest usernameSearchRequest) {
-        memberService.createVerificationCodeForSearchUsername(usernameSearchRequest);
+    public ResponseEntity<Void> createVerificationCodeForSearchUsername(@RequestBody UsernameSearchVerificationCodeRequest usernameSearchVerificationCodeRequest) {
+        memberService.createVerificationCodeForSearchUsername(usernameSearchVerificationCodeRequest);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/cupid/jikting/member/dto/PasswordResetRequest.java
+++ b/src/main/java/com/cupid/jikting/member/dto/PasswordResetRequest.java
@@ -1,0 +1,13 @@
+package com.cupid.jikting.member.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PasswordResetRequest {
+
+    private String username;
+    private String password;
+}

--- a/src/main/java/com/cupid/jikting/member/dto/PasswordResetVerificationCodeRequest.java
+++ b/src/main/java/com/cupid/jikting/member/dto/PasswordResetVerificationCodeRequest.java
@@ -6,7 +6,7 @@ import lombok.*;
 @Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class PasswordResetRequest {
+public class PasswordResetVerificationCodeRequest {
 
     private String username;
     private String name;

--- a/src/main/java/com/cupid/jikting/member/dto/UsernameSearchVerificationCodeRequest.java
+++ b/src/main/java/com/cupid/jikting/member/dto/UsernameSearchVerificationCodeRequest.java
@@ -6,7 +6,7 @@ import lombok.*;
 @Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class UsernameSearchRequest {
+public class UsernameSearchVerificationCodeRequest {
 
     private String username;
     private String phone;

--- a/src/main/java/com/cupid/jikting/member/dto/WithdrawRequest.java
+++ b/src/main/java/com/cupid/jikting/member/dto/WithdrawRequest.java
@@ -6,7 +6,7 @@ import lombok.*;
 @Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class PasswordRequest {
+public class WithdrawRequest {
 
     private String password;
 }

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -45,4 +45,7 @@ public class MemberService {
 
     public void verifyForResetPassword(VerificationRequest verificationRequest) {
     }
+
+    public void resetPassword(PasswordRequest passwordRequest) {
+    }
 }

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -30,7 +30,7 @@ public class MemberService {
     public void updateImage(MultipartFile multipartFile) {
     }
 
-    public void withdraw(Long memberId, PasswordRequest passwordRequest) {
+    public void withdraw(Long memberId, WithdrawRequest withdrawRequest) {
     }
 
     public void createVerificationCodeForSearchUsername(UsernameSearchVerificationCodeRequest usernameSearchVerificationCodeRequest) {

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -40,7 +40,7 @@ public class MemberService {
         return null;
     }
 
-    public void createVerificationCodeForResetPassword(PasswordResetRequest passwordResetRequest) {
+    public void createVerificationCodeForResetPassword(PasswordResetVerificationCodeRequest passwordResetVerificationCodeRequest) {
     }
 
     public void verifyForResetPassword(VerificationRequest verificationRequest) {

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -46,6 +46,6 @@ public class MemberService {
     public void verifyForResetPassword(VerificationRequest verificationRequest) {
     }
 
-    public void resetPassword(PasswordRequest passwordRequest) {
+    public void resetPassword(PasswordResetRequest passwordResetRequest) {
     }
 }

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -33,7 +33,7 @@ public class MemberService {
     public void withdraw(Long memberId, PasswordRequest passwordRequest) {
     }
 
-    public void createVerificationCodeForSearchUsername(UsernameSearchRequest usernameSearchRequest) {
+    public void createVerificationCodeForSearchUsername(UsernameSearchVerificationCodeRequest usernameSearchVerificationCodeRequest) {
     }
 
     public UsernameResponse verifyForSearchUsername(VerificationRequest verificationRequest) {

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -458,11 +458,11 @@ public class MemberControllerTest extends ApiDocument {
     @Test
     void 비밀번호_재설정_성공() throws Exception {
         // given
-        willDoNothing().given(memberService).resetPassword(any(PasswordResetVerificationCodeRequest.class));
+        willDoNothing().given(memberService).resetPassword(any(PasswordRequest.class));
         // when
-        ResultActions resultActions = 비밀번호_재설정_인증_요청();
+        ResultActions resultActions = 비밀번호_재설정_요청();
         // then
-        비밀번호_재설정_인증_요청_성공(resultActions);
+        비밀번호_재설정_요청_성공(resultActions);
     }
 
     private ResultActions 회원_가입_요청() throws Exception {
@@ -737,5 +737,18 @@ public class MemberControllerTest extends ApiDocument {
                         .andExpect(status().isBadRequest())
                         .andExpect(content().json(toJson(ErrorResponse.from(verificationCodeNotEqualException)))),
                 "reset-password-verify-fail");
+    }
+
+    private ResultActions 비밀번호_재설정_요청() throws Exception {
+        return mockMvc.perform(patch(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/password/reset")
+                .contextPath(CONTEXT_PATH)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(toJson(passwordRequest)));
+    }
+
+    private void 비밀번호_재설정_요청_성공(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isOk()),
+                "reset-password-success");
     }
 }

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -480,6 +480,16 @@ public class MemberControllerTest extends ApiDocument {
         비밀번호_재설정_요청_회원정보찾기_실패(resultActions);
     }
 
+    @Test
+    void 비밀번호_재설정_비밀번호양식불일치_실패() throws Exception {
+        // given
+        willThrow(wrongFormException).given(memberService).resetPassword(any(PasswordResetRequest.class));
+        // when
+        ResultActions resultActions = 비밀번호_재설정_요청();
+        // then
+        비밀번호_재설정_요청_비밀번호양식불일치_실패(resultActions);
+    }
+
     private ResultActions 회원_가입_요청() throws Exception {
         return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH)
                 .contextPath(CONTEXT_PATH)
@@ -772,5 +782,12 @@ public class MemberControllerTest extends ApiDocument {
                         .andExpect(status().isBadRequest())
                         .andExpect(content().json(toJson(ErrorResponse.from(memberNotFoundException)))),
                 "reset-password-not-found-member-fail");
+    }
+
+    private void 비밀번호_재설정_요청_비밀번호양식불일치_실패(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isBadRequest())
+                        .andExpect(content().json(toJson(ErrorResponse.from(wrongFormException)))),
+                "reset-password-wrong-form-fail");
     }
 }

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -61,7 +61,7 @@ public class MemberControllerTest extends ApiDocument {
     private MemberProfileUpdateRequest memberProfileUpdateRequest;
     private PasswordUpdateRequest passwordUpdateRequest;
     private PasswordRequest passwordRequest;
-    private UsernameSearchRequest usernameSearchRequest;
+    private UsernameSearchVerificationCodeRequest usernameSearchVerificationCodeRequest;
     private VerificationRequest verificationRequest;
     private PasswordResetRequest passwordResetRequest;
     private MemberResponse memberResponse;
@@ -122,7 +122,7 @@ public class MemberControllerTest extends ApiDocument {
         passwordRequest = PasswordRequest.builder()
                 .password(PASSWORD)
                 .build();
-        usernameSearchRequest = UsernameSearchRequest.builder()
+        usernameSearchVerificationCodeRequest = UsernameSearchVerificationCodeRequest.builder()
                 .username(USERNAME)
                 .phone(PHONE)
                 .build();
@@ -378,7 +378,7 @@ public class MemberControllerTest extends ApiDocument {
     @Test
     void 아이디_찾기_인증번호_발급_성공() throws Exception {
         // given
-        willDoNothing().given(memberService).createVerificationCodeForSearchUsername(any(UsernameSearchRequest.class));
+        willDoNothing().given(memberService).createVerificationCodeForSearchUsername(any(UsernameSearchVerificationCodeRequest.class));
         // when
         ResultActions resultActions = 아이디_찾기_인증번호_발급_요청();
         // then
@@ -388,7 +388,7 @@ public class MemberControllerTest extends ApiDocument {
     @Test
     void 아이디_찾기_실패() throws Exception {
         // given
-        willThrow(memberNotFoundException).given(memberService).createVerificationCodeForSearchUsername(any(UsernameSearchRequest.class));
+        willThrow(memberNotFoundException).given(memberService).createVerificationCodeForSearchUsername(any(UsernameSearchVerificationCodeRequest.class));
         // when
         ResultActions resultActions = 아이디_찾기_인증번호_발급_요청();
         // then
@@ -453,6 +453,16 @@ public class MemberControllerTest extends ApiDocument {
         ResultActions resultActions = 비밀번호_재설정_인증_요청();
         // then
         비밀번호_재설정_인증_요청_실패(resultActions);
+    }
+
+    @Test
+    void 비밀번호_재설정_성공() throws Exception {
+        // given
+        willDoNothing().given(memberService).resetPassword(any(PasswordResetRequest.class));
+        // when
+        ResultActions resultActions = 비밀번호_재설정_인증_요청();
+        // then
+        비밀번호_재설정_인증_요청_성공(resultActions);
     }
 
     private ResultActions 회원_가입_요청() throws Exception {
@@ -652,7 +662,7 @@ public class MemberControllerTest extends ApiDocument {
         return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/search/username/code")
                 .contextPath(CONTEXT_PATH)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(toJson(usernameSearchRequest)));
+                .content(toJson(usernameSearchVerificationCodeRequest)));
     }
 
     private void 아이디_찾기_인증번호_발급_요청_성공(ResultActions resultActions) throws Exception {

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -659,7 +659,7 @@ public class MemberControllerTest extends ApiDocument {
     }
 
     private ResultActions 아이디_찾기_인증번호_발급_요청() throws Exception {
-        return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/search/username/code")
+        return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/username/search/code")
                 .contextPath(CONTEXT_PATH)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(toJson(usernameSearchVerificationCodeRequest)));
@@ -679,7 +679,7 @@ public class MemberControllerTest extends ApiDocument {
     }
 
     private ResultActions 아이디_찾기_인증_요청() throws Exception {
-        return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/search/username/verification")
+        return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/username/search/verification")
                 .contextPath(CONTEXT_PATH)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(toJson(verificationRequest)));

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -700,7 +700,7 @@ public class MemberControllerTest extends ApiDocument {
     }
 
     private ResultActions 비밀번호_재설정_인증번호_발급_요청() throws Exception {
-        return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/reset/password/code")
+        return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/password/reset/code")
                 .contextPath(CONTEXT_PATH)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(toJson(passwordResetVerificationCodeRequest)));
@@ -720,7 +720,7 @@ public class MemberControllerTest extends ApiDocument {
     }
 
     private ResultActions 비밀번호_재설정_인증_요청() throws Exception {
-        return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/reset/password/verification")
+        return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/password/reset/verification")
                 .contextPath(CONTEXT_PATH)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(toJson(verificationRequest)));

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -60,7 +60,7 @@ public class MemberControllerTest extends ApiDocument {
     private NicknameUpdateRequest nicknameUpdateRequest;
     private MemberProfileUpdateRequest memberProfileUpdateRequest;
     private PasswordUpdateRequest passwordUpdateRequest;
-    private PasswordRequest passwordRequest;
+    private WithdrawRequest withdrawRequest;
     private UsernameSearchVerificationCodeRequest usernameSearchVerificationCodeRequest;
     private VerificationRequest verificationRequest;
     private PasswordResetVerificationCodeRequest passwordResetVerificationCodeRequest;
@@ -119,7 +119,7 @@ public class MemberControllerTest extends ApiDocument {
                 .password(PASSWORD)
                 .newPassword(NEW_PASSWORD)
                 .build();
-        passwordRequest = PasswordRequest.builder()
+        withdrawRequest = WithdrawRequest.builder()
                 .password(PASSWORD)
                 .build();
         usernameSearchVerificationCodeRequest = UsernameSearchVerificationCodeRequest.builder()
@@ -348,7 +348,7 @@ public class MemberControllerTest extends ApiDocument {
     @Test
     void 회원_탈퇴_성공() throws Exception {
         // given
-        willDoNothing().given(memberService).withdraw(anyLong(), any(PasswordRequest.class));
+        willDoNothing().given(memberService).withdraw(anyLong(), any(WithdrawRequest.class));
         // when
         ResultActions resultActions = 회원_탈퇴_요청();
         // then
@@ -358,7 +358,7 @@ public class MemberControllerTest extends ApiDocument {
     @Test
     void 회원_탈퇴_회원정보찾기_실패() throws Exception {
         // given
-        willThrow(memberNotFoundException).given(memberService).withdraw(anyLong(), any(PasswordRequest.class));
+        willThrow(memberNotFoundException).given(memberService).withdraw(anyLong(), any(WithdrawRequest.class));
         // when
         ResultActions resultActions = 회원_탈퇴_요청();
         // then
@@ -368,7 +368,7 @@ public class MemberControllerTest extends ApiDocument {
     @Test
     void 회원_탈퇴_비밀번호불일치_실패() throws Exception {
         // given
-        willThrow(passwordNotEqualException).given(memberService).withdraw(anyLong(), any(PasswordRequest.class));
+        willThrow(passwordNotEqualException).given(memberService).withdraw(anyLong(), any(WithdrawRequest.class));
         // when
         ResultActions resultActions = 회원_탈퇴_요청();
         // then

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -63,7 +63,7 @@ public class MemberControllerTest extends ApiDocument {
     private PasswordRequest passwordRequest;
     private UsernameSearchVerificationCodeRequest usernameSearchVerificationCodeRequest;
     private VerificationRequest verificationRequest;
-    private PasswordResetRequest passwordResetRequest;
+    private PasswordResetVerificationCodeRequest passwordResetVerificationCodeRequest;
     private MemberResponse memberResponse;
     private MemberProfileResponse memberProfileResponse;
     private UsernameResponse usernameResponse;
@@ -129,7 +129,7 @@ public class MemberControllerTest extends ApiDocument {
         verificationRequest = VerificationRequest.builder()
                 .verificationCode(VERIFICATION_CODE)
                 .build();
-        passwordResetRequest = PasswordResetRequest.builder()
+        passwordResetVerificationCodeRequest = PasswordResetVerificationCodeRequest.builder()
                 .username(USERNAME)
                 .name(NAME)
                 .phone(PHONE)
@@ -418,7 +418,7 @@ public class MemberControllerTest extends ApiDocument {
     @Test
     void 비밀번호_재설정_인증번호_발급_성공() throws Exception {
         // given
-        willDoNothing().given(memberService).createVerificationCodeForResetPassword(any(PasswordResetRequest.class));
+        willDoNothing().given(memberService).createVerificationCodeForResetPassword(any(PasswordResetVerificationCodeRequest.class));
         // when
         ResultActions resultActions = 비밀번호_재설정_인증번호_발급_요청();
         // then
@@ -428,7 +428,7 @@ public class MemberControllerTest extends ApiDocument {
     @Test
     void 비밀번호_재설정_인증번호_발급_실패() throws Exception {
         // given
-        willThrow(memberNotFoundException).given(memberService).createVerificationCodeForResetPassword(any(PasswordResetRequest.class));
+        willThrow(memberNotFoundException).given(memberService).createVerificationCodeForResetPassword(any(PasswordResetVerificationCodeRequest.class));
         // when
         ResultActions resultActions = 비밀번호_재설정_인증번호_발급_요청();
         // then
@@ -458,7 +458,7 @@ public class MemberControllerTest extends ApiDocument {
     @Test
     void 비밀번호_재설정_성공() throws Exception {
         // given
-        willDoNothing().given(memberService).resetPassword(any(PasswordResetRequest.class));
+        willDoNothing().given(memberService).resetPassword(any(PasswordResetVerificationCodeRequest.class));
         // when
         ResultActions resultActions = 비밀번호_재설정_인증_요청();
         // then
@@ -703,7 +703,7 @@ public class MemberControllerTest extends ApiDocument {
         return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/reset/password/code")
                 .contextPath(CONTEXT_PATH)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(toJson(passwordResetRequest)));
+                .content(toJson(passwordResetVerificationCodeRequest)));
     }
 
     private void 비밀번호_재설정_인증번호_발급_요청_성공(ResultActions resultActions) throws Exception {

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -470,6 +470,16 @@ public class MemberControllerTest extends ApiDocument {
         비밀번호_재설정_요청_성공(resultActions);
     }
 
+    @Test
+    void 비밀번호_재설정_회원정보찾기_실패() throws Exception {
+        // given
+        willThrow(memberNotFoundException).given(memberService).resetPassword(any(PasswordResetRequest.class));
+        // when
+        ResultActions resultActions = 비밀번호_재설정_요청();
+        // then
+        비밀번호_재설정_요청_회원정보찾기_실패(resultActions);
+    }
+
     private ResultActions 회원_가입_요청() throws Exception {
         return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH)
                 .contextPath(CONTEXT_PATH)
@@ -754,6 +764,13 @@ public class MemberControllerTest extends ApiDocument {
     private void 비밀번호_재설정_요청_성공(ResultActions resultActions) throws Exception {
         printAndMakeSnippet(resultActions
                         .andExpect(status().isOk()),
-                "reset-password-success");
+                "reset-password-fail");
+    }
+
+    private void 비밀번호_재설정_요청_회원정보찾기_실패(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isBadRequest())
+                        .andExpect(content().json(toJson(ErrorResponse.from(memberNotFoundException)))),
+                "reset-password-not-found-member-fail");
     }
 }

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -164,9 +164,9 @@ public class MemberControllerTest extends ApiDocument {
         invalidFormatException = new BadRequestException(ApplicationError.INVALID_FORMAT);
         memberNotFoundException = new NotFoundException(ApplicationError.MEMBER_NOT_FOUND);
         passwordNotEqualException = new NotEqualException(ApplicationError.NOT_EQUAL_ID_OR_PASSWORD);
-        wrongFormException = new WrongFromException(ApplicationError.INVALID_FORMAT);
-        wrongFileExtensionException = new WrongFromException(ApplicationError.INVALID_FILE_EXTENSION);
-        wrongFileSizeException = new WrongFromException(ApplicationError.INVALID_FILE_SIZE);
+        wrongFormException = new WrongFormException(ApplicationError.INVALID_FORMAT);
+        wrongFileExtensionException = new WrongFormException(ApplicationError.INVALID_FILE_EXTENSION);
+        wrongFileSizeException = new WrongFormException(ApplicationError.INVALID_FILE_SIZE);
         verificationCodeNotEqualException = new NotEqualException(ApplicationError.VERIFICATION_CODE_NOT_EQUAL);
     }
 

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -281,13 +281,13 @@ public class MemberControllerTest extends ApiDocument {
     }
 
     @Test
-    void 회원_비밀번호_수정_회원정보찾기_실패() throws Exception {
+    void 회원_비밀번호_수정_회원정보없음_실패() throws Exception {
         // given
         willThrow(memberNotFoundException).given(memberService).updatePassword(any(PasswordUpdateRequest.class));
         // when
         ResultActions resultActions = 회원_비밀번호_수정_요청();
         // then
-        회원_비밀번호_수정_요청_회원정보찾기_실패(resultActions);
+        회원_비밀번호_수정_요청_회원정보없음_실패(resultActions);
     }
 
     @Test
@@ -321,13 +321,13 @@ public class MemberControllerTest extends ApiDocument {
     }
 
     @Test
-    void 회원_이미지_수정_회원정보찾기_실패() throws Exception {
+    void 회원_이미지_수정_회원정보없음_실패() throws Exception {
         // given
         willThrow(memberNotFoundException).given(memberService).updateImage(any(MultipartFile.class));
         // when
         ResultActions resultActions = 회원_이미지_수정_요청();
         // then
-        회원_이미지_수정_요청_회원정보찾기_실패(resultActions);
+        회원_이미지_수정_요청_회원정보없음_실패(resultActions);
     }
 
     @Test
@@ -361,13 +361,13 @@ public class MemberControllerTest extends ApiDocument {
     }
 
     @Test
-    void 회원_탈퇴_회원정보찾기_실패() throws Exception {
+    void 회원_탈퇴_회원정보없음_실패() throws Exception {
         // given
         willThrow(memberNotFoundException).given(memberService).withdraw(anyLong(), any(WithdrawRequest.class));
         // when
         ResultActions resultActions = 회원_탈퇴_요청();
         // then
-        회원_탈퇴_요청_회원정보찾기_실패(resultActions);
+        회원_탈퇴_요청_회원정보없음_실패(resultActions);
     }
 
     @Test
@@ -471,13 +471,13 @@ public class MemberControllerTest extends ApiDocument {
     }
 
     @Test
-    void 비밀번호_재설정_회원정보찾기_실패() throws Exception {
+    void 비밀번호_재설정_회원정보없음_실패() throws Exception {
         // given
         willThrow(memberNotFoundException).given(memberService).resetPassword(any(PasswordResetRequest.class));
         // when
         ResultActions resultActions = 비밀번호_재설정_요청();
         // then
-        비밀번호_재설정_요청_회원정보찾기_실패(resultActions);
+        비밀번호_재설정_요청_회원정보없음_실패(resultActions);
     }
 
     @Test
@@ -601,7 +601,7 @@ public class MemberControllerTest extends ApiDocument {
                 "update-member-password-success");
     }
 
-    private void 회원_비밀번호_수정_요청_회원정보찾기_실패(ResultActions resultActions) throws Exception {
+    private void 회원_비밀번호_수정_요청_회원정보없음_실패(ResultActions resultActions) throws Exception {
         printAndMakeSnippet(resultActions
                         .andExpect(status().isBadRequest())
                         .andExpect(content().json(toJson(ErrorResponse.from(memberNotFoundException)))),
@@ -635,7 +635,7 @@ public class MemberControllerTest extends ApiDocument {
                 "update-member-image-success");
     }
 
-    private void 회원_이미지_수정_요청_회원정보찾기_실패(ResultActions resultActions) throws Exception {
+    private void 회원_이미지_수정_요청_회원정보없음_실패(ResultActions resultActions) throws Exception {
         printAndMakeSnippet(resultActions
                         .andExpect(status().isBadRequest())
                         .andExpect(content().json(toJson(ErrorResponse.from(memberNotFoundException)))),
@@ -669,7 +669,7 @@ public class MemberControllerTest extends ApiDocument {
                 "delete-member-success");
     }
 
-    private void 회원_탈퇴_요청_회원정보찾기_실패(ResultActions resultActions) throws Exception {
+    private void 회원_탈퇴_요청_회원정보없음_실패(ResultActions resultActions) throws Exception {
         printAndMakeSnippet(resultActions
                         .andExpect(status().isBadRequest())
                         .andExpect(content().json(toJson(ErrorResponse.from(memberNotFoundException)))),
@@ -777,7 +777,7 @@ public class MemberControllerTest extends ApiDocument {
                 "reset-password-fail");
     }
 
-    private void 비밀번호_재설정_요청_회원정보찾기_실패(ResultActions resultActions) throws Exception {
+    private void 비밀번호_재설정_요청_회원정보없음_실패(ResultActions resultActions) throws Exception {
         printAndMakeSnippet(resultActions
                         .andExpect(status().isBadRequest())
                         .andExpect(content().json(toJson(ErrorResponse.from(memberNotFoundException)))),

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -64,6 +64,7 @@ public class MemberControllerTest extends ApiDocument {
     private UsernameSearchVerificationCodeRequest usernameSearchVerificationCodeRequest;
     private VerificationRequest verificationRequest;
     private PasswordResetVerificationCodeRequest passwordResetVerificationCodeRequest;
+    private PasswordResetRequest passwordResetRequest;
     private MemberResponse memberResponse;
     private MemberProfileResponse memberProfileResponse;
     private UsernameResponse usernameResponse;
@@ -133,6 +134,10 @@ public class MemberControllerTest extends ApiDocument {
                 .username(USERNAME)
                 .name(NAME)
                 .phone(PHONE)
+                .build();
+        passwordResetRequest = PasswordResetRequest.builder()
+                .username(USERNAME)
+                .password(PASSWORD)
                 .build();
         memberResponse = MemberResponse.builder()
                 .nickname(NICKNAME)
@@ -458,7 +463,7 @@ public class MemberControllerTest extends ApiDocument {
     @Test
     void 비밀번호_재설정_성공() throws Exception {
         // given
-        willDoNothing().given(memberService).resetPassword(any(PasswordRequest.class));
+        willDoNothing().given(memberService).resetPassword(any(PasswordResetRequest.class));
         // when
         ResultActions resultActions = 비밀번호_재설정_요청();
         // then
@@ -635,7 +640,7 @@ public class MemberControllerTest extends ApiDocument {
         return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/withdraw")
                 .contextPath(CONTEXT_PATH)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(toJson(passwordRequest)));
+                .content(toJson(withdrawRequest)));
     }
 
     private void 회원_탈퇴_요청_성공(ResultActions resultActions) throws Exception {
@@ -743,7 +748,7 @@ public class MemberControllerTest extends ApiDocument {
         return mockMvc.perform(patch(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/password/reset")
                 .contextPath(CONTEXT_PATH)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(toJson(passwordRequest)));
+                .content(toJson(passwordResetRequest)));
     }
 
     private void 비밀번호_재설정_요청_성공(ResultActions resultActions) throws Exception {


### PR DESCRIPTION
## Issue

closed #40 
[SP-35](https://soma-cupid.atlassian.net/browse/SP-35?atlOrigin=eyJpIjoiMTZiYmYyMjViM2UwNDYxOTljMDZjMTZhZTEwMmI3YmIiLCJwIjoiaiJ9)

## 요구사항

- [x] 비밀번호 재설정 성공 API 명세서 작성
- [x] 비밀번호 재설정 실패 API 명세서 작성

## 변경사항

- 비밀번호 재설정 로직을 `MemberController` 및 `MemberService`에 추가
- 비밀번호 재설정 요청 DTO `PasswordResetRequest` 추가
- `index.adoc` 비밀번호 재설정 추가
- 아이디 찾기 관련 uri `/search/username/../`-> `/username/search/..` 수정
- 비밀번호 재설정 관련 uri `/reset/password/../`-> `/password/reset/..` 수정
- 회원 탈퇴 요청 DTO 네이밍 `PasswordRequest` -> `WithdrawRequest` 수정
- `MemberControllerTest` 회원정보 찾을 수 없음 실패 관련 메소드 네이밍 수정

## 리뷰 우선순위

🙂 보통

## 코멘트

비밀번호 재설정 실패에 대한 케이스를 아래 세 가지로 나누어 작성했습니다.

1. 비밀번호를 재설정하려는 사용자를 찾을 수 없음
2. 새 비밀번호가 비밀번호 양식에 맞지 않음

[SP-35]: https://soma-cupid.atlassian.net/browse/SP-35?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ