### PR TITLE
[SP-122] 팀 상세 조회(호감 페이지) API 명세서 추가

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -347,7 +347,7 @@ include::{snippets}/accept-like-fail/http-response.adoc[]
 
 ==== 팀 상세 조회
 ----
-/api/v1/likes/{likeId}/detail
+/api/v1/likes/{likeId}
 ----
 ===== 성공
 .request

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -327,6 +327,7 @@ include::{snippets}/get-sent-likes-fail/http-request.adoc[]
 
 .response
 include::{snippets}/get-sent-likes-fail/http-response.adoc[]
+
 ==== 받은 호감 수락
 ----
 /api/v1/likes/{likeId}/accept
@@ -343,6 +344,7 @@ include::{snippets}/accept-like-fail/http-request.adoc[]
 
 .response
 include::{snippets}/accept-like-fail/http-response.adoc[]
+
 ==== 팀 상세 조회
 ----
 /api/v1/likes/{likeId}/detail

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -343,3 +343,19 @@ include::{snippets}/accept-like-fail/http-request.adoc[]
 
 .response
 include::{snippets}/accept-like-fail/http-response.adoc[]
+==== 팀 상세 조회
+----
+/api/v1/likes/{likeId}/detail
+----
+===== 성공
+.request
+include::{snippets}/get-team-detail-success/http-request.adoc[]
+
+.response
+include::{snippets}/get-team-detail-success/http-response.adoc[]
+===== 실패
+.request
+include::{snippets}/get-team-detail-fail/http-request.adoc[]
+
+.response
+include::{snippets}/get-team-detail-fail/http-response.adoc[]

--- a/src/main/java/com/cupid/jikting/like/controller/LikeController.java
+++ b/src/main/java/com/cupid/jikting/like/controller/LikeController.java
@@ -1,6 +1,7 @@
 package com.cupid.jikting.like.controller;
 
 import com.cupid.jikting.like.dto.LikeResponse;
+import com.cupid.jikting.like.dto.TeamDetailResponse;
 import com.cupid.jikting.like.service.LikeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -29,5 +30,10 @@ public class LikeController {
     public ResponseEntity<Void> acceptLike(@PathVariable Long likeId) {
         likeService.acceptLike(likeId);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/{likeId}/detail")
+    public ResponseEntity<TeamDetailResponse> getTeamDetail(@PathVariable Long likeId) {
+        return ResponseEntity.ok().body(likeService.getTeamDetail(likeId));
     }
 }

--- a/src/main/java/com/cupid/jikting/like/controller/LikeController.java
+++ b/src/main/java/com/cupid/jikting/like/controller/LikeController.java
@@ -32,7 +32,7 @@ public class LikeController {
         return ResponseEntity.ok().build();
     }
 
-    @GetMapping("/{likeId}/detail")
+    @GetMapping("/{likeId}")
     public ResponseEntity<TeamDetailResponse> getTeamDetail(@PathVariable Long likeId) {
         return ResponseEntity.ok().body(likeService.getTeamDetail(likeId));
     }

--- a/src/main/java/com/cupid/jikting/like/dto/MemberProfileResponse.java
+++ b/src/main/java/com/cupid/jikting/like/dto/MemberProfileResponse.java
@@ -8,7 +8,7 @@ import java.util.List;
 @Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class MemberResponse {
+public class MemberProfileResponse {
 
     private String nickname;
     private String image;

--- a/src/main/java/com/cupid/jikting/like/dto/MemberResponse.java
+++ b/src/main/java/com/cupid/jikting/like/dto/MemberResponse.java
@@ -1,0 +1,25 @@
+package com.cupid.jikting.like.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberResponse {
+
+    private String nickname;
+    private String image;
+    private int age;
+    private String mbti;
+    private String address;
+    private String company;
+    private boolean isSmoke;
+    private String drinkStatus;
+    private int height;
+    private String description;
+    private List<String> keywords;
+    private String college;
+}

--- a/src/main/java/com/cupid/jikting/like/dto/TeamDetailResponse.java
+++ b/src/main/java/com/cupid/jikting/like/dto/TeamDetailResponse.java
@@ -1,0 +1,17 @@
+package com.cupid.jikting.like.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TeamDetailResponse {
+
+    private Long likeId;
+    private String teamName;
+    private List<String> keywords;
+    private List<MemberResponse> members;
+}

--- a/src/main/java/com/cupid/jikting/like/dto/TeamDetailResponse.java
+++ b/src/main/java/com/cupid/jikting/like/dto/TeamDetailResponse.java
@@ -13,5 +13,5 @@ public class TeamDetailResponse {
     private Long likeId;
     private String teamName;
     private List<String> keywords;
-    private List<MemberResponse> members;
+    private List<MemberProfileResponse> members;
 }

--- a/src/main/java/com/cupid/jikting/like/service/LikeService.java
+++ b/src/main/java/com/cupid/jikting/like/service/LikeService.java
@@ -1,6 +1,7 @@
 package com.cupid.jikting.like.service;
 
 import com.cupid.jikting.like.dto.LikeResponse;
+import com.cupid.jikting.like.dto.TeamDetailResponse;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -17,5 +18,9 @@ public class LikeService {
     }
 
     public void acceptLike(Long likeId) {
+    }
+
+    public TeamDetailResponse getTeamDetail(Long likeId) {
+        return null;
     }
 }

--- a/src/test/java/com/cupid/jikting/like/controller/LikeControllerTest.java
+++ b/src/test/java/com/cupid/jikting/like/controller/LikeControllerTest.java
@@ -6,7 +6,9 @@ import com.cupid.jikting.common.error.ApplicationError;
 import com.cupid.jikting.common.error.ApplicationException;
 import com.cupid.jikting.common.error.NotFoundException;
 import com.cupid.jikting.like.dto.LikeResponse;
+import com.cupid.jikting.like.dto.TeamDetailResponse;
 import com.cupid.jikting.like.service.LikeService;
+import com.cupid.jikting.like.dto.MemberResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -30,13 +32,24 @@ public class LikeControllerTest extends ApiDocument {
     private static final String CONTEXT_PATH = "/api/v1";
     private static final String DOMAIN_ROOT_PATH = "/likes";
     private static final String PATH_DELIMITER = "/";
-    private static final String KEYWORD = "키워드";
     private static final String URL = "http://test-url";
     private static final String NAME = "팀명";
     private static final Long ID = 1L;
+    private static final String NICKNAME = "닉네임";
+    private static final int AGE = 20;
+    private final String MBTI = "mbti";
+    private final String ADDRESS = "거주지";
+    private static final String COMPANY = "회사";
+    private final boolean IS_SMOKE = true;
+    private static final String DRINK_STATUS = "안마심";
+    private static final int HEIGHT = 180;
+    private static final String DESCRIPTION = "소개";
+    private static final String KEYWORD = "키워드";
+    private final String COLLEGE = "대학";
 
     private List<LikeResponse> likeResponses;
     private ApplicationException teamNotFoundException;
+    private TeamDetailResponse teamDetailResponse;
 
     @MockBean
     private LikeService likeService;
@@ -49,6 +62,22 @@ public class LikeControllerTest extends ApiDocument {
         List<String> imageUrls = IntStream.rangeClosed(1, 3)
                 .mapToObj(n -> URL + n)
                 .collect(Collectors.toList());
+        List<MemberResponse> memberResponses = IntStream.rangeClosed(1, 2)
+                .mapToObj(n -> MemberResponse.builder()
+                        .nickname(NICKNAME)
+                        .image(URL)
+                        .age(AGE)
+                        .mbti(MBTI)
+                        .address(ADDRESS)
+                        .company(COMPANY)
+                        .isSmoke(IS_SMOKE)
+                        .drinkStatus(DRINK_STATUS)
+                        .height(HEIGHT)
+                        .description(DESCRIPTION)
+                        .keywords(keywords)
+                        .college(COLLEGE)
+                        .build())
+                .collect(Collectors.toList());
         LikeResponse likeResponse = LikeResponse.builder()
                 .likeId(ID)
                 .name(NAME)
@@ -58,6 +87,12 @@ public class LikeControllerTest extends ApiDocument {
         likeResponses = IntStream.rangeClosed(0, 2)
                 .mapToObj(n -> likeResponse)
                 .collect(Collectors.toList());
+        teamDetailResponse = TeamDetailResponse.builder()
+                .likeId(ID)
+                .teamName(NAME)
+                .keywords(keywords)
+                .members(memberResponses)
+                .build();
         teamNotFoundException = new NotFoundException(ApplicationError.TEAM_NOT_FOUND);
     }
 
@@ -121,6 +156,26 @@ public class LikeControllerTest extends ApiDocument {
         받은_호감_수락_요청_실패(resultActions);
     }
 
+    @Test
+    void 팀_상세_조회_성공() throws Exception {
+        //given
+        willReturn(teamDetailResponse).given(likeService).getTeamDetail(anyLong());
+        //when
+        ResultActions resultActions = 팀_상세_조회_요청();
+        //then
+        팀_상세_조회_요청_성공(resultActions);
+    }
+
+    @Test
+    void 팀_상세_조회_실패() throws Exception {
+        //given
+        willThrow(teamNotFoundException).given(likeService).getTeamDetail(anyLong());
+        //when
+        ResultActions resultActions = 팀_상세_조회_요청();
+        //then
+        팀_상세_조회_요청_실패(resultActions);
+    }
+
     private ResultActions 받은_호감_목록_조회_요청() throws Exception {
         ResultActions resultActions = mockMvc.perform(get(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/received")
                 .contextPath(CONTEXT_PATH));
@@ -178,5 +233,24 @@ public class LikeControllerTest extends ApiDocument {
                         .andExpect(status().isBadRequest())
                         .andExpect(content().json(toJson(ErrorResponse.from(teamNotFoundException)))),
                 "accept-like-fail");
+    }
+
+    private ResultActions 팀_상세_조회_요청() throws Exception {
+        return mockMvc.perform(get(CONTEXT_PATH + DOMAIN_ROOT_PATH + PATH_DELIMITER + ID + "/detail")
+                .contextPath(CONTEXT_PATH));
+    }
+
+    private void 팀_상세_조회_요청_성공(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isOk())
+                        .andExpect(content().json(toJson(teamDetailResponse))),
+                "get-team-detail-success");
+    }
+
+    private void 팀_상세_조회_요청_실패(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isBadRequest())
+                        .andExpect(content().json(toJson(ErrorResponse.from(teamNotFoundException)))),
+                "get-team-detail-fail");
     }
 }

--- a/src/test/java/com/cupid/jikting/like/controller/LikeControllerTest.java
+++ b/src/test/java/com/cupid/jikting/like/controller/LikeControllerTest.java
@@ -8,7 +8,7 @@ import com.cupid.jikting.common.error.NotFoundException;
 import com.cupid.jikting.like.dto.LikeResponse;
 import com.cupid.jikting.like.dto.TeamDetailResponse;
 import com.cupid.jikting.like.service.LikeService;
-import com.cupid.jikting.like.dto.MemberResponse;
+import com.cupid.jikting.like.dto.MemberProfileResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -37,19 +37,19 @@ public class LikeControllerTest extends ApiDocument {
     private static final Long ID = 1L;
     private static final String NICKNAME = "닉네임";
     private static final int AGE = 20;
-    private final String MBTI = "mbti";
-    private final String ADDRESS = "거주지";
+    private static final String MBTI = "mbti";
+    private static final String ADDRESS = "거주지";
     private static final String COMPANY = "회사";
-    private final boolean IS_SMOKE = true;
+    private static final boolean IS_SMOKE = true;
     private static final String DRINK_STATUS = "안마심";
     private static final int HEIGHT = 180;
     private static final String DESCRIPTION = "소개";
     private static final String KEYWORD = "키워드";
-    private final String COLLEGE = "대학";
+    private static final String COLLEGE = "대학";
 
     private List<LikeResponse> likeResponses;
-    private ApplicationException teamNotFoundException;
     private TeamDetailResponse teamDetailResponse;
+    private ApplicationException teamNotFoundException;
 
     @MockBean
     private LikeService likeService;
@@ -62,8 +62,8 @@ public class LikeControllerTest extends ApiDocument {
         List<String> imageUrls = IntStream.rangeClosed(1, 3)
                 .mapToObj(n -> URL + n)
                 .collect(Collectors.toList());
-        List<MemberResponse> memberResponses = IntStream.rangeClosed(1, 2)
-                .mapToObj(n -> MemberResponse.builder()
+        List<MemberProfileResponse> memberProfileRespons = IntStream.rangeClosed(1, 2)
+                .mapToObj(n -> MemberProfileResponse.builder()
                         .nickname(NICKNAME)
                         .image(URL)
                         .age(AGE)
@@ -91,7 +91,7 @@ public class LikeControllerTest extends ApiDocument {
                 .likeId(ID)
                 .teamName(NAME)
                 .keywords(keywords)
-                .members(memberResponses)
+                .members(memberProfileRespons)
                 .build();
         teamNotFoundException = new NotFoundException(ApplicationError.TEAM_NOT_FOUND);
     }
@@ -236,7 +236,7 @@ public class LikeControllerTest extends ApiDocument {
     }
 
     private ResultActions 팀_상세_조회_요청() throws Exception {
-        return mockMvc.perform(get(CONTEXT_PATH + DOMAIN_ROOT_PATH + PATH_DELIMITER + ID + "/detail")
+        return mockMvc.perform(get(CONTEXT_PATH + DOMAIN_ROOT_PATH + PATH_DELIMITER + ID)
                 .contextPath(CONTEXT_PATH));
     }
 

--- a/src/test/java/com/cupid/jikting/recommend/controller/RecommendControllerTest.java
+++ b/src/test/java/com/cupid/jikting/recommend/controller/RecommendControllerTest.java
@@ -32,15 +32,20 @@ public class RecommendControllerTest extends ApiDocument {
     private static final String CONTEXT_PATH = "/api/v1";
     private static final String DOMAIN_ROOT_PATH = "/recommends";
     private static final String PATH_DELIMITER = "/";
+    private static final String NICKNAME = "닉네임";
     private static final String HOBBY = "취미";
     private static final String PERSONALITY = "성격";
     private static final String URL = "http://test-url";
     private static final String COMPANY = "회사";
     private static final String DESCRIPTION = "소개";
     private static final String DRINK_STATUS = "안마심";
+    private static final String MBTI = "mbti";
+    private static final String ADDRESS = "거주지";
+    private static final String COLLEGE = "대학";
     private static final int AGE = 20;
     private static final int HEIGHT = 180;
     private static final Long ID = 1L;
+    private static final boolean IS_SMOKE = true;
     private static final boolean TRUE = true;
 
     private List<RecommendResponse> recommendResponses;
@@ -66,13 +71,18 @@ public class RecommendControllerTest extends ApiDocument {
                 .collect(Collectors.toList());
         List<MemberResponse> memberResponses = IntStream.rangeClosed(1, 2)
                 .mapToObj(n -> MemberResponse.builder()
+                        .nickname(NICKNAME)
                         .age(AGE)
+                        .mbti(MBTI)
+                        .address(ADDRESS)
                         .company(COMPANY)
-                        .description(DESCRIPTION)
+                        .isSmoke(IS_SMOKE)
                         .drinkStatus(DRINK_STATUS)
                         .height(HEIGHT)
+                        .description(DESCRIPTION)
                         .hobbies(hobbies)
                         .images(imageResponses)
+                        .college(COLLEGE)
                         .build())
                 .collect(Collectors.toList());
         RecommendResponse recommendResponse = RecommendResponse.builder()


### PR DESCRIPTION
## Issue

closed #43
[SP-122](https://soma-cupid.atlassian.net/browse/SP-122?atlOrigin=eyJpIjoiZTg4NWJiYjA2N2FjNDkyNmE3MjVkNTI0MTc2NDcxOTgiLCJwIjoiaiJ9)

## 요구사항

- [x] 팀 상세 조회 성공 API 명세서 작성
- [x] 팀 상세 조회 실패 API 명세서 작성

## 변경사항

- `LikeController`, `LikeService`에 팀 상세 조회 추가
- `LikeControllerTest`에 팀 상세 조회 테스트 추가
- `MemberResponse`, `TeamDetailResponse` 추가
- `RecommendControllerTest`에 MemberResponse 빠진 내용 추가

## 리뷰 우선순위

🙂 보통

[SP-122]: https://soma-cupid.atlassian.net/browse/SP-122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ