### PR TITLE
[SP-101] 아이디 중복 확인 API 명세서 작성

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -200,6 +200,12 @@ include::{snippets}/check-duplicated-username-success/http-request.adoc[]
 
 .response
 include::{snippets}/check-duplicated-username-success/http-response.adoc[]
+===== 실패
+.request
+include::{snippets}/check-duplicated-username-fail/http-request.adoc[]
+
+.response
+include::{snippets}/check-duplicated-username-fail/http-response.adoc[]
 
 ==== 아이디 찾기 인증번호 발급
 ----

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -190,6 +190,17 @@ include::{snippets}/delete-member-not-found-member-fail/http-response.adoc[]
 .response - 비밀번호 불일치
 include::{snippets}/delete-member-not-equal-password-fail/http-response.adoc[]
 
+==== 아이디 중복 검사
+----
+/api/v1/members/username/check
+----
+===== 성공
+.request
+include::{snippets}/check-duplicated-username-success/http-request.adoc[]
+
+.response
+include::{snippets}/check-duplicated-username-success/http-response.adoc[]
+
 ==== 아이디 찾기 인증번호 발급
 ----
 /api/v1/members/search/username/code

--- a/src/main/java/com/cupid/jikting/member/controller/MemberController.java
+++ b/src/main/java/com/cupid/jikting/member/controller/MemberController.java
@@ -60,6 +60,12 @@ public class MemberController {
         return ResponseEntity.ok().build();
     }
 
+    @PostMapping("/username/check")
+    public ResponseEntity<Void> checkDuplicatedUsername(@RequestBody UsernameCheckRequest usernameCheckRequest) {
+        memberService.checkDuplicatedUsername(usernameCheckRequest);
+        return ResponseEntity.ok().build();
+    }
+
     @PostMapping("/search/username/code")
     public ResponseEntity<Void> createVerificationCodeForSearchUsername(@RequestBody UsernameSearchRequest usernameSearchRequest) {
         memberService.createVerificationCodeForSearchUsername(usernameSearchRequest);

--- a/src/main/java/com/cupid/jikting/member/dto/UsernameCheckRequest.java
+++ b/src/main/java/com/cupid/jikting/member/dto/UsernameCheckRequest.java
@@ -1,0 +1,12 @@
+package com.cupid.jikting.member.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UsernameCheckRequest {
+
+    private String username;
+}

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -33,6 +33,9 @@ public class MemberService {
     public void withdraw(Long memberId, PasswordRequest passwordRequest) {
     }
 
+    public void checkDuplicatedUsername(UsernameCheckRequest usernameCheckRequest) {
+    }
+
     public void createVerificationCodeForSearchUsername(UsernameSearchRequest usernameSearchRequest) {
     }
 

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -75,6 +75,7 @@ public class MemberControllerTest extends ApiDocument {
     private ApplicationException wrongFileExtensionException;
     private ApplicationException wrongFileSizeException;
     private ApplicationException verificationCodeNotEqualException;
+    private ApplicationException duplicatedUsernameException;
 
     @MockBean
     private MemberService memberService;
@@ -167,6 +168,7 @@ public class MemberControllerTest extends ApiDocument {
         wrongFileExtensionException = new WrongFromException(ApplicationError.INVALID_FILE_EXTENSION);
         wrongFileSizeException = new WrongFromException(ApplicationError.INVALID_FILE_SIZE);
         verificationCodeNotEqualException = new NotEqualException(ApplicationError.VERIFICATION_CODE_NOT_EQUAL);
+        duplicatedUsernameException = new DuplicateException(ApplicationError.DUPLICATE_USERNAME);
     }
 
     @Test
@@ -387,6 +389,16 @@ public class MemberControllerTest extends ApiDocument {
         ResultActions resultActions = 아이디_중복_검사_요청();
         // then
         아이디_중복_검사_요청_성공(resultActions);
+    }
+
+    @Test
+    void 아이디_중복_검사_실패() throws Exception {
+        // given
+        willThrow(duplicatedUsernameException).given(memberService).checkDuplicatedUsername(any(UsernameCheckRequest.class));
+        // when
+        ResultActions resultActions = 아이디_중복_검사_요청();
+        // then
+        아이디_중복_검사_요청_실패(resultActions);
     }
 
     @Test
@@ -673,6 +685,13 @@ public class MemberControllerTest extends ApiDocument {
         printAndMakeSnippet(resultActions
                         .andExpect(status().isOk()),
                 "check-duplicated-username-success");
+    }
+
+    private void 아이디_중복_검사_요청_실패(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isBadRequest())
+                        .andExpect(content().json(toJson(ErrorResponse.from(duplicatedUsernameException)))),
+                "check-duplicated-username-fail");
     }
 
     private ResultActions 아이디_찾기_인증번호_발급_요청() throws Exception {

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -64,6 +64,7 @@ public class MemberControllerTest extends ApiDocument {
     private UsernameSearchRequest usernameSearchRequest;
     private VerificationRequest verificationRequest;
     private PasswordResetRequest passwordResetRequest;
+    private UsernameCheckRequest usernameCheckRequest;
     private MemberResponse memberResponse;
     private MemberProfileResponse memberProfileResponse;
     private UsernameResponse usernameResponse;
@@ -133,6 +134,9 @@ public class MemberControllerTest extends ApiDocument {
                 .username(USERNAME)
                 .name(NAME)
                 .phone(PHONE)
+                .build();
+        usernameCheckRequest = UsernameCheckRequest.builder()
+                .username(USERNAME)
                 .build();
         memberResponse = MemberResponse.builder()
                 .nickname(NICKNAME)
@@ -373,6 +377,16 @@ public class MemberControllerTest extends ApiDocument {
         ResultActions resultActions = 회원_탈퇴_요청();
         // then
         회원_탈퇴_요청_비밀번호불일치_실패(resultActions);
+    }
+
+    @Test
+    void 아이디_중복_검사_성공() throws Exception {
+        // given
+        willDoNothing().given(memberService).checkDuplicatedUsername(any(UsernameCheckRequest.class));
+        // when
+        ResultActions resultActions = 아이디_중복_검사_요청();
+        // then
+        아이디_중복_검사_요청_성공(resultActions);
     }
 
     @Test
@@ -646,6 +660,19 @@ public class MemberControllerTest extends ApiDocument {
                         .andExpect(status().isBadRequest())
                         .andExpect(content().json(toJson(ErrorResponse.from(passwordNotEqualException)))),
                 "delete-member-not-equal-password-fail");
+    }
+
+    private ResultActions 아이디_중복_검사_요청() throws Exception {
+        return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/username/check")
+                .contextPath(CONTEXT_PATH)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(toJson(usernameCheckRequest)));
+    }
+
+    private void 아이디_중복_검사_요청_성공(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isOk()),
+                "check-duplicated-username-success");
     }
 
     private ResultActions 아이디_찾기_인증번호_발급_요청() throws Exception {

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -386,7 +386,7 @@ public class MemberControllerTest extends ApiDocument {
     }
 
     @Test
-    void 아이디_찾기_실패() throws Exception {
+    void 아이디_찾기_인증번호_발급_실패() throws Exception {
         // given
         willThrow(memberNotFoundException).given(memberService).createVerificationCodeForSearchUsername(any(UsernameSearchRequest.class));
         // when

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -236,7 +236,7 @@ public class MemberControllerTest extends ApiDocument {
     }
 
     @Test
-    void 회원_닉네임수정_실패() throws Exception {
+    void 회원_닉네임수_수정_실패() throws Exception {
         // given
         willThrow(memberNotFoundException).given(memberService).update(any(NicknameUpdateRequest.class));
         // when


### PR DESCRIPTION
## Issue

closed #45 
[SP-101](https://soma-cupid.atlassian.net/browse/SP-101?atlOrigin=eyJpIjoiYjNiOGQwYzU3NTJjNDI0MmJkODRjNjk4M2I5NDZiOWIiLCJwIjoiaiJ9)

## 요구사항

- [x] 아이디 중복 확인 성공 API 명세서 작성
- [x] 아이디 중복 확인 실패 API 명세서 작성

## 변경사항

- 아이디 중복 확인 로직을 `MemberController` 및 `MemberService`에 추가
- 아이디 중복 확인 요청 DTO `UsernameCheckRequest` 추가
- `index.adoc` 아이디 중복 확인 추가
- `MemberControllerTest` 아이디 찾기 인증번호 발급 실패 테스트 메소드 네이밍 수정
- `MemberControllerTest` 닉네임 수정 실패 테스트 메소드 네이밍 수정

## 리뷰 우선순위

🙂 보통

[SP-101]: https://soma-cupid.atlassian.net/browse/SP-101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ