### PR TITLE
[SP-127] 번개팅 조회 API 추가

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -355,4 +355,3 @@ include::{snippets}/get-instant-meeting-success/http-request.adoc[]
 
 .response
 include::{snippets}/get-instant-meeting-success/http-response.adoc[]
-===== 실패

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -343,3 +343,16 @@ include::{snippets}/accept-like-fail/http-request.adoc[]
 
 .response
 include::{snippets}/accept-like-fail/http-response.adoc[]
+
+=== 번개팅 관련 기능
+==== 번개팅 목록 조회
+----
+/api/v1/instants
+----
+===== 성공
+.request
+include::{snippets}/get-instant-meeting-success/http-request.adoc[]
+
+.response
+include::{snippets}/get-instant-meeting-success/http-response.adoc[]
+===== 실패

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -347,7 +347,7 @@ include::{snippets}/accept-like-fail/http-response.adoc[]
 === 번개팅 관련 기능
 ==== 번개팅 목록 조회
 ----
-/api/v1/instants
+/api/v1/instant-meetings
 ----
 ===== 성공
 .request

--- a/src/main/java/com/cupid/jikting/common/error/ApplicationError.java
+++ b/src/main/java/com/cupid/jikting/common/error/ApplicationError.java
@@ -32,6 +32,7 @@ public enum ApplicationError {
     MEETING_NOT_FOUND(HttpStatus.BAD_REQUEST, "M001", "미팅을 찾을 수 없습니다."),
 
     INSTANT_MEETING_NOT_FOUND(HttpStatus.BAD_REQUEST, "I001", "번개팅을 찾을 수 없습니다."),
+    INSTANT_MEETING_ALREADY_FULL(HttpStatus.BAD_REQUEST, "I002", "이미 번개팅 모집이 완료되었습니다."),
 
     CHATTING_ROOM_NOT_FOUND(HttpStatus.BAD_REQUEST, "C001", "채팅방을 찾을 수 없습니다."),
 

--- a/src/main/java/com/cupid/jikting/instantmeeting/controller/InstantMeetingController.java
+++ b/src/main/java/com/cupid/jikting/instantmeeting/controller/InstantMeetingController.java
@@ -1,0 +1,24 @@
+package com.cupid.jikting.instantmeeting.controller;
+
+import com.cupid.jikting.instantmeeting.dto.InstantMeetingResponse;
+import com.cupid.jikting.instantmeeting.service.InstantMeetingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/instants")
+public class InstantMeetingController {
+
+    private final InstantMeetingService instantMeetingService;
+
+    @GetMapping
+    public ResponseEntity<List<InstantMeetingResponse>> getAll() {
+        return ResponseEntity.ok().body(instantMeetingService.getAll());
+    }
+}

--- a/src/main/java/com/cupid/jikting/instantmeeting/controller/InstantMeetingController.java
+++ b/src/main/java/com/cupid/jikting/instantmeeting/controller/InstantMeetingController.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/instants")
+@RequestMapping("/instant-meetings")
 public class InstantMeetingController {
 
     private final InstantMeetingService instantMeetingService;

--- a/src/main/java/com/cupid/jikting/instantmeeting/dto/InstantMeetingResponse.java
+++ b/src/main/java/com/cupid/jikting/instantmeeting/dto/InstantMeetingResponse.java
@@ -1,0 +1,17 @@
+package com.cupid.jikting.instantmeeting.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class InstantMeetingResponse {
+
+    private Long InstantMeetingId;
+    private LocalDateTime InstantMeetingDateTime;
+    private String location;
+    private int point;
+}

--- a/src/main/java/com/cupid/jikting/instantmeeting/dto/InstantMeetingResponse.java
+++ b/src/main/java/com/cupid/jikting/instantmeeting/dto/InstantMeetingResponse.java
@@ -10,8 +10,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class InstantMeetingResponse {
 
-    private Long InstantMeetingId;
-    private LocalDateTime InstantMeetingDateTime;
+    private Long instantMeetingId;
+    private LocalDateTime instantMeetingDateTime;
     private String location;
-    private int point;
 }

--- a/src/main/java/com/cupid/jikting/instantmeeting/service/InstantMeetingService.java
+++ b/src/main/java/com/cupid/jikting/instantmeeting/service/InstantMeetingService.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 @Service
 public class InstantMeetingService {
+
     public List<InstantMeetingResponse> getAll() {
         return null;
     }

--- a/src/main/java/com/cupid/jikting/instantmeeting/service/InstantMeetingService.java
+++ b/src/main/java/com/cupid/jikting/instantmeeting/service/InstantMeetingService.java
@@ -1,0 +1,13 @@
+package com.cupid.jikting.instantmeeting.service;
+
+import com.cupid.jikting.instantmeeting.dto.InstantMeetingResponse;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class InstantMeetingService {
+    public List<InstantMeetingResponse> getAll() {
+        return null;
+    }
+}

--- a/src/test/java/com/cupid/jikting/instantmeeting/controller/InstantMeetingControllerTest.java
+++ b/src/test/java/com/cupid/jikting/instantmeeting/controller/InstantMeetingControllerTest.java
@@ -24,7 +24,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class InstantMeetingControllerTest extends ApiDocument {
 
     private static final String CONTEXT_PATH = "/api/v1";
-    private static final String DOMAIN_ROOT_PATH = "/instants";
+    private static final String DOMAIN_ROOT_PATH = "/instant-meetings";
     private static final Long ID = 1L;
     private static final LocalDateTime LOCAL_DATE_TIME = LocalDateTime.of(2023, Month.JUNE, 30, 18, 0);
     private static final String LOCATION = "장소";

--- a/src/test/java/com/cupid/jikting/instantmeeting/controller/InstantMeetingControllerTest.java
+++ b/src/test/java/com/cupid/jikting/instantmeeting/controller/InstantMeetingControllerTest.java
@@ -1,0 +1,72 @@
+package com.cupid.jikting.instantmeeting.controller;
+
+import com.cupid.jikting.ApiDocument;
+import com.cupid.jikting.instantmeeting.dto.InstantMeetingResponse;
+import com.cupid.jikting.instantmeeting.service.InstantMeetingService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.mockito.BDDMockito.willReturn;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(InstantMeetingController.class)
+public class InstantMeetingControllerTest extends ApiDocument {
+
+    private static final String CONTEXT_PATH = "/api/v1";
+    private static final String DOMAIN_ROOT_PATH = "/instants";
+    private static final Long ID = 1L;
+    private static final LocalDateTime LOCAL_DATE_TIME = LocalDateTime.of(2023, Month.JUNE, 30, 18, 0);
+    private static final String LOCATION = "장소";
+    private static final int POINT = 10;
+
+    private List<InstantMeetingResponse> instantMeetingResponses;
+
+    @MockBean
+    private InstantMeetingService instantMeetingService;
+
+    @BeforeEach
+    void setUp() {
+        instantMeetingResponses = IntStream.rangeClosed(0, 3)
+                .mapToObj(n -> InstantMeetingResponse.builder()
+                        .InstantMeetingId(ID)
+                        .InstantMeetingDateTime(LOCAL_DATE_TIME)
+                        .location(LOCATION)
+                        .point(POINT)
+                        .build())
+                .collect(Collectors.toList());
+
+    }
+
+    @Test
+    void 번개팅_조회_성공() throws Exception {
+        //given
+        willReturn(instantMeetingResponses).given(instantMeetingService).getAll();
+        //when
+        ResultActions resultActions = 번개팅_조회_요청();
+        //then
+        번개팅_조회_요청_성공(resultActions);
+    }
+
+    private ResultActions 번개팅_조회_요청() throws Exception {
+        return mockMvc.perform(get(CONTEXT_PATH + DOMAIN_ROOT_PATH)
+                .contextPath(CONTEXT_PATH));
+    }
+
+    private void 번개팅_조회_요청_성공(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isOk())
+                        .andExpect(content().json(toJson(instantMeetingResponses))),
+                "get-instant-meeting-success");
+    }
+}

--- a/src/test/java/com/cupid/jikting/instantmeeting/controller/InstantMeetingControllerTest.java
+++ b/src/test/java/com/cupid/jikting/instantmeeting/controller/InstantMeetingControllerTest.java
@@ -28,7 +28,6 @@ public class InstantMeetingControllerTest extends ApiDocument {
     private static final Long ID = 1L;
     private static final LocalDateTime LOCAL_DATE_TIME = LocalDateTime.of(2023, Month.JUNE, 30, 18, 0);
     private static final String LOCATION = "장소";
-    private static final int POINT = 10;
 
     private List<InstantMeetingResponse> instantMeetingResponses;
 
@@ -42,7 +41,6 @@ public class InstantMeetingControllerTest extends ApiDocument {
                         .InstantMeetingId(ID)
                         .InstantMeetingDateTime(LOCAL_DATE_TIME)
                         .location(LOCATION)
-                        .point(POINT)
                         .build())
                 .collect(Collectors.toList());
 

--- a/src/test/java/com/cupid/jikting/instantmeeting/controller/InstantMeetingControllerTest.java
+++ b/src/test/java/com/cupid/jikting/instantmeeting/controller/InstantMeetingControllerTest.java
@@ -38,12 +38,11 @@ public class InstantMeetingControllerTest extends ApiDocument {
     void setUp() {
         instantMeetingResponses = IntStream.rangeClosed(0, 3)
                 .mapToObj(n -> InstantMeetingResponse.builder()
-                        .InstantMeetingId(ID)
-                        .InstantMeetingDateTime(LOCAL_DATE_TIME)
+                        .instantMeetingId(ID)
+                        .instantMeetingDateTime(LOCAL_DATE_TIME)
                         .location(LOCATION)
                         .build())
                 .collect(Collectors.toList());
-
     }
 
     @Test


### PR DESCRIPTION
## Issue

closed #48
[SP-127](https://soma-cupid.atlassian.net/browse/SP-127?atlOrigin=eyJpIjoiNmNmNzExZTIxMzc0NDAzYjlhOWVkMGE0NTY4YWQ1MWQiLCJwIjoiaiJ9)

## 요구사항

- [x] 번개팅 조회 성공 API 명세서 작성
- [ ] ~~번개팅 조회 실패 API 명세서 작성~~

## 변경사항

- `InstantMeetingController`, `InstantMeetingService`에 번개팅 조회 추가
- `InstantMeetingControllerTest`에 번개팅 조회 테스트 추가
- `InstantMeetingResponse` 추가

## 리뷰 우선순위

🙂 보통

## 코멘트

- 번개팅 디렉토리명을 "instantmeeting"으로 하고 api를 "/instants"라고 했는데 다른 의견 있으시면 코멘트 달아주세요
- 발생할 에러가 생각이 안나서 추가를 안했습니다. 생각이 나시면 코멘트 달아주세요!

[SP-127]: https://soma-cupid.atlassian.net/browse/SP-127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ