### PR TITLE
[SP-102] 닉네임 중복 확인 API 명세서 작성

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -217,6 +217,12 @@ include::{snippets}/check-duplicated-nickname-success/http-request.adoc[]
 
 .response
 include::{snippets}/check-duplicated-nickname-success/http-response.adoc[]
+===== 실패
+.request
+include::{snippets}/check-duplicated-nickname-fail/http-request.adoc[]
+
+.response
+include::{snippets}/check-duplicated-nickname-fail/http-response.adoc[]
 
 ==== 아이디 찾기 인증번호 발급
 ----

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -207,6 +207,17 @@ include::{snippets}/check-duplicated-username-fail/http-request.adoc[]
 .response
 include::{snippets}/check-duplicated-username-fail/http-response.adoc[]
 
+==== 닉네임 중복 검사
+----
+/api/v1/members/nickname/check
+----
+===== 성공
+.request
+include::{snippets}/check-duplicated-nickname-success/http-request.adoc[]
+
+.response
+include::{snippets}/check-duplicated-nickname-success/http-response.adoc[]
+
 ==== 아이디 찾기 인증번호 발급
 ----
 /api/v1/members/username/search/code

--- a/src/main/java/com/cupid/jikting/member/controller/MemberController.java
+++ b/src/main/java/com/cupid/jikting/member/controller/MemberController.java
@@ -66,6 +66,12 @@ public class MemberController {
         return ResponseEntity.ok().build();
     }
 
+    @PostMapping("/nickname/check")
+    public ResponseEntity<Void> checkDuplicatedNickname(@RequestBody NicknameCheckRequest nicknameCheckRequest) {
+        memberService.checkDuplicatedNickname(nicknameCheckRequest);
+        return ResponseEntity.ok().build();
+    }
+
     @PostMapping("/username/search/code")
     public ResponseEntity<Void> createVerificationCodeForSearchUsername(@RequestBody UsernameSearchVerificationCodeRequest usernameSearchVerificationCodeRequest) {
         memberService.createVerificationCodeForSearchUsername(usernameSearchVerificationCodeRequest);

--- a/src/main/java/com/cupid/jikting/member/dto/NicknameCheckRequest.java
+++ b/src/main/java/com/cupid/jikting/member/dto/NicknameCheckRequest.java
@@ -1,0 +1,12 @@
+package com.cupid.jikting.member.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NicknameCheckRequest {
+
+    private String nickname;
+}

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -51,4 +51,7 @@ public class MemberService {
 
     public void resetPassword(PasswordResetRequest passwordResetRequest) {
     }
+
+    public void checkDuplicatedNickname(NicknameCheckRequest nicknameCheckRequest) {
+    }
 }

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -61,6 +61,8 @@ public class MemberControllerTest extends ApiDocument {
     private MemberProfileUpdateRequest memberProfileUpdateRequest;
     private PasswordUpdateRequest passwordUpdateRequest;
     private WithdrawRequest withdrawRequest;
+    private UsernameCheckRequest usernameCheckRequest;
+    private NicknameCheckRequest nicknameCheckRequest;
     private UsernameSearchVerificationCodeRequest usernameSearchVerificationCodeRequest;
     private VerificationRequest verificationRequest;
     private PasswordResetVerificationCodeRequest passwordResetVerificationCodeRequest;
@@ -127,6 +129,9 @@ public class MemberControllerTest extends ApiDocument {
                 .build();
         usernameCheckRequest = UsernameCheckRequest.builder()
                 .username(USERNAME)
+                .build();
+        nicknameCheckRequest = NicknameCheckRequest.builder()
+                .nickname(NICKNAME)
                 .build();
         usernameSearchVerificationCodeRequest = UsernameSearchVerificationCodeRequest.builder()
                 .username(USERNAME)
@@ -404,6 +409,16 @@ public class MemberControllerTest extends ApiDocument {
         ResultActions resultActions = 아이디_중복_검사_요청();
         // then
         아이디_중복_검사_요청_실패(resultActions);
+    }
+
+    @Test
+    void 닉네임_중복_검사_성공() throws Exception {
+        // given
+        willDoNothing().given(memberService).checkDuplicatedNickname(any(NicknameCheckRequest.class));
+        // when
+        ResultActions resultActions = 닉네임_중복_검사_요청();
+        // then
+        닉네임_중복_검사_요청_성공(resultActions);
     }
 
     @Test

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -67,7 +67,6 @@ public class MemberControllerTest extends ApiDocument {
     private VerificationRequest verificationRequest;
     private PasswordResetVerificationCodeRequest passwordResetVerificationCodeRequest;
     private PasswordResetRequest passwordResetRequest;
-    private UsernameCheckRequest usernameCheckRequest;
     private MemberResponse memberResponse;
     private MemberProfileResponse memberProfileResponse;
     private UsernameResponse usernameResponse;
@@ -79,6 +78,7 @@ public class MemberControllerTest extends ApiDocument {
     private ApplicationException wrongFileSizeException;
     private ApplicationException verificationCodeNotEqualException;
     private ApplicationException duplicatedUsernameException;
+    private ApplicationException duplicatedNicknameException;
 
     @MockBean
     private MemberService memberService;
@@ -179,6 +179,7 @@ public class MemberControllerTest extends ApiDocument {
         wrongFileSizeException = new WrongFormException(ApplicationError.INVALID_FILE_SIZE);
         verificationCodeNotEqualException = new NotEqualException(ApplicationError.VERIFICATION_CODE_NOT_EQUAL);
         duplicatedUsernameException = new DuplicateException(ApplicationError.DUPLICATE_USERNAME);
+        duplicatedNicknameException = new DuplicateException(ApplicationError.DUPLICATE_NICKNAME);
     }
 
     @Test
@@ -419,6 +420,16 @@ public class MemberControllerTest extends ApiDocument {
         ResultActions resultActions = 닉네임_중복_검사_요청();
         // then
         닉네임_중복_검사_요청_성공(resultActions);
+    }
+
+    @Test
+    void 닉네임_중복_검사_실패() throws Exception {
+        // given
+        willThrow(duplicatedNicknameException).given(memberService).checkDuplicatedUsername(any(UsernameCheckRequest.class));
+        // when
+        ResultActions resultActions = 아이디_중복_검사_요청();
+        // then
+        닉네임_중복_검사_요청_실패(resultActions);
     }
 
     @Test
@@ -742,6 +753,26 @@ public class MemberControllerTest extends ApiDocument {
                         .andExpect(status().isBadRequest())
                         .andExpect(content().json(toJson(ErrorResponse.from(duplicatedUsernameException)))),
                 "check-duplicated-username-fail");
+    }
+
+    private ResultActions 닉네임_중복_검사_요청() throws Exception {
+        return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/nickname/check")
+                .contextPath(CONTEXT_PATH)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(toJson(nicknameCheckRequest)));
+    }
+
+    private void 닉네임_중복_검사_요청_성공(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isOk()),
+                "check-duplicated-nickname-success");
+    }
+
+    private void 닉네임_중복_검사_요청_실패(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isBadRequest())
+                        .andExpect(content().json(toJson(ErrorResponse.from(duplicatedNicknameException)))),
+                "check-duplicated-nickname-fail");
     }
 
     private ResultActions 아이디_찾기_인증번호_발급_요청() throws Exception {

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -820,7 +820,7 @@ public class MemberControllerTest extends ApiDocument {
     private void 비밀번호_재설정_요청_성공(ResultActions resultActions) throws Exception {
         printAndMakeSnippet(resultActions
                         .andExpect(status().isOk()),
-                "reset-password-fail");
+                "reset-password-success");
     }
 
     private void 비밀번호_재설정_요청_회원정보없음_실패(ResultActions resultActions) throws Exception {


### PR DESCRIPTION
## Issue

closed #50 
[SP-102](https://soma-cupid.atlassian.net/browse/SP-102?atlOrigin=eyJpIjoiNzA5MTdkNmQwOTE5NGU2NThiMjNlMDVjYmUwN2RiNDEiLCJwIjoiaiJ9)

## 요구사항

- [x] 닉네임 중복 확인 성공 API 명세서 작성
- [x] 닉네임 중복 확인 실패 API 명세서 작성

## 변경사항

- 닉네임 중복 확인 로직을 `MemberController` 및 `MemberService`에 추가
- 닉네임 중복 확인 요청 DTO `NicknameCheckRequest` 추가
- `index.adoc` 닉네임 중복 확인 추가
- `MemberControllerTest` 비밀번호 재설정 실패 스니펫 제목 수정

## 리뷰 우선순위

🙂 보통

[SP-102]: https://soma-cupid.atlassian.net/browse/SP-102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ