### PR TITLE
[SP-103] 전화번호 인증번호 발급 API 명세서 작성

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -217,6 +217,12 @@ include::{snippets}/signup-create-verification-code-success/http-request.adoc[]
 
 .response
 include::{snippets}/signup-create-verification-code-success/http-response.adoc[]
+===== 실패
+.request
+include::{snippets}/signup-create-verification-code-fail/http-request.adoc[]
+
+.response
+include::{snippets}/signup-create-verification-code-fail/http-response.adoc[]
 
 ==== 아이디 찾기 인증번호 발급
 ----

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -207,6 +207,17 @@ include::{snippets}/check-duplicated-username-fail/http-request.adoc[]
 .response
 include::{snippets}/check-duplicated-username-fail/http-response.adoc[]
 
+==== 전화번호 인증번호 발급
+----
+/api/v1/members/code
+----
+===== 성공
+.request
+include::{snippets}/signup-create-verification-code-success/http-request.adoc[]
+
+.response
+include::{snippets}/signup-create-verification-code-success/http-response.adoc[]
+
 ==== 아이디 찾기 인증번호 발급
 ----
 /api/v1/members/username/search/code

--- a/src/main/java/com/cupid/jikting/member/controller/MemberController.java
+++ b/src/main/java/com/cupid/jikting/member/controller/MemberController.java
@@ -66,6 +66,12 @@ public class MemberController {
         return ResponseEntity.ok().build();
     }
 
+    @PostMapping("/code")
+    public ResponseEntity<Void> createVerificationCodeForSignup(@RequestBody SignUpVerificationCodeRequest signUpVerificationCodeRequest) {
+        memberService.createVerificationCodeForSignup(signUpVerificationCodeRequest);
+        return ResponseEntity.ok().build();
+    }
+
     @PostMapping("/username/search/code")
     public ResponseEntity<Void> createVerificationCodeForSearchUsername(@RequestBody UsernameSearchVerificationCodeRequest usernameSearchVerificationCodeRequest) {
         memberService.createVerificationCodeForSearchUsername(usernameSearchVerificationCodeRequest);

--- a/src/main/java/com/cupid/jikting/member/dto/SignUpVerificationCodeRequest.java
+++ b/src/main/java/com/cupid/jikting/member/dto/SignUpVerificationCodeRequest.java
@@ -1,0 +1,12 @@
+package com.cupid.jikting.member.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SignUpVerificationCodeRequest {
+
+    private String phone;
+}

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -36,6 +36,9 @@ public class MemberService {
     public void checkDuplicatedUsername(UsernameCheckRequest usernameCheckRequest) {
     }
 
+    public void createVerificationCodeForSignup(SignUpVerificationCodeRequest signUpVerificationCodeRequest) {
+    }
+
     public void createVerificationCodeForSearchUsername(UsernameSearchVerificationCodeRequest usernameSearchVerificationCodeRequest) {
     }
 

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -61,6 +61,7 @@ public class MemberControllerTest extends ApiDocument {
     private MemberProfileUpdateRequest memberProfileUpdateRequest;
     private PasswordUpdateRequest passwordUpdateRequest;
     private WithdrawRequest withdrawRequest;
+    private SignUpVerificationCodeRequest signUpVerificationCodeRequest;
     private UsernameSearchVerificationCodeRequest usernameSearchVerificationCodeRequest;
     private VerificationRequest verificationRequest;
     private PasswordResetVerificationCodeRequest passwordResetVerificationCodeRequest;
@@ -127,6 +128,9 @@ public class MemberControllerTest extends ApiDocument {
                 .build();
         usernameCheckRequest = UsernameCheckRequest.builder()
                 .username(USERNAME)
+                .build();
+        signUpVerificationCodeRequest = SignUpVerificationCodeRequest.builder()
+                .phone(PHONE)
                 .build();
         usernameSearchVerificationCodeRequest = UsernameSearchVerificationCodeRequest.builder()
                 .username(USERNAME)
@@ -447,6 +451,16 @@ public class MemberControllerTest extends ApiDocument {
     }
 
     @Test
+    void 전화번호_인증번호_발급_성공() throws Exception {
+        // given
+        willDoNothing().given(memberService).createVerificationCodeForSignup(any(SignUpVerificationCodeRequest.class));
+        // when
+        ResultActions resultActions = 전화번호_인증번호_발급_요청();
+        // then
+        전화번호_인증번호_발급_요청_성공(resultActions);
+    }
+
+    @Test
     void 비밀번호_재설정_인증번호_발급_성공() throws Exception {
         // given
         willDoNothing().given(memberService).createVerificationCodeForResetPassword(any(PasswordResetVerificationCodeRequest.class));
@@ -727,6 +741,19 @@ public class MemberControllerTest extends ApiDocument {
                         .andExpect(status().isBadRequest())
                         .andExpect(content().json(toJson(ErrorResponse.from(duplicatedUsernameException)))),
                 "check-duplicated-username-fail");
+    }
+
+    private ResultActions 전화번호_인증번호_발급_요청() throws Exception {
+        return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/code")
+                .contextPath(CONTEXT_PATH)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(toJson(signUpVerificationCodeRequest)));
+    }
+
+    private void 전화번호_인증번호_발급_요청_성공(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isOk()),
+                "signup-create-verification-code-success");
     }
 
     private ResultActions 아이디_찾기_인증번호_발급_요청() throws Exception {

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -461,6 +461,16 @@ public class MemberControllerTest extends ApiDocument {
     }
 
     @Test
+    void 전화번호_인증번호_발급_실패() throws Exception {
+        // given
+        willThrow(wrongFormException).given(memberService).createVerificationCodeForSignup(any(SignUpVerificationCodeRequest.class));
+        // when
+        ResultActions resultActions = 전화번호_인증번호_발급_요청();
+        // then
+        전화번호_인증번호_발급_요청_실패(resultActions);
+    }
+
+    @Test
     void 비밀번호_재설정_인증번호_발급_성공() throws Exception {
         // given
         willDoNothing().given(memberService).createVerificationCodeForResetPassword(any(PasswordResetVerificationCodeRequest.class));
@@ -754,6 +764,13 @@ public class MemberControllerTest extends ApiDocument {
         printAndMakeSnippet(resultActions
                         .andExpect(status().isOk()),
                 "signup-create-verification-code-success");
+    }
+
+    private void 전화번호_인증번호_발급_요청_실패(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isBadRequest())
+                        .andExpect(content().json(toJson(ErrorResponse.from(wrongFormException)))),
+                "signup-create-verification-code-fail");
     }
 
     private ResultActions 아이디_찾기_인증번호_발급_요청() throws Exception {


### PR DESCRIPTION
## Issue

closed #55 
[SP-103](https://soma-cupid.atlassian.net/browse/SP-103?atlOrigin=eyJpIjoiNjJjMmVlZWZmZTg2NGU3YjljNGYyOWZiZmRlNGYxNjAiLCJwIjoiaiJ9)

## 요구사항

- [x] 전화번호 인증번호 발급 성공 API 명세서 작성
- [x] 전화번호 인증번호 발급 실패 API 명세서 작성

## 변경사항

-  전화번호 인증번호 발급 로직을 `MemberController` 및 `MemberService`에 추가
-  전화번호 인증번호 발급 요청 DTO `SignUpVerificationCodeRequest` 추가
- `index.adoc` 전화번호 인증번호 발급 추가

## 리뷰 우선순위

🙂 보통

## 코멘트

전화번호 인증번호 발급은 실패 사례가 없다고 생각해서 구현하지 않았습니다. 실패 사례가 생각나시면 코멘트 남겨주세요!

[SP-103]: https://soma-cupid.atlassian.net/browse/SP-103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ