### PR TITLE
[SP-104] 전화번호 인증 API 명세서 작성

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -217,6 +217,12 @@ include::{snippets}/signup-verify-success/http-request.adoc[]
 
 .response
 include::{snippets}/signup-verify-success/http-response.adoc[]
+===== 실패
+.request
+include::{snippets}/signup-verify-fail/http-request.adoc[]
+
+.response
+include::{snippets}/signup-verify-fail/http-response.adoc[]
 
 ==== 아이디 찾기 인증번호 발급
 ----

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -207,6 +207,17 @@ include::{snippets}/check-duplicated-username-fail/http-request.adoc[]
 .response
 include::{snippets}/check-duplicated-username-fail/http-response.adoc[]
 
+==== 전화번호 인증
+----
+/api/v1/members/verification
+----
+===== 성공
+.request
+include::{snippets}/signup-verify-success/http-request.adoc[]
+
+.response
+include::{snippets}/signup-verify-success/http-response.adoc[]
+
 ==== 아이디 찾기 인증번호 발급
 ----
 /api/v1/members/username/search/code

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -213,16 +213,16 @@ include::{snippets}/check-duplicated-username-fail/http-response.adoc[]
 ----
 ===== 성공
 .request
-include::{snippets}/signup-verify-success/http-request.adoc[]
+include::{snippets}/signup-verify-phone-success/http-request.adoc[]
 
 .response
-include::{snippets}/signup-verify-success/http-response.adoc[]
+include::{snippets}/signup-verify-phone-success/http-response.adoc[]
 ===== 실패
 .request
-include::{snippets}/signup-verify-fail/http-request.adoc[]
+include::{snippets}/signup-verify-phone-fail/http-request.adoc[]
 
 .response
-include::{snippets}/signup-verify-fail/http-response.adoc[]
+include::{snippets}/signup-verify-phone-fail/http-response.adoc[]
 
 ==== 아이디 찾기 인증번호 발급
 ----

--- a/src/main/java/com/cupid/jikting/member/controller/MemberController.java
+++ b/src/main/java/com/cupid/jikting/member/controller/MemberController.java
@@ -67,8 +67,8 @@ public class MemberController {
     }
 
     @PostMapping("/verification")
-    public ResponseEntity<Void> verifyForSignup(@RequestBody VerificationRequest verificationRequest) {
-        memberService.verifyForSignup(verificationRequest);
+    public ResponseEntity<Void> verifyPhoneForSignup(@RequestBody VerificationRequest verificationRequest) {
+        memberService.verifyPhoneForSignup(verificationRequest);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/cupid/jikting/member/controller/MemberController.java
+++ b/src/main/java/com/cupid/jikting/member/controller/MemberController.java
@@ -66,6 +66,12 @@ public class MemberController {
         return ResponseEntity.ok().build();
     }
 
+    @PostMapping("/verification")
+    public ResponseEntity<Void> verifyForSignup(@RequestBody VerificationRequest verificationRequest) {
+        memberService.verifyForSignup(verificationRequest);
+        return ResponseEntity.ok().build();
+    }
+
     @PostMapping("/username/search/code")
     public ResponseEntity<Void> createVerificationCodeForSearchUsername(@RequestBody UsernameSearchVerificationCodeRequest usernameSearchVerificationCodeRequest) {
         memberService.createVerificationCodeForSearchUsername(usernameSearchVerificationCodeRequest);

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -36,6 +36,9 @@ public class MemberService {
     public void checkDuplicatedUsername(UsernameCheckRequest usernameCheckRequest) {
     }
 
+    public void verifyForSignup(VerificationRequest verificationRequest) {
+    }
+
     public void createVerificationCodeForSearchUsername(UsernameSearchVerificationCodeRequest usernameSearchVerificationCodeRequest) {
     }
 

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -36,7 +36,7 @@ public class MemberService {
     public void checkDuplicatedUsername(UsernameCheckRequest usernameCheckRequest) {
     }
 
-    public void verifyForSignup(VerificationRequest verificationRequest) {
+    public void verifyPhoneForSignup(VerificationRequest verificationRequest) {
     }
 
     public void createVerificationCodeForSearchUsername(UsernameSearchVerificationCodeRequest usernameSearchVerificationCodeRequest) {

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -417,6 +417,16 @@ public class MemberControllerTest extends ApiDocument {
     }
 
     @Test
+    void 전화번호_인증_실패() throws Exception {
+        // given
+        willThrow(verificationCodeNotEqualException).given(memberService).verifyForSignup(any(VerificationRequest.class));
+        // when
+        ResultActions resultActions = 전화번호_인증_요청();
+        // then
+        전화번호_인증_요청_실패(resultActions);
+    }
+
+    @Test
     void 아이디_찾기_인증번호_발급_성공() throws Exception {
         // given
         willDoNothing().given(memberService).createVerificationCodeForSearchUsername(any(UsernameSearchVerificationCodeRequest.class));
@@ -750,6 +760,13 @@ public class MemberControllerTest extends ApiDocument {
         printAndMakeSnippet(resultActions
                         .andExpect(status().isOk()),
                 "signup-verify-success");
+    }
+
+    private void 전화번호_인증_요청_실패(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isBadRequest())
+                        .andExpect(content().json(toJson(ErrorResponse.from(verificationCodeNotEqualException)))),
+                "signup-verify-fail");
     }
 
     private ResultActions 아이디_찾기_인증번호_발급_요청() throws Exception {

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -407,6 +407,16 @@ public class MemberControllerTest extends ApiDocument {
     }
 
     @Test
+    void 전화번호_인증_성공() throws Exception {
+        // given
+        willDoNothing().given(memberService).verifyForSignup(any(VerificationRequest.class));
+        // when
+        ResultActions resultActions = 전화번호_인증_요청();
+        // then
+        전화번호_인증_요청_성공(resultActions);
+    }
+
+    @Test
     void 아이디_찾기_인증번호_발급_성공() throws Exception {
         // given
         willDoNothing().given(memberService).createVerificationCodeForSearchUsername(any(UsernameSearchVerificationCodeRequest.class));
@@ -727,6 +737,19 @@ public class MemberControllerTest extends ApiDocument {
                         .andExpect(status().isBadRequest())
                         .andExpect(content().json(toJson(ErrorResponse.from(duplicatedUsernameException)))),
                 "check-duplicated-username-fail");
+    }
+
+    private ResultActions 전화번호_인증_요청() throws Exception {
+        return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/verification")
+                .contextPath(CONTEXT_PATH)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(toJson(verificationRequest)));
+    }
+
+    private void 전화번호_인증_요청_성공(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isOk()),
+                "signup-verify-success");
     }
 
     private ResultActions 아이디_찾기_인증번호_발급_요청() throws Exception {

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -409,7 +409,7 @@ public class MemberControllerTest extends ApiDocument {
     @Test
     void 전화번호_인증_성공() throws Exception {
         // given
-        willDoNothing().given(memberService).verifyForSignup(any(VerificationRequest.class));
+        willDoNothing().given(memberService).verifyPhoneForSignup(any(VerificationRequest.class));
         // when
         ResultActions resultActions = 전화번호_인증_요청();
         // then
@@ -419,7 +419,7 @@ public class MemberControllerTest extends ApiDocument {
     @Test
     void 전화번호_인증_실패() throws Exception {
         // given
-        willThrow(verificationCodeNotEqualException).given(memberService).verifyForSignup(any(VerificationRequest.class));
+        willThrow(verificationCodeNotEqualException).given(memberService).verifyPhoneForSignup(any(VerificationRequest.class));
         // when
         ResultActions resultActions = 전화번호_인증_요청();
         // then

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -759,14 +759,14 @@ public class MemberControllerTest extends ApiDocument {
     private void 전화번호_인증_요청_성공(ResultActions resultActions) throws Exception {
         printAndMakeSnippet(resultActions
                         .andExpect(status().isOk()),
-                "signup-verify-success");
+                "signup-verify-phone-success");
     }
 
     private void 전화번호_인증_요청_실패(ResultActions resultActions) throws Exception {
         printAndMakeSnippet(resultActions
                         .andExpect(status().isBadRequest())
                         .andExpect(content().json(toJson(ErrorResponse.from(verificationCodeNotEqualException)))),
-                "signup-verify-fail");
+                "signup-verify-phone-fail");
     }
 
     private ResultActions 아이디_찾기_인증번호_발급_요청() throws Exception {


### PR DESCRIPTION
## Issue

closed #57 
[SP-104](https://soma-cupid.atlassian.net/browse/SP-104?atlOrigin=eyJpIjoiYjM3Y2NkNDA4NWM2NGRhY2FmNDZmNTI0OWY3NDljM2EiLCJwIjoiaiJ9)

## 요구사항

- [x] 전화번호 인증 성공 API 명세서 작성
- [x] 전화번호 인증 실패 API 명세서 작성

## 변경사항

- 전화번호 인증 로직을 `MemberController` 및 `MemberService`에 추가
- `index.adoc` 전화번호 인증 추가

## 리뷰 우선순위

🙂 보통

[SP-104]: https://soma-cupid.atlassian.net/browse/SP-104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ