### PR TITLE
[SP-32] 팀 등록 API 명세서 작성

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -306,6 +306,12 @@ include::{snippets}/register-team-success/http-request.adoc[]
 
 .response
 include::{snippets}/register-team-success/http-response.adoc[]
+===== 실패
+.request
+include::{snippets}/register-team-fail/http-request.adoc[]
+
+.response
+include::{snippets}/register-team-fail/http-response.adoc[]
 
 === 추천 관련 기능
 ==== 추천 팀 조회

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -295,6 +295,18 @@ include::{snippets}/reset-password-not-found-member-fail/http-response.adoc[]
 .response - 비밀번호 양식 불일치
 include::{snippets}/reset-password-wrong-form-fail/http-response.adoc[]
 
+=== 팀 관련 기능
+==== 팀 등록
+----
+/api/v1/teams
+----
+===== 성공
+.request
+include::{snippets}/register-team-success/http-request.adoc[]
+
+.response
+include::{snippets}/register-team-success/http-response.adoc[]
+
 === 추천 관련 기능
 ==== 추천 팀 조회
 ----

--- a/src/main/java/com/cupid/jikting/team/controller/TeamController.java
+++ b/src/main/java/com/cupid/jikting/team/controller/TeamController.java
@@ -1,0 +1,24 @@
+package com.cupid.jikting.team.controller;
+
+import com.cupid.jikting.team.dto.TeamRegisterRequest;
+import com.cupid.jikting.team.dto.TeamRegisterResponse;
+import com.cupid.jikting.team.service.TeamService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/teams")
+public class TeamController {
+
+    private final TeamService teamService;
+
+    @PostMapping
+    public ResponseEntity<TeamRegisterResponse> register(@RequestBody TeamRegisterRequest teamRegisterRequest) {
+        return ResponseEntity.ok().body(teamService.register(teamRegisterRequest));
+    }
+}

--- a/src/main/java/com/cupid/jikting/team/dto/TeamRegisterRequest.java
+++ b/src/main/java/com/cupid/jikting/team/dto/TeamRegisterRequest.java
@@ -1,0 +1,15 @@
+package com.cupid.jikting.team.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TeamRegisterRequest {
+
+    private String description;
+    private List<String> keywords;
+}

--- a/src/main/java/com/cupid/jikting/team/dto/TeamRegisterResponse.java
+++ b/src/main/java/com/cupid/jikting/team/dto/TeamRegisterResponse.java
@@ -1,0 +1,12 @@
+package com.cupid.jikting.team.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TeamRegisterResponse {
+
+    private String invitationUrl;
+}

--- a/src/main/java/com/cupid/jikting/team/service/TeamService.java
+++ b/src/main/java/com/cupid/jikting/team/service/TeamService.java
@@ -1,0 +1,13 @@
+package com.cupid.jikting.team.service;
+
+import com.cupid.jikting.team.dto.TeamRegisterRequest;
+import com.cupid.jikting.team.dto.TeamRegisterResponse;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TeamService {
+
+    public TeamRegisterResponse register(TeamRegisterRequest teamRegisterRequest) {
+        return null;
+    }
+}

--- a/src/test/java/com/cupid/jikting/team/controller/TeamControllerTest.java
+++ b/src/test/java/com/cupid/jikting/team/controller/TeamControllerTest.java
@@ -1,0 +1,76 @@
+package com.cupid.jikting.team.controller;
+
+import com.cupid.jikting.ApiDocument;
+import com.cupid.jikting.team.dto.TeamRegisterRequest;
+import com.cupid.jikting.team.dto.TeamRegisterResponse;
+import com.cupid.jikting.team.service.TeamService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.willReturn;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(TeamController.class)
+public class TeamControllerTest extends ApiDocument {
+
+    private static final String CONTEXT_PATH = "/api/v1";
+    private static final String DOMAIN_ROOT_PATH = "/teams";
+    private static final String KEYWORD = "키워드";
+    private static final String DESCRIPTION = "한줄 소개";
+    private static final String INVITATION_URL = "초대 URL";
+
+    private TeamRegisterRequest teamRegisterRequest;
+    private TeamRegisterResponse teamRegisterResponse;
+
+    @MockBean
+    private TeamService teamService;
+
+    @BeforeEach
+    void setUp() {
+        List<String> keywords = IntStream.rangeClosed(1, 3)
+                .mapToObj(n -> KEYWORD + n)
+                .collect(Collectors.toList());
+        teamRegisterRequest = TeamRegisterRequest.builder()
+                .description(DESCRIPTION)
+                .keywords(keywords)
+                .build();
+        teamRegisterResponse = TeamRegisterResponse.builder()
+                .invitationUrl(INVITATION_URL)
+                .build();
+    }
+
+    @Test
+    void 팀_등록_성공() throws Exception {
+        // given
+        willReturn(teamRegisterResponse).given(teamService).register(any(TeamRegisterRequest.class));
+        // when
+        ResultActions resultActions = 팀_등록_요청();
+        // then
+        팀_등록_요청_성공(resultActions);
+    }
+
+    private ResultActions 팀_등록_요청() throws Exception {
+        return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH)
+                .contextPath(CONTEXT_PATH)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(toJson(teamRegisterRequest)));
+    }
+
+    private void 팀_등록_요청_성공(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isOk())
+                        .andExpect(content().json(toJson(teamRegisterResponse))),
+                "register-team-success");
+    }
+}


### PR DESCRIPTION
## Issue

closed #59
[SP-32](https://soma-cupid.atlassian.net/browse/SP-32?atlOrigin=eyJpIjoiODZhMzg5MGQ3ZDExNDNjNGE4ZGEzMTU1ZmEyY2Q2YjMiLCJwIjoiaiJ9)

## 요구사항

- [x] 팀 등록 성공 API 명세서 작성
- [x] 팀 등록 실패 API 명세서 작성

## 변경사항

- 팀 관련 MVC 테스트를 수행하는 `MemberControllerTest` 추가
- 팀 등록 로직을 `TeamController` 및 `TeamService`에 추가
- 팀 등록 요청 DTO `TeamRegisterRequest` 추가
- 팀 등록 응답 DTO `TeamRegisterResponse` 추가
- `index.adoc` 팀 등록 추가

## 리뷰 우선순위

🙂 보통

[SP-32]: https://soma-cupid.atlassian.net/browse/SP-32?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ