### PR TITLE
[SP-123] 채팅방 목록 조회 API 명세서 작성

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -432,3 +432,15 @@ include::{snippets}/reject-like-fail/http-request.adoc[]
 
 .response
 include::{snippets}/reject-like-fail/http-response.adoc[]
+
+=== 채팅 관련 기능
+==== 채팅 목록 조회
+----
+/api/v1/chattings
+----
+===== 성공
+.request
+include::{snippets}/get-chattings-success/http-request.adoc[]
+
+.response
+include::{snippets}/get-chattings-success/http-response.adoc[]

--- a/src/main/java/com/cupid/jikting/chatting/controller/ChattingController.java
+++ b/src/main/java/com/cupid/jikting/chatting/controller/ChattingController.java
@@ -1,0 +1,24 @@
+package com.cupid.jikting.chatting.controller;
+
+import com.cupid.jikting.chatting.dto.ChattingResponse;
+import com.cupid.jikting.chatting.service.ChattingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/chattings")
+public class ChattingController {
+
+    private final ChattingService chattingService;
+
+    @GetMapping
+    public ResponseEntity<List<ChattingResponse>> getAll() {
+        return ResponseEntity.ok().body(chattingService.getAll());
+    }
+}

--- a/src/main/java/com/cupid/jikting/chatting/dto/ChattingResponse.java
+++ b/src/main/java/com/cupid/jikting/chatting/dto/ChattingResponse.java
@@ -2,13 +2,16 @@ package com.cupid.jikting.chatting.dto;
 
 import lombok.*;
 
+import java.util.List;
+
 @Getter
 @Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChattingResponse {
 
-    Long chattingId;
-    String opposingTeamName;
-    String lastMessage;
+    private Long chattingId;
+    private String opposingTeamName;
+    private String lastMessage;
+    private List<String> images;
 }

--- a/src/main/java/com/cupid/jikting/chatting/dto/ChattingResponse.java
+++ b/src/main/java/com/cupid/jikting/chatting/dto/ChattingResponse.java
@@ -1,0 +1,14 @@
+package com.cupid.jikting.chatting.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChattingResponse {
+
+    Long chattingId;
+    String opposingTeamName;
+    String lastMessage;
+}

--- a/src/main/java/com/cupid/jikting/chatting/service/ChattingService.java
+++ b/src/main/java/com/cupid/jikting/chatting/service/ChattingService.java
@@ -8,7 +8,6 @@ import java.util.List;
 @Service
 public class ChattingService {
 
-
     public List<ChattingResponse> getAll() {
         return null;
     }

--- a/src/main/java/com/cupid/jikting/chatting/service/ChattingService.java
+++ b/src/main/java/com/cupid/jikting/chatting/service/ChattingService.java
@@ -1,0 +1,15 @@
+package com.cupid.jikting.chatting.service;
+
+import com.cupid.jikting.chatting.dto.ChattingResponse;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class ChattingService {
+
+
+    public List<ChattingResponse> getAll() {
+        return null;
+    }
+}

--- a/src/test/java/com/cupid/jikting/chatting/controller/ChattingControllerTest.java
+++ b/src/test/java/com/cupid/jikting/chatting/controller/ChattingControllerTest.java
@@ -1,0 +1,68 @@
+package com.cupid.jikting.chatting.controller;
+
+import com.cupid.jikting.ApiDocument;
+import com.cupid.jikting.chatting.dto.ChattingResponse;
+import com.cupid.jikting.chatting.service.ChattingService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.mockito.BDDMockito.willReturn;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ChattingController.class)
+public class ChattingControllerTest extends ApiDocument {
+
+    private static final String CONTEXT_PATH = "/api/v1";
+    private static final String DOMAIN_ROOT_PATH = "/chattings";
+    private static final Long ID = 1L;
+    private static final String TEAM_NAME = "팀이름";
+    private static final String MESSAGE = "메시지";
+
+    private List<ChattingResponse> chattingResponses;
+
+    @MockBean
+    private ChattingService chattingService;
+
+    @BeforeEach
+    void setUp() {
+        chattingResponses = IntStream.rangeClosed(0, 2)
+                .mapToObj(n -> ChattingResponse.builder()
+                        .chattingId(ID)
+                        .opposingTeamName(TEAM_NAME)
+                        .lastMessage(MESSAGE)
+                        .build())
+                .collect(Collectors.toList());
+
+    }
+
+    @Test
+    void 채팅방_목록_조회_성공() throws Exception {
+        //given
+        willReturn(chattingResponses).given(chattingService).getAll();
+        //when
+        ResultActions resultActions = 채팅방_목록_조회_요청();
+        //then
+        채팅방_목록_조회_요청_성공(resultActions);
+    }
+
+    private ResultActions 채팅방_목록_조회_요청() throws Exception {
+        return mockMvc.perform(get(CONTEXT_PATH + DOMAIN_ROOT_PATH)
+                .contextPath(CONTEXT_PATH));
+    }
+
+    private void 채팅방_목록_조회_요청_성공(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isOk())
+                        .andExpect(content().json(toJson(chattingResponses))),
+                "get-chattings-success");
+    }
+}

--- a/src/test/java/com/cupid/jikting/chatting/controller/ChattingControllerTest.java
+++ b/src/test/java/com/cupid/jikting/chatting/controller/ChattingControllerTest.java
@@ -23,6 +23,7 @@ public class ChattingControllerTest extends ApiDocument {
 
     private static final String CONTEXT_PATH = "/api/v1";
     private static final String DOMAIN_ROOT_PATH = "/chattings";
+    private static final String URL = "이미지 주소";
     private static final Long ID = 1L;
     private static final String TEAM_NAME = "팀이름";
     private static final String MESSAGE = "메시지";
@@ -34,14 +35,17 @@ public class ChattingControllerTest extends ApiDocument {
 
     @BeforeEach
     void setUp() {
+        List<String> images = IntStream.rangeClosed(0, 2)
+                .mapToObj(n -> URL)
+                .collect(Collectors.toList());
         chattingResponses = IntStream.rangeClosed(0, 2)
                 .mapToObj(n -> ChattingResponse.builder()
                         .chattingId(ID)
                         .opposingTeamName(TEAM_NAME)
                         .lastMessage(MESSAGE)
+                        .images(images)
                         .build())
                 .collect(Collectors.toList());
-
     }
 
     @Test


### PR DESCRIPTION
## Issue

closed #65 
[SP-123](https://soma-cupid.atlassian.net/browse/SP-123?atlOrigin=eyJpIjoiNjVhNmJiZmMxMjEyNDMwZGEzYjRmZjZlYzg2ODFhYjkiLCJwIjoiaiJ9)

## 요구사항

- [x] 채팅방 목록 조회 성공 API 명세서 작성
- [x] 채팅방 목록 조회 실패 API 명세서 작성

## 변경사항

- 채팅 관련 MVC 테스트를 수행하는 `ChattingControllerTest` 추가
- 채팅방 목록 조회 로직을 `ChattingController` 및 `ChattingService`에 추가
- `index.adoc` 채팅방 목록 조회 추가

## 리뷰 우선순위

🙂 보통

[SP-123]: https://soma-cupid.atlassian.net/browse/SP-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ