### PR TITLE
[SP-105] 회사 이메일 인증번호 발급 API 명세서 작성

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -339,6 +339,12 @@ include::{snippets}/verify-company-create-verification-code-success/http-request
 
 .response
 include::{snippets}/verify-company-create-verification-code-success/http-response.adoc[]
+===== 실패
+.request
+include::{snippets}/verify-company-create-verification-code-fail/http-request.adoc[]
+
+.response
+include::{snippets}/verify-company-create-verification-code-fail/http-response.adoc[]
 
 === 팀 관련 기능
 ==== 팀 등록

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -329,6 +329,17 @@ include::{snippets}/reset-password-not-found-member-fail/http-response.adoc[]
 .response - 비밀번호 양식 불일치
 include::{snippets}/reset-password-wrong-form-fail/http-response.adoc[]
 
+==== 회사 이메일 인증번호 발급
+----
+/api/v1/members/company/code
+----
+===== 성공
+.request
+include::{snippets}/verify-company-create-verification-code-success/http-request.adoc[]
+
+.response
+include::{snippets}/verify-company-create-verification-code-success/http-response.adoc[]
+
 === 팀 관련 기능
 ==== 팀 등록
 ----

--- a/src/main/java/com/cupid/jikting/member/controller/MemberController.java
+++ b/src/main/java/com/cupid/jikting/member/controller/MemberController.java
@@ -106,4 +106,10 @@ public class MemberController {
         memberService.resetPassword(passwordResetRequest);
         return ResponseEntity.ok().build();
     }
+
+    @PatchMapping("/company/code")
+    public ResponseEntity<Void> createVerificationCodeForCompany(@RequestBody CompanyVerificationCodeRequest companyVerificationCodeRequest) {
+        memberService.createVerificationCodeForCompany(companyVerificationCodeRequest);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/cupid/jikting/member/dto/CompanyVerificationCodeRequest.java
+++ b/src/main/java/com/cupid/jikting/member/dto/CompanyVerificationCodeRequest.java
@@ -1,0 +1,13 @@
+package com.cupid.jikting.member.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CompanyVerificationCodeRequest {
+
+    private String company;
+    private String companyEmail;
+}

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -57,4 +57,7 @@ public class MemberService {
 
     public void checkDuplicatedNickname(NicknameCheckRequest nicknameCheckRequest) {
     }
+
+    public void createVerificationCodeForCompany(CompanyVerificationCodeRequest companyVerificationCodeRequest) {
+    }
 }

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -582,6 +582,16 @@ public class MemberControllerTest extends ApiDocument {
         회사_이메일_인증번호_발급_요청_성공(resultActions);
     }
 
+    @Test
+    void 회사_이메일_인증번호_발급_실패() throws Exception {
+        // given
+        willThrow(wrongFormException).given(memberService).createVerificationCodeForCompany(any(CompanyVerificationCodeRequest.class));
+        // when
+        ResultActions resultActions = 회사_이메일_인증번호_발급_요청();
+        // then
+        회사_이메일_인증번호_발급_요청_실패(resultActions);
+    }
+
     private ResultActions 회원_가입_요청() throws Exception {
         return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH)
                 .contextPath(CONTEXT_PATH)
@@ -954,5 +964,12 @@ public class MemberControllerTest extends ApiDocument {
         printAndMakeSnippet(resultActions
                         .andExpect(status().isOk()),
                 "verify-company-create-verification-code-success");
+    }
+
+    private void 회사_이메일_인증번호_발급_요청_실패(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isBadRequest())
+                        .andExpect(content().json(toJson(ErrorResponse.from(wrongFormException)))),
+                "verify-company-create-verification-code-fail");
     }
 }

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -55,6 +55,7 @@ public class MemberControllerTest extends ApiDocument {
     private static final String CONTENT_TYPE = "image/png";
     private static final String IMAGE_FILE = "이미지 파일";
     private static final String VERIFICATION_CODE = "인증번호";
+    private static final String COMPANY_EMAIL = "회사 이메일";
 
     private SignupRequest signupRequest;
     private NicknameUpdateRequest nicknameUpdateRequest;
@@ -68,6 +69,7 @@ public class MemberControllerTest extends ApiDocument {
     private VerificationRequest verificationRequest;
     private PasswordResetVerificationCodeRequest passwordResetVerificationCodeRequest;
     private PasswordResetRequest passwordResetRequest;
+    private CompanyVerificationCodeRequest companyVerificationCodeRequest;
     private MemberResponse memberResponse;
     private MemberProfileResponse memberProfileResponse;
     private UsernameResponse usernameResponse;
@@ -152,6 +154,10 @@ public class MemberControllerTest extends ApiDocument {
         passwordResetRequest = PasswordResetRequest.builder()
                 .username(USERNAME)
                 .password(PASSWORD)
+                .build();
+        companyVerificationCodeRequest = CompanyVerificationCodeRequest.builder()
+                .company(COMPANY)
+                .companyEmail(COMPANY_EMAIL)
                 .build();
         memberResponse = MemberResponse.builder()
                 .nickname(NICKNAME)
@@ -566,6 +572,16 @@ public class MemberControllerTest extends ApiDocument {
         비밀번호_재설정_요청_비밀번호양식불일치_실패(resultActions);
     }
 
+    @Test
+    void 회사_이메일_인증번호_발급_성공() throws Exception {
+        // given
+        willDoNothing().given(memberService).createVerificationCodeForCompany(any(CompanyVerificationCodeRequest.class));
+        // when
+        ResultActions resultActions = 회사_이메일_인증번호_발급_요청();
+        // then
+        회사_이메일_인증번호_발급_요청_성공(resultActions);
+    }
+
     private ResultActions 회원_가입_요청() throws Exception {
         return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH)
                 .contextPath(CONTEXT_PATH)
@@ -925,5 +941,18 @@ public class MemberControllerTest extends ApiDocument {
                         .andExpect(status().isBadRequest())
                         .andExpect(content().json(toJson(ErrorResponse.from(wrongFormException)))),
                 "reset-password-wrong-form-fail");
+    }
+
+    private ResultActions 회사_이메일_인증번호_발급_요청() throws Exception {
+        return mockMvc.perform(patch(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/company/code")
+                .contextPath(CONTEXT_PATH)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(toJson(companyVerificationCodeRequest)));
+    }
+
+    private void 회사_이메일_인증번호_발급_요청_성공(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isOk()),
+                "verify-company-create-verification-code-success");
     }
 }


### PR DESCRIPTION
## Issue

closed #62 
[SP-105](https://soma-cupid.atlassian.net/browse/SP-105?atlOrigin=eyJpIjoiYjUzM2E1NmJiMjRiNGJkOWE0OWYxMGEyZDNhZTBhODgiLCJwIjoiaiJ9)

## 요구사항

- [x] 회사 이메일 인증번호 발급 성공 API 명세서 작성
- [x] 회사 이메일 인증번호 발급 실패 API 명세서 작성

## 변경사항

- 회사 이메일 인증번호 발급 로직을 `MemberController` 및 `MemberService`에 추가
- 회사 이메일 인증번호 발급 요청 DTO `CompanyVerificationCodeRequest` 추가
- `index.adoc` 회사 이메일 인증번호 발급 추가

## 리뷰 우선순위

🙂 보통

[SP-105]: https://soma-cupid.atlassian.net/browse/SP-105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ