### PR TITLE
[SP-111] 회사 이메일 인증 API 명세서 작성

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -339,6 +339,12 @@ include::{snippets}/verify-company-success/http-request.adoc[]
 
 .response
 include::{snippets}/verify-company-success/http-response.adoc[]
+===== 실패
+.request
+include::{snippets}/verify-company-fail/http-request.adoc[]
+
+.response
+include::{snippets}/verify-company-fail/http-response.adoc[]
 
 === 팀 관련 기능
 ==== 팀 등록

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -329,6 +329,17 @@ include::{snippets}/reset-password-not-found-member-fail/http-response.adoc[]
 .response - 비밀번호 양식 불일치
 include::{snippets}/reset-password-wrong-form-fail/http-response.adoc[]
 
+==== 회사 이메일 인증
+----
+/api/v1/members/company/verification
+----
+===== 성공
+.request
+include::{snippets}/verify-company-success/http-request.adoc[]
+
+.response
+include::{snippets}/verify-company-success/http-response.adoc[]
+
 === 팀 관련 기능
 ==== 팀 등록
 ----

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -346,6 +346,9 @@ include::{snippets}/verify-company-not-equal-code-fail/http-request.adoc[]
 .response - 인증번호 불일치
 include::{snippets}/verify-company-not-equal-code-fail/http-response.adoc[]
 
+.response - 인증번호 만료
+include::{snippets}/verify-company-code-expired-fail/http-response.adoc[]
+
 === 팀 관련 기능
 ==== 팀 등록
 ----

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -341,10 +341,10 @@ include::{snippets}/verify-company-success/http-request.adoc[]
 include::{snippets}/verify-company-success/http-response.adoc[]
 ===== 실패
 .request
-include::{snippets}/verify-company-fail/http-request.adoc[]
+include::{snippets}/verify-company-not-equal-code-fail/http-request.adoc[]
 
-.response
-include::{snippets}/verify-company-fail/http-response.adoc[]
+.response - 인증번호 불일치
+include::{snippets}/verify-company-not-equal-code-fail/http-response.adoc[]
 
 === 팀 관련 기능
 ==== 팀 등록

--- a/src/main/java/com/cupid/jikting/common/error/ApplicationError.java
+++ b/src/main/java/com/cupid/jikting/common/error/ApplicationError.java
@@ -15,6 +15,7 @@ public enum ApplicationError {
     INVALID_FILE_SIZE(HttpStatus.BAD_REQUEST, "C005", "지원하지 않는 파일 크기입니다."),
     INCOMPLETE_FORM(HttpStatus.BAD_REQUEST, "C006", "채워지지 않은 내용이 있습니다."),
     POINT_NOT_ENOUGH(HttpStatus.BAD_REQUEST, "C007", "포인트가 부족합니다."),
+    VERIFICATION_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "C008", "인증번호가 유효하지 않습니다."),
 
     UNAUTHORIZED_MEMBER(HttpStatus.UNAUTHORIZED, "U001", "인증되지 않은 사용자입니다."),
     FORBIDDEN_MEMBER(HttpStatus.FORBIDDEN, "U002", "권한이 없는 사용자입니다."),

--- a/src/main/java/com/cupid/jikting/member/controller/MemberController.java
+++ b/src/main/java/com/cupid/jikting/member/controller/MemberController.java
@@ -106,4 +106,10 @@ public class MemberController {
         memberService.resetPassword(passwordResetRequest);
         return ResponseEntity.ok().build();
     }
+
+    @PostMapping("/company/verification")
+    public ResponseEntity<Void> verifyForCompany(@RequestBody VerificationRequest verificationRequest) {
+        memberService.verifyForCompany(verificationRequest);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -57,4 +57,7 @@ public class MemberService {
 
     public void checkDuplicatedNickname(NicknameCheckRequest nicknameCheckRequest) {
     }
+
+    public void verifyForCompany(VerificationRequest verificationRequest) {
+    }
 }

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -576,6 +576,16 @@ public class MemberControllerTest extends ApiDocument {
         회사_이메일_인증_요청_성공(resultActions);
     }
 
+    @Test
+    void 회사_이메일_인증_실패() throws Exception {
+        // given
+        willThrow(verificationCodeNotEqualException).given(memberService).verifyForCompany(any(VerificationRequest.class));
+        // when
+        ResultActions resultActions = 회사_이메일_인증_요청();
+        // then
+        회사_이메일_인증_요청_실패(resultActions);
+    }
+
     private ResultActions 회원_가입_요청() throws Exception {
         return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH)
                 .contextPath(CONTEXT_PATH)
@@ -948,5 +958,12 @@ public class MemberControllerTest extends ApiDocument {
         printAndMakeSnippet(resultActions
                         .andExpect(status().isOk()),
                 "verify-company-success");
+    }
+
+    private void 회사_이메일_인증_요청_실패(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isBadRequest())
+                        .andExpect(content().json(toJson(ErrorResponse.from(verificationCodeNotEqualException)))),
+                "verify-company-fail");
     }
 }

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -566,6 +566,16 @@ public class MemberControllerTest extends ApiDocument {
         비밀번호_재설정_요청_비밀번호양식불일치_실패(resultActions);
     }
 
+    @Test
+    void 회사_이메일_인증_성공() throws Exception {
+        // given
+        willDoNothing().given(memberService).verifyForCompany(any(VerificationRequest.class));
+        // when
+        ResultActions resultActions = 회사_이메일_인증_요청();
+        // then
+        회사_이메일_인증_요청_성공(resultActions);
+    }
+
     private ResultActions 회원_가입_요청() throws Exception {
         return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH)
                 .contextPath(CONTEXT_PATH)
@@ -925,5 +935,18 @@ public class MemberControllerTest extends ApiDocument {
                         .andExpect(status().isBadRequest())
                         .andExpect(content().json(toJson(ErrorResponse.from(wrongFormException)))),
                 "reset-password-wrong-form-fail");
+    }
+
+    private ResultActions 회사_이메일_인증_요청() throws Exception {
+        return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/company/verification")
+                .contextPath(CONTEXT_PATH)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(toJson(verificationRequest)));
+    }
+
+    private void 회사_이메일_인증_요청_성공(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isOk()),
+                "verify-company-success");
     }
 }

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -577,13 +577,13 @@ public class MemberControllerTest extends ApiDocument {
     }
 
     @Test
-    void 회사_이메일_인증_실패() throws Exception {
+    void 회사_이메일_인증_인증번호불일치_실패() throws Exception {
         // given
         willThrow(verificationCodeNotEqualException).given(memberService).verifyForCompany(any(VerificationRequest.class));
         // when
         ResultActions resultActions = 회사_이메일_인증_요청();
         // then
-        회사_이메일_인증_요청_실패(resultActions);
+        회사_이메일_인증_요청_인증번호불일치_실패(resultActions);
     }
 
     private ResultActions 회원_가입_요청() throws Exception {
@@ -960,10 +960,10 @@ public class MemberControllerTest extends ApiDocument {
                 "verify-company-success");
     }
 
-    private void 회사_이메일_인증_요청_실패(ResultActions resultActions) throws Exception {
+    private void 회사_이메일_인증_요청_인증번호불일치_실패(ResultActions resultActions) throws Exception {
         printAndMakeSnippet(resultActions
                         .andExpect(status().isBadRequest())
                         .andExpect(content().json(toJson(ErrorResponse.from(verificationCodeNotEqualException)))),
-                "verify-company-fail");
+                "verify-company-not-equal-code-fail");
     }
 }

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -80,6 +80,7 @@ public class MemberControllerTest extends ApiDocument {
     private ApplicationException verificationCodeNotEqualException;
     private ApplicationException duplicatedUsernameException;
     private ApplicationException duplicatedNicknameException;
+    private ApplicationException verificationCodeExpiredException;
 
     @MockBean
     private MemberService memberService;
@@ -184,6 +185,7 @@ public class MemberControllerTest extends ApiDocument {
         verificationCodeNotEqualException = new NotEqualException(ApplicationError.VERIFICATION_CODE_NOT_EQUAL);
         duplicatedUsernameException = new DuplicateException(ApplicationError.DUPLICATE_USERNAME);
         duplicatedNicknameException = new DuplicateException(ApplicationError.DUPLICATE_NICKNAME);
+        verificationCodeExpiredException = new BadRequestException(ApplicationError.VERIFICATION_CODE_EXPIRED);
     }
 
     @Test
@@ -586,6 +588,16 @@ public class MemberControllerTest extends ApiDocument {
         회사_이메일_인증_요청_인증번호불일치_실패(resultActions);
     }
 
+    @Test
+    void 회사_이메일_인증_시간초과_실패() throws Exception {
+        // given
+        willThrow(verificationCodeExpiredException).given(memberService).verifyForCompany(any(VerificationRequest.class));
+        // when
+        ResultActions resultActions = 회사_이메일_인증_요청();
+        // then
+        회사_이메일_인증_요청_시간초과_실패(resultActions);
+    }
+
     private ResultActions 회원_가입_요청() throws Exception {
         return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH)
                 .contextPath(CONTEXT_PATH)
@@ -965,5 +977,12 @@ public class MemberControllerTest extends ApiDocument {
                         .andExpect(status().isBadRequest())
                         .andExpect(content().json(toJson(ErrorResponse.from(verificationCodeNotEqualException)))),
                 "verify-company-not-equal-code-fail");
+    }
+
+    private void 회사_이메일_인증_요청_시간초과_실패(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isBadRequest())
+                        .andExpect(content().json(toJson(ErrorResponse.from(verificationCodeExpiredException)))),
+                "verify-company-code-expired-fail");
     }
 }


### PR DESCRIPTION
## Issue

closed #68 
[SP-111](https://soma-cupid.atlassian.net/browse/SP-111?atlOrigin=eyJpIjoiMTg5YWYzMDYwZDYyNDA2N2JlNjNiZjFkMDE4YWI3MzciLCJwIjoiaiJ9)

## 요구사항

- [x] 회사 이메일 인증 성공 API 명세서 작성
- [x] 회사 이메일 인증 실패 API 명세서 작성

## 변경사항

- 회사 이메일 인증 로직을 `MemberController` 및 `MemberService`에 추가
- `index.adoc` 회사 이메일 인증 추가

## 리뷰 우선순위

🙂 보통

[SP-111]: https://soma-cupid.atlassian.net/browse/SP-111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ