### PR TITLE
[SP-128] 번개팅 참여 API 명세서 작성

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -444,3 +444,20 @@ include::{snippets}/get-instant-meeting-success/http-request.adoc[]
 
 .response
 include::{snippets}/get-instant-meeting-success/http-response.adoc[]
+
+==== 번개팅 참여
+----
+/api/v1/instant-meetings/{instantMeetingId}
+----
+===== 성공
+.request
+include::{snippets}/attend-instant-meeting-success/http-request.adoc[]
+
+.response
+include::{snippets}/attend-instant-meeting-success/http-response.adoc[]
+===== 실패
+.request
+include::{snippets}/attend-instant-meeting-fail/http-request.adoc[]
+
+.response
+include::{snippets}/attend-instant-meeting-fail/http-response.adoc[]

--- a/src/main/java/com/cupid/jikting/instantmeeting/controller/InstantMeetingController.java
+++ b/src/main/java/com/cupid/jikting/instantmeeting/controller/InstantMeetingController.java
@@ -4,9 +4,7 @@ import com.cupid.jikting.instantmeeting.dto.InstantMeetingResponse;
 import com.cupid.jikting.instantmeeting.service.InstantMeetingService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -20,5 +18,11 @@ public class InstantMeetingController {
     @GetMapping
     public ResponseEntity<List<InstantMeetingResponse>> getAll() {
         return ResponseEntity.ok().body(instantMeetingService.getAll());
+    }
+
+    @PostMapping("/{instantMeetingId}")
+    public ResponseEntity<Void> attend(@PathVariable Long instantMeetingId) {
+        instantMeetingService.attend(instantMeetingId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/cupid/jikting/instantmeeting/service/InstantMeetingService.java
+++ b/src/main/java/com/cupid/jikting/instantmeeting/service/InstantMeetingService.java
@@ -11,4 +11,7 @@ public class InstantMeetingService {
     public List<InstantMeetingResponse> getAll() {
         return null;
     }
+
+    public void attend(Long instantMeetingId) {
+    }
 }

--- a/src/test/java/com/cupid/jikting/instantmeeting/controller/InstantMeetingControllerTest.java
+++ b/src/test/java/com/cupid/jikting/instantmeeting/controller/InstantMeetingControllerTest.java
@@ -1,6 +1,10 @@
 package com.cupid.jikting.instantmeeting.controller;
 
 import com.cupid.jikting.ApiDocument;
+import com.cupid.jikting.common.dto.ErrorResponse;
+import com.cupid.jikting.common.error.ApplicationError;
+import com.cupid.jikting.common.error.ApplicationException;
+import com.cupid.jikting.common.error.BadRequestException;
 import com.cupid.jikting.instantmeeting.dto.InstantMeetingResponse;
 import com.cupid.jikting.instantmeeting.service.InstantMeetingService;
 import org.junit.jupiter.api.BeforeEach;
@@ -15,8 +19,10 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.mockito.BDDMockito.willReturn;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -25,11 +31,13 @@ public class InstantMeetingControllerTest extends ApiDocument {
 
     private static final String CONTEXT_PATH = "/api/v1";
     private static final String DOMAIN_ROOT_PATH = "/instant-meetings";
+    private static final String PATH_DELIMITER = "/";
     private static final Long ID = 1L;
     private static final LocalDateTime LOCAL_DATE_TIME = LocalDateTime.of(2023, Month.JUNE, 30, 18, 0);
     private static final String LOCATION = "장소";
 
     private List<InstantMeetingResponse> instantMeetingResponses;
+    private ApplicationException instantMeetingAlreadyFullException;
 
     @MockBean
     private InstantMeetingService instantMeetingService;
@@ -43,6 +51,7 @@ public class InstantMeetingControllerTest extends ApiDocument {
                         .location(LOCATION)
                         .build())
                 .collect(Collectors.toList());
+        instantMeetingAlreadyFullException = new BadRequestException(ApplicationError.INSTANT_MEETING_ALREADY_FULL);
     }
 
     @Test
@@ -55,6 +64,26 @@ public class InstantMeetingControllerTest extends ApiDocument {
         번개팅_조회_요청_성공(resultActions);
     }
 
+    @Test
+    void 번개팅_참여_성공() throws Exception {
+        //given
+        willDoNothing().given(instantMeetingService).attend(anyLong());
+        //when
+        ResultActions resultActions = 번개팅_참여_요청();
+        //then
+        번개팅_참여_요청_성공(resultActions);
+    }
+
+    @Test
+    void 번개팅_참여_실패() throws Exception {
+        //given
+        willThrow(instantMeetingAlreadyFullException).given(instantMeetingService).attend(anyLong());
+        //when
+        ResultActions resultActions = 번개팅_참여_요청();
+        //then
+        번개팅_참여_요청_실패(resultActions);
+    }
+
     private ResultActions 번개팅_조회_요청() throws Exception {
         return mockMvc.perform(get(CONTEXT_PATH + DOMAIN_ROOT_PATH)
                 .contextPath(CONTEXT_PATH));
@@ -65,5 +94,23 @@ public class InstantMeetingControllerTest extends ApiDocument {
                         .andExpect(status().isOk())
                         .andExpect(content().json(toJson(instantMeetingResponses))),
                 "get-instant-meeting-success");
+    }
+
+    private ResultActions 번개팅_참여_요청() throws Exception {
+        return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH + PATH_DELIMITER + ID)
+                .contextPath(CONTEXT_PATH));
+    }
+
+    private void 번개팅_참여_요청_성공(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isOk()),
+                "attend-instant-meeting-success");
+    }
+
+    private void 번개팅_참여_요청_실패(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isBadRequest())
+                        .andExpect(content().json(toJson(ErrorResponse.from(instantMeetingAlreadyFullException)))),
+                "attend-instant-meeting-fail");
     }
 }


### PR DESCRIPTION
## Issue

closed #52  
[SP-128](https://soma-cupid.atlassian.net/browse/SP-128?atlOrigin=eyJpIjoiNDBjMTM0Zjk4NjEyNGE4ZmIwMGIyOTRhMDgyNzE5YzEiLCJwIjoiaiJ9)

## 요구사항

- [x] 번개팅 참여 성공 API 명세서 작성
- [x] 번개팅 참여 실패 API 명세서 작성

## 변경사항

  - 번개팅 참여 로직을 `InstantMeetingController` 및 `InstantMeetingService`에 추가
- `index.adoc` 번개팅 참여 추가

## 리뷰 우선순위

🙂 보통

[SP-128]: https://soma-cupid.atlassian.net/browse/SP-128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ