### PR TITLE
[SP-36] 팀 조회 API 명세서 작성

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -347,6 +347,23 @@ include::{snippets}/register-team-fail/http-request.adoc[]
 .response
 include::{snippets}/register-team-fail/http-response.adoc[]
 
+==== 팀 조회
+----
+/api/v1/teams/{teamId}
+----
+===== 성공
+.request
+include::{snippets}/get-team-success/http-request.adoc[]
+
+.response
+include::{snippets}/get-team-success/http-response.adoc[]
+===== 실패
+.request
+include::{snippets}/get-team-fail/http-request.adoc[]
+
+.response
+include::{snippets}/get-team-fail/http-response.adoc[]
+
 === 추천 관련 기능
 ==== 추천 팀 조회
 ----

--- a/src/main/java/com/cupid/jikting/team/controller/TeamController.java
+++ b/src/main/java/com/cupid/jikting/team/controller/TeamController.java
@@ -2,13 +2,11 @@ package com.cupid.jikting.team.controller;
 
 import com.cupid.jikting.team.dto.TeamRegisterRequest;
 import com.cupid.jikting.team.dto.TeamRegisterResponse;
+import com.cupid.jikting.team.dto.TeamResponse;
 import com.cupid.jikting.team.service.TeamService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
@@ -20,5 +18,10 @@ public class TeamController {
     @PostMapping
     public ResponseEntity<TeamRegisterResponse> register(@RequestBody TeamRegisterRequest teamRegisterRequest) {
         return ResponseEntity.ok().body(teamService.register(teamRegisterRequest));
+    }
+
+    @GetMapping("/{teamId}")
+    public ResponseEntity<TeamResponse> get(@PathVariable Long teamId) {
+        return ResponseEntity.ok().body(teamService.get(teamId));
     }
 }

--- a/src/main/java/com/cupid/jikting/team/dto/MemberResponse.java
+++ b/src/main/java/com/cupid/jikting/team/dto/MemberResponse.java
@@ -1,0 +1,18 @@
+package com.cupid.jikting.team.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberResponse {
+
+    private String nickname;
+    private List<String> images;
+    private int age;
+    private String mbti;
+    private String address;
+}

--- a/src/main/java/com/cupid/jikting/team/dto/TeamResponse.java
+++ b/src/main/java/com/cupid/jikting/team/dto/TeamResponse.java
@@ -1,0 +1,16 @@
+package com.cupid.jikting.team.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TeamResponse {
+
+    private String description;
+    private List<String> keywords;
+    private List<MemberResponse> members;
+}

--- a/src/main/java/com/cupid/jikting/team/service/TeamService.java
+++ b/src/main/java/com/cupid/jikting/team/service/TeamService.java
@@ -2,12 +2,17 @@ package com.cupid.jikting.team.service;
 
 import com.cupid.jikting.team.dto.TeamRegisterRequest;
 import com.cupid.jikting.team.dto.TeamRegisterResponse;
+import com.cupid.jikting.team.dto.TeamResponse;
 import org.springframework.stereotype.Service;
 
 @Service
 public class TeamService {
 
     public TeamRegisterResponse register(TeamRegisterRequest teamRegisterRequest) {
+        return null;
+    }
+
+    public TeamResponse get(Long teamId) {
         return null;
     }
 }

--- a/src/test/java/com/cupid/jikting/team/controller/TeamControllerTest.java
+++ b/src/test/java/com/cupid/jikting/team/controller/TeamControllerTest.java
@@ -5,8 +5,11 @@ import com.cupid.jikting.common.dto.ErrorResponse;
 import com.cupid.jikting.common.error.ApplicationError;
 import com.cupid.jikting.common.error.ApplicationException;
 import com.cupid.jikting.common.error.BadRequestException;
+import com.cupid.jikting.common.error.NotFoundException;
+import com.cupid.jikting.team.dto.MemberResponse;
 import com.cupid.jikting.team.dto.TeamRegisterRequest;
 import com.cupid.jikting.team.dto.TeamRegisterResponse;
+import com.cupid.jikting.team.dto.TeamResponse;
 import com.cupid.jikting.team.service.TeamService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,8 +23,10 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.willReturn;
 import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -31,13 +36,22 @@ public class TeamControllerTest extends ApiDocument {
 
     private static final String CONTEXT_PATH = "/api/v1";
     private static final String DOMAIN_ROOT_PATH = "/teams";
+    private static final String PATH_DELIMITER = "/";
+    private static final Long ID = 1L;
     private static final String KEYWORD = "키워드";
     private static final String DESCRIPTION = "한줄 소개";
     private static final String INVITATION_URL = "초대 URL";
+    private static final String NICKNAME = "닉네임";
+    private static final String URL = "이미지 링크";
+    private static final int AGE = 20;
+    private static final String MBTI = "mbti";
+    private static final String ADDRESS = "거주지";
 
     private TeamRegisterRequest teamRegisterRequest;
     private TeamRegisterResponse teamRegisterResponse;
+    private TeamResponse teamResponse;
     private ApplicationException invalidFormatException;
+    private ApplicationException teamNotFoundException;
 
     @MockBean
     private TeamService teamService;
@@ -47,6 +61,18 @@ public class TeamControllerTest extends ApiDocument {
         List<String> keywords = IntStream.rangeClosed(1, 3)
                 .mapToObj(n -> KEYWORD + n)
                 .collect(Collectors.toList());
+        List<String> images = IntStream.rangeClosed(1, 3)
+                .mapToObj(n -> URL + n)
+                .collect(Collectors.toList());
+        List<MemberResponse> members = IntStream.rangeClosed(1, 3)
+                .mapToObj(n -> MemberResponse.builder()
+                        .nickname(NICKNAME)
+                        .images(images)
+                        .age(AGE)
+                        .mbti(MBTI)
+                        .address(ADDRESS)
+                        .build())
+                .collect(Collectors.toList());
         teamRegisterRequest = TeamRegisterRequest.builder()
                 .description(DESCRIPTION)
                 .keywords(keywords)
@@ -54,7 +80,13 @@ public class TeamControllerTest extends ApiDocument {
         teamRegisterResponse = TeamRegisterResponse.builder()
                 .invitationUrl(INVITATION_URL)
                 .build();
+        teamResponse = TeamResponse.builder()
+                .description(DESCRIPTION)
+                .keywords(keywords)
+                .members(members)
+                .build();
         invalidFormatException = new BadRequestException(ApplicationError.INVALID_FORMAT);
+        teamNotFoundException = new NotFoundException(ApplicationError.TEAM_NOT_FOUND);
     }
 
     @Test
@@ -77,6 +109,26 @@ public class TeamControllerTest extends ApiDocument {
         팀_등록_요청_실패(resultActions);
     }
 
+    @Test
+    void 팀_조회_성공() throws Exception {
+        //given
+        willReturn(teamResponse).given(teamService).get(anyLong());
+        //when
+        ResultActions resultActions = 팀_조회_요청();
+        //then
+        팀_조회_요청_성공(resultActions);
+    }
+
+    @Test
+    void 팀_조회_실패() throws Exception {
+        //given
+        willThrow(teamNotFoundException).given(teamService).get(anyLong());
+        //when
+        ResultActions resultActions = 팀_조회_요청();
+        //then
+        팀_조회_요청_실패(resultActions);
+    }
+
     private ResultActions 팀_등록_요청() throws Exception {
         return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH)
                 .contextPath(CONTEXT_PATH)
@@ -96,5 +148,24 @@ public class TeamControllerTest extends ApiDocument {
                         .andExpect(status().isBadRequest())
                         .andExpect(content().json(toJson(ErrorResponse.from(invalidFormatException)))),
                 "register-team-fail");
+    }
+
+    private ResultActions 팀_조회_요청() throws Exception {
+        return mockMvc.perform(get(CONTEXT_PATH + DOMAIN_ROOT_PATH + PATH_DELIMITER + ID)
+                .contextPath(CONTEXT_PATH));
+    }
+
+    private void 팀_조회_요청_성공(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isOk())
+                        .andExpect(content().json(toJson(teamResponse))),
+                "get-team-success");
+    }
+
+    private void 팀_조회_요청_실패(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isBadRequest())
+                        .andExpect(content().json(toJson(ErrorResponse.from(teamNotFoundException)))),
+                "get-team-fail");
     }
 }


### PR DESCRIPTION
## Issue

closed #72 
[SP-36](https://soma-cupid.atlassian.net/browse/SP-36?atlOrigin=eyJpIjoiNjEyNDM3ODVmZWNlNDNlYWFlYWZhZGE3MjE0MTFiZGQiLCJwIjoiaiJ9)

## 요구사항

- [x] 팀 조회 성공 API 명세서 작성
- [x] 팀 조회 실패 API 명세서 작성

## 변경사항

- 팀 조회 로직을 `TeamController` 및 `TeamService`에 추가
- 팀 조회 테스트를 `TeamControllerTest`에 추가
- `index.adoc`팀 조회 추가

## 리뷰 우선순위

🙂 보통

[SP-36]: https://soma-cupid.atlassian.net/browse/SP-36?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ