### PR TITLE
[SP-119] 팀 수정 API 명세서 작성

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -347,6 +347,23 @@ include::{snippets}/register-team-fail/http-request.adoc[]
 .response
 include::{snippets}/register-team-fail/http-response.adoc[]
 
+==== 팀 수정
+----
+/api/v1/teams/{teamId}
+----
+===== 성공
+.request
+include::{snippets}/update-team-success/http-request.adoc[]
+
+.response
+include::{snippets}/update-team-success/http-response.adoc[]
+===== 실패
+.request
+include::{snippets}/update-team-fail/http-request.adoc[]
+
+.response
+include::{snippets}/update-team-fail/http-response.adoc[]
+
 === 추천 관련 기능
 ==== 추천 팀 조회
 ----

--- a/src/main/java/com/cupid/jikting/team/controller/TeamController.java
+++ b/src/main/java/com/cupid/jikting/team/controller/TeamController.java
@@ -2,13 +2,11 @@ package com.cupid.jikting.team.controller;
 
 import com.cupid.jikting.team.dto.TeamRegisterRequest;
 import com.cupid.jikting.team.dto.TeamRegisterResponse;
+import com.cupid.jikting.team.dto.TeamUpdateRequest;
 import com.cupid.jikting.team.service.TeamService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
@@ -20,5 +18,11 @@ public class TeamController {
     @PostMapping
     public ResponseEntity<TeamRegisterResponse> register(@RequestBody TeamRegisterRequest teamRegisterRequest) {
         return ResponseEntity.ok().body(teamService.register(teamRegisterRequest));
+    }
+
+    @PatchMapping("/{teamId}")
+    public ResponseEntity<Void> update(@PathVariable Long teamId, @RequestBody TeamUpdateRequest teamUpdateRequest) {
+        teamService.update(teamId, teamUpdateRequest);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/cupid/jikting/team/dto/TeamUpdateRequest.java
+++ b/src/main/java/com/cupid/jikting/team/dto/TeamUpdateRequest.java
@@ -1,0 +1,15 @@
+package com.cupid.jikting.team.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TeamUpdateRequest {
+
+    private String description;
+    private List<String> keywords;
+}

--- a/src/main/java/com/cupid/jikting/team/service/TeamService.java
+++ b/src/main/java/com/cupid/jikting/team/service/TeamService.java
@@ -2,6 +2,7 @@ package com.cupid.jikting.team.service;
 
 import com.cupid.jikting.team.dto.TeamRegisterRequest;
 import com.cupid.jikting.team.dto.TeamRegisterResponse;
+import com.cupid.jikting.team.dto.TeamUpdateRequest;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -9,5 +10,8 @@ public class TeamService {
 
     public TeamRegisterResponse register(TeamRegisterRequest teamRegisterRequest) {
         return null;
+    }
+
+    public void update(Long teamId, TeamUpdateRequest teamUpdateRequest) {
     }
 }


### PR DESCRIPTION
## Issue

closed #74 
[SP-119](https://soma-cupid.atlassian.net/browse/SP-119?atlOrigin=eyJpIjoiZTRhMzgyNjZlYThkNDBkY2E4Njg1NTgxODNlNDE3YzAiLCJwIjoiaiJ9)

## 요구사항

- [x] 팀 수정 성공 API 명세서 작성
- [x] 팀 수정 실패 API 명세서 작성

## 변경사항

- 팀 수정 로직을 `TeamController` 및 `TeamService`에 추가
- 팀 수정 테스트를 `TeamControllerTest`에 추가
- `index.adoc`팀 수정 추가

## 리뷰 우선순위

🙂 보통

[SP-119]: https://soma-cupid.atlassian.net/browse/SP-119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ