### PR TITLE
[SP-107] 회사 명함 인증 API 명세서 작성

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -329,6 +329,17 @@ include::{snippets}/reset-password-not-found-member-fail/http-response.adoc[]
 .response - 비밀번호 양식 불일치
 include::{snippets}/reset-password-wrong-form-fail/http-response.adoc[]
 
+==== 회사 명함 인증
+----
+/api/v1/members/company/card
+----
+===== 성공
+.request
+include::{snippets}/verify-company-card-success/http-request.adoc[]
+
+.response
+include::{snippets}/verify-company-card-success/http-response.adoc[]
+
 === 팀 관련 기능
 ==== 팀 등록
 ----

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -346,6 +346,9 @@ include::{snippets}/verify-company-card-invalid-file-extension-fail/http-request
 .response - 파일 형식 미지원
 include::{snippets}/verify-company-card-invalid-file-extension-fail/http-response.adoc[]
 
+.response - 파일 크기 미지원
+include::{snippets}/verify-company-card-invalid-file-size-fail/http-response.adoc[]
+
 === 팀 관련 기능
 ==== 팀 등록
 ----

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -339,6 +339,12 @@ include::{snippets}/verify-company-card-success/http-request.adoc[]
 
 .response
 include::{snippets}/verify-company-card-success/http-response.adoc[]
+===== 실패
+.request
+include::{snippets}/verify-company-card-invalid-file-extension-fail/http-request.adoc[]
+
+.response - 파일 형식 미지원
+include::{snippets}/verify-company-card-invalid-file-extension-fail/http-response.adoc[]
 
 === 팀 관련 기능
 ==== 팀 등록

--- a/src/main/java/com/cupid/jikting/member/controller/MemberController.java
+++ b/src/main/java/com/cupid/jikting/member/controller/MemberController.java
@@ -106,4 +106,10 @@ public class MemberController {
         memberService.resetPassword(passwordResetRequest);
         return ResponseEntity.ok().build();
     }
+
+    @PostMapping("/company/card")
+    public ResponseEntity<Void> verifyCardForCompany(@RequestPart CompanyVerificationRequest companyVerificationRequest, @RequestPart(value = "file") MultipartFile multipartFile) {
+        memberService.verifyCardForCompany(companyVerificationRequest, multipartFile);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/cupid/jikting/member/dto/CompanyVerificationRequest.java
+++ b/src/main/java/com/cupid/jikting/member/dto/CompanyVerificationRequest.java
@@ -1,0 +1,12 @@
+package com.cupid.jikting.member.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CompanyVerificationRequest {
+
+    private String company;
+}

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -57,4 +57,7 @@ public class MemberService {
 
     public void checkDuplicatedNickname(NicknameCheckRequest nicknameCheckRequest) {
     }
+
+    public void verifyCardForCompany(CompanyVerificationRequest companyVerificationRequest, MultipartFile multipartFile) {
+    }
 }

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -597,6 +597,16 @@ public class MemberControllerTest extends ApiDocument {
         회사_명함_인증_요청_파일형식미지원_실패(resultActions);
     }
 
+    @Test
+    void 회사_명함_인증_파일크기미지원_실패() throws Exception {
+        // given
+        willThrow(wrongFileSizeException).given(memberService).verifyCardForCompany(any(CompanyVerificationRequest.class), any(MultipartFile.class));
+        // when
+        ResultActions resultActions = 회사_명함_인증_요청();
+        // then
+        회사_명함_인증_요청_파일크기미지원_실패(resultActions);
+    }
+
     private ResultActions 회원_가입_요청() throws Exception {
         return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH)
                 .contextPath(CONTEXT_PATH)
@@ -977,5 +987,12 @@ public class MemberControllerTest extends ApiDocument {
                         .andExpect(status().isBadRequest())
                         .andExpect(content().json(toJson(ErrorResponse.from(wrongFileExtensionException)))),
                 "verify-company-card-invalid-file-extension-fail");
+    }
+
+    private void 회사_명함_인증_요청_파일크기미지원_실패(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isBadRequest())
+                        .andExpect(content().json(toJson(ErrorResponse.from(wrongFileSizeException)))),
+                "verify-company-card-invalid-file-size-fail");
     }
 }

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -587,6 +587,16 @@ public class MemberControllerTest extends ApiDocument {
         회사_명함_인증_요청_성공(resultActions);
     }
 
+    @Test
+    void 회사_명함_인증_파일형식미지원_실패() throws Exception {
+        // given
+        willThrow(wrongFileExtensionException).given(memberService).verifyCardForCompany(any(CompanyVerificationRequest.class), any(MultipartFile.class));
+        // when
+        ResultActions resultActions = 회사_명함_인증_요청();
+        // then
+        회사_명함_인증_요청_파일형식미지원_실패(resultActions);
+    }
+
     private ResultActions 회원_가입_요청() throws Exception {
         return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH)
                 .contextPath(CONTEXT_PATH)
@@ -960,5 +970,12 @@ public class MemberControllerTest extends ApiDocument {
         printAndMakeSnippet(resultActions
                         .andExpect(status().isOk()),
                 "verify-company-card-success");
+    }
+
+    private void 회사_명함_인증_요청_파일형식미지원_실패(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isBadRequest())
+                        .andExpect(content().json(toJson(ErrorResponse.from(wrongFileExtensionException)))),
+                "verify-company-card-invalid-file-extension-fail");
     }
 }


### PR DESCRIPTION
## Issue

closed #70 
[SP-107](https://soma-cupid.atlassian.net/browse/SP-107?atlOrigin=eyJpIjoiM2NkNzE2OWZjOGZhNGY5ZGI5NWI0ODFmZjU2ZDM4NzgiLCJwIjoiaiJ9)

## 요구사항

- [x] 회사 명함 인증 성공 API 명세서 작성
- [x] 회사 명함 인증 실패 API 명세서 작성

## 변경사항

- 회사 명함 인증 로직을 `MemberController` 및 `MemberService`에 추가
- 회사 명함 인증 요청 DTO `CompanyVerificationRequest` 추가
- `index.adoc` 회사 명함 인증 추가

## 리뷰 우선순위

🙂 보통

## 코멘트

- 회사 명함 인증 실패에 대한 케이스를 아래 두 가지로 나누어 작성했습니다.

    1. 회사 명함 이미지 파일 확장자 미지원
    2. 회사 명함 이미지 파일 크기 미지원

- 파일 업로드 MVC 테스트

    https://github.com/SWM-Cupid/jikting-backend/issues/70#issuecomment-1628328931

[SP-107]: https://soma-cupid.atlassian.net/browse/SP-107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ