### PR TITLE
[SP-131] 팀 삭제 API 명세서 작성

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -374,6 +374,12 @@ include::{snippets}/delete-team-success/http-request.adoc[]
 
 .response
 include::{snippets}/delete-team-success/http-response.adoc[]
+===== 실패
+.request
+include::{snippets}/delete-team-fail/http-request.adoc[]
+
+.response
+include::{snippets}/delete-team-fail/http-response.adoc[]
 
 === 추천 관련 기능
 ==== 추천 팀 조회

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -364,6 +364,17 @@ include::{snippets}/register-team-fail/http-request.adoc[]
 .response
 include::{snippets}/register-team-fail/http-response.adoc[]
 
+==== 팀 삭제
+----
+/api/v1/teams/{teamId}
+----
+===== 성공
+.request
+include::{snippets}/delete-team-success/http-request.adoc[]
+
+.response
+include::{snippets}/delete-team-success/http-response.adoc[]
+
 === 추천 관련 기능
 ==== 추천 팀 조회
 ----

--- a/src/main/java/com/cupid/jikting/team/controller/TeamController.java
+++ b/src/main/java/com/cupid/jikting/team/controller/TeamController.java
@@ -20,7 +20,7 @@ public class TeamController {
     }
 
     @DeleteMapping("/{teamId}")
-    public ResponseEntity<TeamRegisterResponse> delete(@PathVariable Long teamId) {
+    public ResponseEntity<Void> delete(@PathVariable Long teamId) {
         teamService.delete(teamId);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/cupid/jikting/team/controller/TeamController.java
+++ b/src/main/java/com/cupid/jikting/team/controller/TeamController.java
@@ -5,10 +5,7 @@ import com.cupid.jikting.team.dto.TeamRegisterResponse;
 import com.cupid.jikting.team.service.TeamService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
@@ -20,5 +17,11 @@ public class TeamController {
     @PostMapping
     public ResponseEntity<TeamRegisterResponse> register(@RequestBody TeamRegisterRequest teamRegisterRequest) {
         return ResponseEntity.ok().body(teamService.register(teamRegisterRequest));
+    }
+
+    @DeleteMapping("/{teamId}")
+    public ResponseEntity<TeamRegisterResponse> delete(@PathVariable Long teamId) {
+        teamService.delete(teamId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/cupid/jikting/team/service/TeamService.java
+++ b/src/main/java/com/cupid/jikting/team/service/TeamService.java
@@ -10,4 +10,7 @@ public class TeamService {
     public TeamRegisterResponse register(TeamRegisterRequest teamRegisterRequest) {
         return null;
     }
+
+    public void delete(Long teamId) {
+    }
 }

--- a/src/test/java/com/cupid/jikting/team/controller/TeamControllerTest.java
+++ b/src/test/java/com/cupid/jikting/team/controller/TeamControllerTest.java
@@ -91,6 +91,16 @@ public class TeamControllerTest extends ApiDocument {
         팀_삭제_요청_성공(resultActions);
     }
 
+    @Test
+    void 팀_삭제_실패() throws Exception {
+        // given
+        willThrow(teamNotFoundException).given(teamService).delete(anyLong());
+        // when
+        ResultActions resultActions = 팀_삭제_요청();
+        // then
+        팀_삭제_요청_실패(resultActions);
+    }
+
     private ResultActions 팀_등록_요청() throws Exception {
         return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH)
                 .contextPath(CONTEXT_PATH)
@@ -121,5 +131,12 @@ public class TeamControllerTest extends ApiDocument {
         printAndMakeSnippet(resultActions
                         .andExpect(status().isOk()),
                 "delete-team-success");
+    }
+
+    private void 팀_삭제_요청_실패(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isBadRequest())
+                        .andExpect(content().json(toJson(ErrorResponse.from(teamNotFoundException)))),
+                "delete-team-fail");
     }
 }

--- a/src/test/java/com/cupid/jikting/team/controller/TeamControllerTest.java
+++ b/src/test/java/com/cupid/jikting/team/controller/TeamControllerTest.java
@@ -20,8 +20,8 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.willReturn;
-import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -34,10 +34,13 @@ public class TeamControllerTest extends ApiDocument {
     private static final String KEYWORD = "키워드";
     private static final String DESCRIPTION = "한줄 소개";
     private static final String INVITATION_URL = "초대 URL";
+    private static final String PATH_DELIMITER = "/";
+    private static final Long ID = 1L;
 
     private TeamRegisterRequest teamRegisterRequest;
     private TeamRegisterResponse teamRegisterResponse;
     private ApplicationException invalidFormatException;
+    private ApplicationException teamNotFoundException;
 
     @MockBean
     private TeamService teamService;
@@ -55,6 +58,7 @@ public class TeamControllerTest extends ApiDocument {
                 .invitationUrl(INVITATION_URL)
                 .build();
         invalidFormatException = new BadRequestException(ApplicationError.INVALID_FORMAT);
+        teamNotFoundException = new BadRequestException(ApplicationError.TEAM_NOT_FOUND);
     }
 
     @Test
@@ -77,6 +81,16 @@ public class TeamControllerTest extends ApiDocument {
         팀_등록_요청_실패(resultActions);
     }
 
+    @Test
+    void 팀_삭제_성공() throws Exception {
+        // given
+        willDoNothing().given(teamService).delete(anyLong());
+        // when
+        ResultActions resultActions = 팀_삭제_요청();
+        // then
+        팀_삭제_요청_성공(resultActions);
+    }
+
     private ResultActions 팀_등록_요청() throws Exception {
         return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH)
                 .contextPath(CONTEXT_PATH)
@@ -96,5 +110,16 @@ public class TeamControllerTest extends ApiDocument {
                         .andExpect(status().isBadRequest())
                         .andExpect(content().json(toJson(ErrorResponse.from(invalidFormatException)))),
                 "register-team-fail");
+    }
+
+    private ResultActions 팀_삭제_요청() throws Exception {
+        return mockMvc.perform(delete(CONTEXT_PATH + DOMAIN_ROOT_PATH + PATH_DELIMITER + ID)
+                .contextPath(CONTEXT_PATH));
+    }
+
+    private void 팀_삭제_요청_성공(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isOk()),
+                "delete-team-success");
     }
 }


### PR DESCRIPTION
## Issue

closed #76 
[SP-131](https://soma-cupid.atlassian.net/browse/SP-131?atlOrigin=eyJpIjoiMDY1YjAxZTEyY2U3NGNlZWJiMjkwNmU5NWVjYTQxZDUiLCJwIjoiaiJ9)

## 요구사항

- [x] 팀 삭제 성공 API 명세서 작성
- [x] 팀 삭제 실패 API 명세서 작성

## 변경사항

- 팀 삭제 로직을 `TeamController` 및 `TeamService`에 추가
- `index.adoc` 팀 삭제 추가

## 리뷰 우선순위

🙂 보통

[SP-131]: https://soma-cupid.atlassian.net/browse/SP-131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ