### PR TITLE
[SP-132] 팀원 삭제 API 명세서 작성

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -374,6 +374,12 @@ include::{snippets}/delete-team-member-success/http-request.adoc[]
 
 .response
 include::{snippets}/delete-team-member-success/http-response.adoc[]
+===== 실패
+.request
+include::{snippets}/delete-team-member-not-found-team-fail/http-request.adoc[]
+
+.response - 팀을 찾을 수 없음
+include::{snippets}/delete-team-member-not-found-team-fail/http-response.adoc[]
 
 === 추천 관련 기능
 ==== 추천 팀 조회

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -364,6 +364,17 @@ include::{snippets}/register-team-fail/http-request.adoc[]
 .response
 include::{snippets}/register-team-fail/http-response.adoc[]
 
+==== 팀원 삭제
+----
+/api/v1/teams/{teamId}/members/{memberId}
+----
+===== 성공
+.request
+include::{snippets}/delete-team-member-success/http-request.adoc[]
+
+.response
+include::{snippets}/delete-team-member-success/http-response.adoc[]
+
 === 추천 관련 기능
 ==== 추천 팀 조회
 ----

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -381,6 +381,9 @@ include::{snippets}/delete-team-member-not-found-team-fail/http-request.adoc[]
 .response - 팀을 찾을 수 없음
 include::{snippets}/delete-team-member-not-found-team-fail/http-response.adoc[]
 
+.response - 회원을 찾을 수 없음
+include::{snippets}/delete-team-member-not-found-member-fail/http-response.adoc[]
+
 === 추천 관련 기능
 ==== 추천 팀 조회
 ----

--- a/src/main/java/com/cupid/jikting/team/controller/TeamController.java
+++ b/src/main/java/com/cupid/jikting/team/controller/TeamController.java
@@ -20,7 +20,7 @@ public class TeamController {
     }
 
     @DeleteMapping("/{teamId}/members/{memberId}")
-    public ResponseEntity<TeamRegisterResponse> deleteMember(@PathVariable Long teamId, @PathVariable Long memberId) {
+    public ResponseEntity<Void> deleteMember(@PathVariable Long teamId, @PathVariable Long memberId) {
         teamService.deleteMember(teamId, memberId);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/cupid/jikting/team/controller/TeamController.java
+++ b/src/main/java/com/cupid/jikting/team/controller/TeamController.java
@@ -5,10 +5,7 @@ import com.cupid.jikting.team.dto.TeamRegisterResponse;
 import com.cupid.jikting.team.service.TeamService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
@@ -20,5 +17,11 @@ public class TeamController {
     @PostMapping
     public ResponseEntity<TeamRegisterResponse> register(@RequestBody TeamRegisterRequest teamRegisterRequest) {
         return ResponseEntity.ok().body(teamService.register(teamRegisterRequest));
+    }
+
+    @DeleteMapping("/{teamId}/members/{memberId}")
+    public ResponseEntity<TeamRegisterResponse> deleteMember(@PathVariable Long teamId, @PathVariable Long memberId) {
+        teamService.deleteMember(teamId, memberId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/cupid/jikting/team/service/TeamService.java
+++ b/src/main/java/com/cupid/jikting/team/service/TeamService.java
@@ -10,4 +10,7 @@ public class TeamService {
     public TeamRegisterResponse register(TeamRegisterRequest teamRegisterRequest) {
         return null;
     }
+
+    public void deleteMember(Long teamId, Long memberId) {
+    }
 }

--- a/src/test/java/com/cupid/jikting/team/controller/TeamControllerTest.java
+++ b/src/test/java/com/cupid/jikting/team/controller/TeamControllerTest.java
@@ -41,6 +41,7 @@ public class TeamControllerTest extends ApiDocument {
     private TeamRegisterRequest teamRegisterRequest;
     private TeamRegisterResponse teamRegisterResponse;
     private ApplicationException invalidFormatException;
+    private ApplicationException teamNotFoundException;
 
     @MockBean
     private TeamService teamService;
@@ -58,6 +59,7 @@ public class TeamControllerTest extends ApiDocument {
                 .invitationUrl(INVITATION_URL)
                 .build();
         invalidFormatException = new BadRequestException(ApplicationError.INVALID_FORMAT);
+        teamNotFoundException = new BadRequestException(ApplicationError.TEAM_NOT_FOUND);
     }
 
     @Test
@@ -90,6 +92,16 @@ public class TeamControllerTest extends ApiDocument {
         팀원_삭제_요청_성공(resultActions);
     }
 
+    @Test
+    void 팀원_삭제_팀정보없음_실패() throws Exception {
+        // given
+        willThrow(teamNotFoundException).given(teamService).deleteMember(anyLong(), anyLong());
+        // when
+        ResultActions resultActions = 팀원_삭제_요청();
+        // then
+        팀원_삭제_요청_팀정보없음_실패(resultActions);
+    }
+
     private ResultActions 팀_등록_요청() throws Exception {
         return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH)
                 .contextPath(CONTEXT_PATH)
@@ -120,5 +132,12 @@ public class TeamControllerTest extends ApiDocument {
         printAndMakeSnippet(resultActions
                         .andExpect(status().isOk()),
                 "delete-team-member-success");
+    }
+
+    private void 팀원_삭제_요청_팀정보없음_실패(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isBadRequest())
+                        .andExpect(content().json(toJson(ErrorResponse.from(teamNotFoundException)))),
+                "delete-team-member-not-found-team-fail");
     }
 }

--- a/src/test/java/com/cupid/jikting/team/controller/TeamControllerTest.java
+++ b/src/test/java/com/cupid/jikting/team/controller/TeamControllerTest.java
@@ -42,6 +42,7 @@ public class TeamControllerTest extends ApiDocument {
     private TeamRegisterResponse teamRegisterResponse;
     private ApplicationException invalidFormatException;
     private ApplicationException teamNotFoundException;
+    private ApplicationException memberNotFoundException;
 
     @MockBean
     private TeamService teamService;
@@ -60,6 +61,7 @@ public class TeamControllerTest extends ApiDocument {
                 .build();
         invalidFormatException = new BadRequestException(ApplicationError.INVALID_FORMAT);
         teamNotFoundException = new BadRequestException(ApplicationError.TEAM_NOT_FOUND);
+        memberNotFoundException = new BadRequestException(ApplicationError.MEMBER_NOT_FOUND);
     }
 
     @Test
@@ -102,6 +104,16 @@ public class TeamControllerTest extends ApiDocument {
         팀원_삭제_요청_팀정보없음_실패(resultActions);
     }
 
+    @Test
+    void 팀원_삭제_회원정보없음_실패() throws Exception {
+        // given
+        willThrow(memberNotFoundException).given(teamService).deleteMember(anyLong(), anyLong());
+        // when
+        ResultActions resultActions = 팀원_삭제_요청();
+        // then
+        팀원_삭제_요청_회원정보없음_실패(resultActions);
+    }
+
     private ResultActions 팀_등록_요청() throws Exception {
         return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH)
                 .contextPath(CONTEXT_PATH)
@@ -139,5 +151,12 @@ public class TeamControllerTest extends ApiDocument {
                         .andExpect(status().isBadRequest())
                         .andExpect(content().json(toJson(ErrorResponse.from(teamNotFoundException)))),
                 "delete-team-member-not-found-team-fail");
+    }
+
+    private void 팀원_삭제_요청_회원정보없음_실패(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isBadRequest())
+                        .andExpect(content().json(toJson(ErrorResponse.from(memberNotFoundException)))),
+                "delete-team-member-not-found-member-fail");
     }
 }

--- a/src/test/java/com/cupid/jikting/team/controller/TeamControllerTest.java
+++ b/src/test/java/com/cupid/jikting/team/controller/TeamControllerTest.java
@@ -20,8 +20,9 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.willReturn;
-import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -31,9 +32,11 @@ public class TeamControllerTest extends ApiDocument {
 
     private static final String CONTEXT_PATH = "/api/v1";
     private static final String DOMAIN_ROOT_PATH = "/teams";
+    private static final String PATH_DELIMITER = "/";
     private static final String KEYWORD = "키워드";
     private static final String DESCRIPTION = "한줄 소개";
     private static final String INVITATION_URL = "초대 URL";
+    private static final Long ID = 1L;
 
     private TeamRegisterRequest teamRegisterRequest;
     private TeamRegisterResponse teamRegisterResponse;
@@ -77,6 +80,16 @@ public class TeamControllerTest extends ApiDocument {
         팀_등록_요청_실패(resultActions);
     }
 
+    @Test
+    void 팀원_삭제_성공() throws Exception {
+        // given
+        willDoNothing().given(teamService).deleteMember(anyLong(), anyLong());
+        // when
+        ResultActions resultActions = 팀원_삭제_요청();
+        // then
+        팀원_삭제_요청_성공(resultActions);
+    }
+
     private ResultActions 팀_등록_요청() throws Exception {
         return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH)
                 .contextPath(CONTEXT_PATH)
@@ -96,5 +109,16 @@ public class TeamControllerTest extends ApiDocument {
                         .andExpect(status().isBadRequest())
                         .andExpect(content().json(toJson(ErrorResponse.from(invalidFormatException)))),
                 "register-team-fail");
+    }
+
+    private ResultActions 팀원_삭제_요청() throws Exception {
+        return mockMvc.perform(delete(CONTEXT_PATH + DOMAIN_ROOT_PATH + PATH_DELIMITER + ID + "/members" + PATH_DELIMITER + ID)
+                .contextPath(CONTEXT_PATH));
+    }
+
+    private void 팀원_삭제_요청_성공(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isOk()),
+                "delete-team-member-success");
     }
 }


### PR DESCRIPTION
## Issue

closed #79
[SP-132](https://soma-cupid.atlassian.net/browse/SP-132?atlOrigin=eyJpIjoiNDQwN2FmOTRmMzQzNGY4ZGExNzgzMWQxNTYwMTc1YjciLCJwIjoiaiJ9)

## 요구사항

- [x] 팀원 삭제 성공 API 명세서 작성
- [x] 팀원 삭제 실패 API 명세서 작성

## 변경사항

- 팀원 삭제 로직을 `TeamController` 및 `TeamService`에 추가
- `index.adoc` 팀원 삭제 추가

## 리뷰 우선순위

🙂 보통

## 코멘트

팀원 삭제 실패에 대한 케이스를 아래 두 가지로 나누어 작성했습니다.

1. 팀원 삭제 요청을 한 팀의 정보를 찾을 수 없음
2. 팀원 삭제 요청을 한 회원의 정보를 찾을 수 없음

[SP-132]: https://soma-cupid.atlassian.net/browse/SP-132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ