### PR TITLE
[SP-125] 미팅 확정 API 명세서 작성

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -673,8 +673,11 @@ include::{snippets}/meeting-confirm-success/http-response.adoc[]
 .request
 include::{snippets}/meeting-confirm-fail/http-request.adoc[]
 
-.response
-include::{snippets}/meeting-confirm-fail/http-response.adoc[]
+.response - 잘못된 양식
+include::{snippets}/meeting-confirm-wrong-form-fail/http-response.adoc[]
+
+.response - 채팅방 정보를 찾을 수 없음
+include::{snippets}/meeting-confirm-chattingRoom-not-found-fail/http-response.adoc[]
 
 === 번개팅 관련 기능
 ==== 번개팅 목록 조회

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -659,6 +659,23 @@ include::{snippets}/get-chattings-success/http-request.adoc[]
 .response
 include::{snippets}/get-chattings-success/http-response.adoc[]
 
+==== 미팅 확정
+----
+/api/v1/chattings/{chattingId}/confirm
+----
+===== 성공
+.request
+include::{snippets}/meeting-confirm-success/http-request.adoc[]
+
+.response
+include::{snippets}/meeting-confirm-success/http-response.adoc[]
+===== 실패
+.request
+include::{snippets}/meeting-confirm-fail/http-request.adoc[]
+
+.response
+include::{snippets}/meeting-confirm-fail/http-response.adoc[]
+
 === 번개팅 관련 기능
 ==== 번개팅 목록 조회
 ----

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -677,7 +677,7 @@ include::{snippets}/meeting-confirm-fail/http-request.adoc[]
 include::{snippets}/meeting-confirm-wrong-form-fail/http-response.adoc[]
 
 .response - 채팅방 정보를 찾을 수 없음
-include::{snippets}/meeting-confirm-chattingRoom-not-found-fail/http-response.adoc[]
+include::{snippets}/meeting-confirm-chatting-room-not-found-fail/http-response.adoc[]
 
 === 번개팅 관련 기능
 ==== 번개팅 목록 조회

--- a/src/main/java/com/cupid/jikting/chatting/controller/ChattingController.java
+++ b/src/main/java/com/cupid/jikting/chatting/controller/ChattingController.java
@@ -4,9 +4,7 @@ import com.cupid.jikting.chatting.dto.ChattingResponse;
 import com.cupid.jikting.chatting.service.ChattingService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -20,5 +18,11 @@ public class ChattingController {
     @GetMapping
     public ResponseEntity<List<ChattingResponse>> getAll() {
         return ResponseEntity.ok().body(chattingService.getAll());
+    }
+
+    @PostMapping("/{chattingRoomId}/confirm")
+    public ResponseEntity<Void> confirm(@PathVariable Long chattingRoomId) {
+        chattingService.confirm(chattingRoomId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/cupid/jikting/chatting/controller/ChattingController.java
+++ b/src/main/java/com/cupid/jikting/chatting/controller/ChattingController.java
@@ -1,6 +1,6 @@
 package com.cupid.jikting.chatting.controller;
 
-import com.cupid.jikting.chatting.dto.ChattingResponse;
+import com.cupid.jikting.chatting.dto.ChattingRoomResponse;
 import com.cupid.jikting.chatting.service.ChattingService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -16,7 +16,7 @@ public class ChattingController {
     private final ChattingService chattingService;
 
     @GetMapping
-    public ResponseEntity<List<ChattingResponse>> getAll() {
+    public ResponseEntity<List<ChattingRoomResponse>> getAll() {
         return ResponseEntity.ok().body(chattingService.getAll());
     }
 

--- a/src/main/java/com/cupid/jikting/chatting/dto/ChattingResponse.java
+++ b/src/main/java/com/cupid/jikting/chatting/dto/ChattingResponse.java
@@ -10,7 +10,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChattingResponse {
 
-    private Long chattingId;
+    private Long chattingRoomId;
     private String opposingTeamName;
     private String lastMessage;
     private List<String> images;

--- a/src/main/java/com/cupid/jikting/chatting/dto/ChattingRoomResponse.java
+++ b/src/main/java/com/cupid/jikting/chatting/dto/ChattingRoomResponse.java
@@ -8,7 +8,7 @@ import java.util.List;
 @Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ChattingResponse {
+public class ChattingRoomResponse {
 
     private Long chattingRoomId;
     private String opposingTeamName;

--- a/src/main/java/com/cupid/jikting/chatting/dto/MeetingConfirmRequest.java
+++ b/src/main/java/com/cupid/jikting/chatting/dto/MeetingConfirmRequest.java
@@ -12,5 +12,5 @@ public class MeetingConfirmRequest {
 
     private Long meetingId;
     private String place;
-    private LocalDateTime dateTime;
+    private LocalDateTime schedule;
 }

--- a/src/main/java/com/cupid/jikting/chatting/dto/MeetingConfirmRequest.java
+++ b/src/main/java/com/cupid/jikting/chatting/dto/MeetingConfirmRequest.java
@@ -12,5 +12,5 @@ public class MeetingConfirmRequest {
 
     private Long meetingId;
     private String place;
-    private LocalDateTime date;
+    private LocalDateTime dateTime;
 }

--- a/src/main/java/com/cupid/jikting/chatting/dto/MeetingConfirmRequest.java
+++ b/src/main/java/com/cupid/jikting/chatting/dto/MeetingConfirmRequest.java
@@ -1,0 +1,16 @@
+package com.cupid.jikting.chatting.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MeetingConfirmRequest {
+
+    private Long meetingId;
+    private String place;
+    private LocalDateTime date;
+}

--- a/src/main/java/com/cupid/jikting/chatting/service/ChattingService.java
+++ b/src/main/java/com/cupid/jikting/chatting/service/ChattingService.java
@@ -11,4 +11,7 @@ public class ChattingService {
     public List<ChattingResponse> getAll() {
         return null;
     }
+
+    public void confirm(Long chattingRoomId) {
+    }
 }

--- a/src/main/java/com/cupid/jikting/chatting/service/ChattingService.java
+++ b/src/main/java/com/cupid/jikting/chatting/service/ChattingService.java
@@ -1,6 +1,6 @@
 package com.cupid.jikting.chatting.service;
 
-import com.cupid.jikting.chatting.dto.ChattingResponse;
+import com.cupid.jikting.chatting.dto.ChattingRoomResponse;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -8,7 +8,7 @@ import java.util.List;
 @Service
 public class ChattingService {
 
-    public List<ChattingResponse> getAll() {
+    public List<ChattingRoomResponse> getAll() {
         return null;
     }
 

--- a/src/test/java/com/cupid/jikting/chatting/controller/ChattingControllerTest.java
+++ b/src/test/java/com/cupid/jikting/chatting/controller/ChattingControllerTest.java
@@ -1,7 +1,7 @@
 package com.cupid.jikting.chatting.controller;
 
 import com.cupid.jikting.ApiDocument;
-import com.cupid.jikting.chatting.dto.ChattingResponse;
+import com.cupid.jikting.chatting.dto.ChattingRoomResponse;
 import com.cupid.jikting.chatting.dto.MeetingConfirmRequest;
 import com.cupid.jikting.chatting.service.ChattingService;
 import com.cupid.jikting.common.dto.ErrorResponse;
@@ -42,7 +42,7 @@ public class ChattingControllerTest extends ApiDocument {
     private static final String MESSAGE = "메시지";
 
     private MeetingConfirmRequest meetingConfirmRequest;
-    private List<ChattingResponse> chattingResponses;
+    private List<ChattingRoomResponse> chattingRoomResponses;
     private ApplicationException wrongFormException;
 
     @MockBean
@@ -58,8 +58,8 @@ public class ChattingControllerTest extends ApiDocument {
                 .place(PLACE)
                 .date(DATE)
                 .build();
-        chattingResponses = IntStream.rangeClosed(0, 2)
-                .mapToObj(n -> ChattingResponse.builder()
+        chattingRoomResponses = IntStream.rangeClosed(0, 2)
+                .mapToObj(n -> ChattingRoomResponse.builder()
                         .chattingRoomId(ID)
                         .opposingTeamName(TEAM_NAME)
                         .lastMessage(MESSAGE)
@@ -72,7 +72,7 @@ public class ChattingControllerTest extends ApiDocument {
     @Test
     void 채팅방_목록_조회_성공() throws Exception {
         //given
-        willReturn(chattingResponses).given(chattingService).getAll();
+        willReturn(chattingRoomResponses).given(chattingService).getAll();
         //when
         ResultActions resultActions = 채팅방_목록_조회_요청();
         //then
@@ -107,7 +107,7 @@ public class ChattingControllerTest extends ApiDocument {
     private void 채팅방_목록_조회_요청_성공(ResultActions resultActions) throws Exception {
         printAndMakeSnippet(resultActions
                         .andExpect(status().isOk())
-                        .andExpect(content().json(toJson(chattingResponses))),
+                        .andExpect(content().json(toJson(chattingRoomResponses))),
                 "get-chattings-success");
     }
 
@@ -120,8 +120,8 @@ public class ChattingControllerTest extends ApiDocument {
 
     private void 미팅_확정_요쳥_성공(ResultActions resultActions) throws Exception {
         printAndMakeSnippet(resultActions
-                        .andExpect(status().isOk())
-                , "meeting-confirm-success");
+                        .andExpect(status().isOk()),
+                "meeting-confirm-success");
     }
 
     private void 미팅_확정_요청_실패(ResultActions resultActions) throws Exception {

--- a/src/test/java/com/cupid/jikting/chatting/controller/ChattingControllerTest.java
+++ b/src/test/java/com/cupid/jikting/chatting/controller/ChattingControllerTest.java
@@ -56,7 +56,7 @@ public class ChattingControllerTest extends ApiDocument {
         meetingConfirmRequest = MeetingConfirmRequest.builder()
                 .meetingId(ID)
                 .place(PLACE)
-                .date(DATE)
+                .dateTime(DATE)
                 .build();
         chattingRoomResponses = IntStream.rangeClosed(0, 2)
                 .mapToObj(n -> ChattingRoomResponse.builder()

--- a/src/test/java/com/cupid/jikting/chatting/controller/ChattingControllerTest.java
+++ b/src/test/java/com/cupid/jikting/chatting/controller/ChattingControllerTest.java
@@ -58,7 +58,7 @@ public class ChattingControllerTest extends ApiDocument {
         meetingConfirmRequest = MeetingConfirmRequest.builder()
                 .meetingId(ID)
                 .place(PLACE)
-                .dateTime(DATE)
+                .schedule(DATE)
                 .build();
         chattingRoomResponses = IntStream.rangeClosed(0, 2)
                 .mapToObj(n -> ChattingRoomResponse.builder()

--- a/src/test/java/com/cupid/jikting/chatting/controller/ChattingControllerTest.java
+++ b/src/test/java/com/cupid/jikting/chatting/controller/ChattingControllerTest.java
@@ -2,19 +2,29 @@ package com.cupid.jikting.chatting.controller;
 
 import com.cupid.jikting.ApiDocument;
 import com.cupid.jikting.chatting.dto.ChattingResponse;
+import com.cupid.jikting.chatting.dto.MeetingConfirmRequest;
 import com.cupid.jikting.chatting.service.ChattingService;
+import com.cupid.jikting.common.dto.ErrorResponse;
+import com.cupid.jikting.common.error.ApplicationError;
+import com.cupid.jikting.common.error.ApplicationException;
+import com.cupid.jikting.common.error.WrongFormException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
+import java.time.LocalDateTime;
+import java.time.Month;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.mockito.BDDMockito.willReturn;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -23,12 +33,17 @@ public class ChattingControllerTest extends ApiDocument {
 
     private static final String CONTEXT_PATH = "/api/v1";
     private static final String DOMAIN_ROOT_PATH = "/chattings";
+    private static final String PATH_DELIMITER = "/";
     private static final String URL = "이미지 주소";
     private static final Long ID = 1L;
+    private static final String PLACE = "미팅장소";
+    private static final LocalDateTime DATE = LocalDateTime.of(2023, Month.JUNE, 30, 18, 0);
     private static final String TEAM_NAME = "팀이름";
     private static final String MESSAGE = "메시지";
 
+    private MeetingConfirmRequest meetingConfirmRequest;
     private List<ChattingResponse> chattingResponses;
+    private ApplicationException wrongFormException;
 
     @MockBean
     private ChattingService chattingService;
@@ -38,14 +53,20 @@ public class ChattingControllerTest extends ApiDocument {
         List<String> images = IntStream.rangeClosed(0, 2)
                 .mapToObj(n -> URL)
                 .collect(Collectors.toList());
+        meetingConfirmRequest = MeetingConfirmRequest.builder()
+                .meetingId(ID)
+                .place(PLACE)
+                .date(DATE)
+                .build();
         chattingResponses = IntStream.rangeClosed(0, 2)
                 .mapToObj(n -> ChattingResponse.builder()
-                        .chattingId(ID)
+                        .chattingRoomId(ID)
                         .opposingTeamName(TEAM_NAME)
                         .lastMessage(MESSAGE)
                         .images(images)
                         .build())
                 .collect(Collectors.toList());
+        wrongFormException = new WrongFormException(ApplicationError.INVALID_FORMAT);
     }
 
     @Test
@@ -58,6 +79,26 @@ public class ChattingControllerTest extends ApiDocument {
         채팅방_목록_조회_요청_성공(resultActions);
     }
 
+    @Test
+    void 미팅_확정_성공() throws Exception {
+        //given
+        willDoNothing().given(chattingService).confirm(anyLong());
+        //when
+        ResultActions resultActions = 미팅_확정_요청();
+        //then
+        미팅_확정_요쳥_성공(resultActions);
+    }
+
+    @Test
+    void 미팅_확정_실패() throws Exception {
+        //given
+        willThrow(wrongFormException).given(chattingService).confirm(anyLong());
+        //when
+        ResultActions resultActions = 미팅_확정_요청();
+        //then
+        미팅_확정_요청_실패(resultActions);
+    }
+
     private ResultActions 채팅방_목록_조회_요청() throws Exception {
         return mockMvc.perform(get(CONTEXT_PATH + DOMAIN_ROOT_PATH)
                 .contextPath(CONTEXT_PATH));
@@ -68,5 +109,25 @@ public class ChattingControllerTest extends ApiDocument {
                         .andExpect(status().isOk())
                         .andExpect(content().json(toJson(chattingResponses))),
                 "get-chattings-success");
+    }
+
+    private ResultActions 미팅_확정_요청() throws Exception {
+        return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH + PATH_DELIMITER + ID + "/confirm")
+                .contextPath(CONTEXT_PATH)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(toJson(meetingConfirmRequest)));
+    }
+
+    private void 미팅_확정_요쳥_성공(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isOk())
+                , "meeting-confirm-success");
+    }
+
+    private void 미팅_확정_요청_실패(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isBadRequest())
+                        .andExpect(content().json(toJson(ErrorResponse.from(wrongFormException)))),
+                "meeting-confirm-fail");
     }
 }

--- a/src/test/java/com/cupid/jikting/chatting/controller/ChattingControllerTest.java
+++ b/src/test/java/com/cupid/jikting/chatting/controller/ChattingControllerTest.java
@@ -148,6 +148,6 @@ public class ChattingControllerTest extends ApiDocument {
         printAndMakeSnippet(resultActions
                         .andExpect(status().isBadRequest())
                         .andExpect(content().json(toJson(ErrorResponse.from(chattingRoomNotFoundException)))),
-                "meeting-confirm-chattingRoom-not-found-fail");
+                "meeting-confirm-chatting-room-not-found-fail");
     }
 }


### PR DESCRIPTION
## Issue

closed #47
[SP-125](https://soma-cupid.atlassian.net/browse/SP-125?atlOrigin=eyJpIjoiMjEyOWMzMTFiYzc0NDdiNjgzMGU0YjRmYjc2NGMwZWYiLCJwIjoiaiJ9)

## 요구사항

- [x] 미팅 확정 성공 API 명세서 작성
- [x] 미팅 확정 실패 API 명세서 작성 

## 변경사항

- 미팅 확정 로직을 `ChattingController` 및 `ChattingService`에 추가
- 미팅 확정 요청 DTO `MeetingConfirmRequest` 추가
- `index.adoc` 미팅 확정 추가
- `ChattingResponse` chattingId -> chattingRoomId로 변경 

## 리뷰 우선순위

🙂보통 

## 코멘트

기능명세서에는 미팅 확정 요청에 meetingId로 되어있는데 chattingRoomId가 맞는 것 같아서 수정했습니다.



[SP-125]: https://soma-cupid.atlassian.net/browse/SP-125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ