### PR TITLE
[SP-124] 채팅방 입장 API 명세서 작성

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -659,6 +659,24 @@ include::{snippets}/get-chattings-success/http-request.adoc[]
 .response
 include::{snippets}/get-chattings-success/http-response.adoc[]
 
+==== 채팅방 입장
+----
+/api/v1/chattings/{chattingRoomId}
+----
+===== 성공
+.request
+include::{snippets}/chattingRoom-enter-success/http-request.adoc[]
+
+.response
+include::{snippets}/chattingRoom-enter-success/http-response.adoc[]
+
+===== 실패
+.request
+include::{snippets}/chattingRoom-enter-fail/http-request.adoc[]
+
+.response
+include::{snippets}/chattingRoom-enter-fail/http-response.adoc[]
+
 === 번개팅 관련 기능
 ==== 번개팅 목록 조회
 ----

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -665,17 +665,17 @@ include::{snippets}/get-chattings-success/http-response.adoc[]
 ----
 ===== 성공
 .request
-include::{snippets}/chattingRoom-enter-success/http-request.adoc[]
+include::{snippets}/chatting-room-enter-success/http-request.adoc[]
 
 .response
-include::{snippets}/chattingRoom-enter-success/http-response.adoc[]
+include::{snippets}/chatting-room-enter-success/http-response.adoc[]
 
 ===== 실패
 .request
-include::{snippets}/chattingRoom-enter-fail/http-request.adoc[]
+include::{snippets}/chatting-room-enter-fail/http-request.adoc[]
 
 .response
-include::{snippets}/chattingRoom-enter-fail/http-response.adoc[]
+include::{snippets}/chatting-room-enter-fail/http-response.adoc[]
 
 === 번개팅 관련 기능
 ==== 번개팅 목록 조회

--- a/src/main/java/com/cupid/jikting/chatting/controller/ChattingController.java
+++ b/src/main/java/com/cupid/jikting/chatting/controller/ChattingController.java
@@ -1,10 +1,12 @@
 package com.cupid.jikting.chatting.controller;
 
 import com.cupid.jikting.chatting.dto.ChattingResponse;
+import com.cupid.jikting.chatting.dto.ChattingRoomResponse;
 import com.cupid.jikting.chatting.service.ChattingService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,5 +22,10 @@ public class ChattingController {
     @GetMapping
     public ResponseEntity<List<ChattingResponse>> getAll() {
         return ResponseEntity.ok().body(chattingService.getAll());
+    }
+
+    @GetMapping("/{chattingRoomId}")
+    public ResponseEntity<ChattingRoomResponse> get(@PathVariable Long chattingRoomId) {
+        return ResponseEntity.ok().body(chattingService.get(chattingRoomId));
     }
 }

--- a/src/main/java/com/cupid/jikting/chatting/controller/ChattingController.java
+++ b/src/main/java/com/cupid/jikting/chatting/controller/ChattingController.java
@@ -1,7 +1,7 @@
 package com.cupid.jikting.chatting.controller;
 
 import com.cupid.jikting.chatting.dto.ChattingResponse;
-import com.cupid.jikting.chatting.dto.ChattingRoomResponse;
+import com.cupid.jikting.chatting.dto.ChattingRoomDetailResponse;
 import com.cupid.jikting.chatting.service.ChattingService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -25,7 +25,7 @@ public class ChattingController {
     }
 
     @GetMapping("/{chattingRoomId}")
-    public ResponseEntity<ChattingRoomResponse> get(@PathVariable Long chattingRoomId) {
+    public ResponseEntity<ChattingRoomDetailResponse> get(@PathVariable Long chattingRoomId) {
         return ResponseEntity.ok().body(chattingService.get(chattingRoomId));
     }
 }

--- a/src/main/java/com/cupid/jikting/chatting/dto/ChattingRoomDetailResponse.java
+++ b/src/main/java/com/cupid/jikting/chatting/dto/ChattingRoomDetailResponse.java
@@ -8,7 +8,7 @@ import java.util.List;
 @Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ChattingRoomResponse {
+public class ChattingRoomDetailResponse {
 
     private String description;
     private List<String> keywords;

--- a/src/main/java/com/cupid/jikting/chatting/dto/ChattingRoomResponse.java
+++ b/src/main/java/com/cupid/jikting/chatting/dto/ChattingRoomResponse.java
@@ -1,0 +1,16 @@
+package com.cupid.jikting.chatting.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChattingRoomResponse {
+
+    private String description;
+    private List<String> keywords;
+    private List<MemberResponse> members;
+}

--- a/src/main/java/com/cupid/jikting/chatting/dto/MemberResponse.java
+++ b/src/main/java/com/cupid/jikting/chatting/dto/MemberResponse.java
@@ -1,0 +1,14 @@
+package com.cupid.jikting.chatting.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberResponse {
+
+    private Long memberId;
+    private String image;
+    private String nickname;
+}

--- a/src/main/java/com/cupid/jikting/chatting/service/ChattingService.java
+++ b/src/main/java/com/cupid/jikting/chatting/service/ChattingService.java
@@ -1,6 +1,7 @@
 package com.cupid.jikting.chatting.service;
 
 import com.cupid.jikting.chatting.dto.ChattingResponse;
+import com.cupid.jikting.chatting.dto.ChattingRoomResponse;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -9,6 +10,10 @@ import java.util.List;
 public class ChattingService {
 
     public List<ChattingResponse> getAll() {
+        return null;
+    }
+
+    public ChattingRoomResponse get(Long chattingRoomId) {
         return null;
     }
 }

--- a/src/main/java/com/cupid/jikting/chatting/service/ChattingService.java
+++ b/src/main/java/com/cupid/jikting/chatting/service/ChattingService.java
@@ -1,7 +1,7 @@
 package com.cupid.jikting.chatting.service;
 
 import com.cupid.jikting.chatting.dto.ChattingResponse;
-import com.cupid.jikting.chatting.dto.ChattingRoomResponse;
+import com.cupid.jikting.chatting.dto.ChattingRoomDetailResponse;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -13,7 +13,7 @@ public class ChattingService {
         return null;
     }
 
-    public ChattingRoomResponse get(Long chattingRoomId) {
+    public ChattingRoomDetailResponse get(Long chattingRoomId) {
         return null;
     }
 }

--- a/src/test/java/com/cupid/jikting/chatting/controller/ChattingControllerTest.java
+++ b/src/test/java/com/cupid/jikting/chatting/controller/ChattingControllerTest.java
@@ -2,7 +2,13 @@ package com.cupid.jikting.chatting.controller;
 
 import com.cupid.jikting.ApiDocument;
 import com.cupid.jikting.chatting.dto.ChattingResponse;
+import com.cupid.jikting.chatting.dto.ChattingRoomResponse;
+import com.cupid.jikting.chatting.dto.MemberResponse;
 import com.cupid.jikting.chatting.service.ChattingService;
+import com.cupid.jikting.common.dto.ErrorResponse;
+import com.cupid.jikting.common.error.ApplicationError;
+import com.cupid.jikting.common.error.ApplicationException;
+import com.cupid.jikting.common.error.NotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -13,7 +19,9 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.willReturn;
+import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -23,12 +31,18 @@ public class ChattingControllerTest extends ApiDocument {
 
     private static final String CONTEXT_PATH = "/api/v1";
     private static final String DOMAIN_ROOT_PATH = "/chattings";
+    private static final String PATH_DELIMITER = "/";
     private static final String URL = "이미지 주소";
     private static final Long ID = 1L;
     private static final String TEAM_NAME = "팀이름";
     private static final String MESSAGE = "메시지";
+    private static final String DESCRIPTION = "팀소개";
+    private static final String KEYWORD = "키워드";
+    private static final String NICKNAME = "닉네임";
 
     private List<ChattingResponse> chattingResponses;
+    private ChattingRoomResponse chattingRoomResponse;
+    private ApplicationException chattingRoomNotFoundException;
 
     @MockBean
     private ChattingService chattingService;
@@ -38,6 +52,9 @@ public class ChattingControllerTest extends ApiDocument {
         List<String> images = IntStream.rangeClosed(0, 2)
                 .mapToObj(n -> URL)
                 .collect(Collectors.toList());
+        List<String> keywords = IntStream.rangeClosed(1, 3)
+                .mapToObj(n -> KEYWORD + n)
+                .collect(Collectors.toList());
         chattingResponses = IntStream.rangeClosed(0, 2)
                 .mapToObj(n -> ChattingResponse.builder()
                         .chattingId(ID)
@@ -46,6 +63,18 @@ public class ChattingControllerTest extends ApiDocument {
                         .images(images)
                         .build())
                 .collect(Collectors.toList());
+        chattingRoomResponse = ChattingRoomResponse.builder()
+                .description(DESCRIPTION)
+                .keywords(keywords)
+                .members(IntStream.rangeClosed(0, 2)
+                        .mapToObj(n -> MemberResponse.builder()
+                                .memberId(ID)
+                                .image(URL)
+                                .nickname(NICKNAME)
+                                .build())
+                        .collect(Collectors.toList()))
+                .build();
+        chattingRoomNotFoundException = new NotFoundException(ApplicationError.CHATTING_ROOM_NOT_FOUND);
     }
 
     @Test
@@ -58,6 +87,26 @@ public class ChattingControllerTest extends ApiDocument {
         채팅방_목록_조회_요청_성공(resultActions);
     }
 
+    @Test
+    void 채팅방_입장_성공() throws Exception {
+        //given
+        willReturn(chattingRoomResponse).given(chattingService).get(anyLong());
+        //when
+        ResultActions resultActions = 채팅방_입장_요청();
+        //then
+        채팅방_입장_요청_성공(resultActions);
+    }
+
+    @Test
+    void 채팅방_입장_실패() throws Exception {
+        //given
+        willThrow(chattingRoomNotFoundException).given(chattingService).get(anyLong());
+        //when
+        ResultActions resultActions = 채팅방_입장_요청();
+        //then
+        채팅방_입장_요청_실패(resultActions);
+    }
+
     private ResultActions 채팅방_목록_조회_요청() throws Exception {
         return mockMvc.perform(get(CONTEXT_PATH + DOMAIN_ROOT_PATH)
                 .contextPath(CONTEXT_PATH));
@@ -68,5 +117,24 @@ public class ChattingControllerTest extends ApiDocument {
                         .andExpect(status().isOk())
                         .andExpect(content().json(toJson(chattingResponses))),
                 "get-chattings-success");
+    }
+
+    private ResultActions 채팅방_입장_요청() throws Exception {
+        return mockMvc.perform(get(CONTEXT_PATH + DOMAIN_ROOT_PATH + PATH_DELIMITER + ID)
+                .contextPath(CONTEXT_PATH));
+    }
+
+    private void 채팅방_입장_요청_성공(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isOk())
+                        .andExpect(content().json(toJson(chattingRoomResponse))),
+                "chattingRoom-enter-success");
+    }
+
+    private void 채팅방_입장_요청_실패(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isBadRequest())
+                        .andExpect(content().json(toJson(ErrorResponse.from(chattingRoomNotFoundException)))),
+                "chattingRoom-enter-fail");
     }
 }

--- a/src/test/java/com/cupid/jikting/chatting/controller/ChattingControllerTest.java
+++ b/src/test/java/com/cupid/jikting/chatting/controller/ChattingControllerTest.java
@@ -2,7 +2,7 @@ package com.cupid.jikting.chatting.controller;
 
 import com.cupid.jikting.ApiDocument;
 import com.cupid.jikting.chatting.dto.ChattingResponse;
-import com.cupid.jikting.chatting.dto.ChattingRoomResponse;
+import com.cupid.jikting.chatting.dto.ChattingRoomDetailResponse;
 import com.cupid.jikting.chatting.dto.MemberResponse;
 import com.cupid.jikting.chatting.service.ChattingService;
 import com.cupid.jikting.common.dto.ErrorResponse;
@@ -41,7 +41,7 @@ public class ChattingControllerTest extends ApiDocument {
     private static final String NICKNAME = "닉네임";
 
     private List<ChattingResponse> chattingResponses;
-    private ChattingRoomResponse chattingRoomResponse;
+    private ChattingRoomDetailResponse chattingRoomDetailResponse;
     private ApplicationException chattingRoomNotFoundException;
 
     @MockBean
@@ -63,7 +63,7 @@ public class ChattingControllerTest extends ApiDocument {
                         .images(images)
                         .build())
                 .collect(Collectors.toList());
-        chattingRoomResponse = ChattingRoomResponse.builder()
+        chattingRoomDetailResponse = ChattingRoomDetailResponse.builder()
                 .description(DESCRIPTION)
                 .keywords(keywords)
                 .members(IntStream.rangeClosed(0, 2)
@@ -90,7 +90,7 @@ public class ChattingControllerTest extends ApiDocument {
     @Test
     void 채팅방_입장_성공() throws Exception {
         //given
-        willReturn(chattingRoomResponse).given(chattingService).get(anyLong());
+        willReturn(chattingRoomDetailResponse).given(chattingService).get(anyLong());
         //when
         ResultActions resultActions = 채팅방_입장_요청();
         //then
@@ -127,7 +127,7 @@ public class ChattingControllerTest extends ApiDocument {
     private void 채팅방_입장_요청_성공(ResultActions resultActions) throws Exception {
         printAndMakeSnippet(resultActions
                         .andExpect(status().isOk())
-                        .andExpect(content().json(toJson(chattingRoomResponse))),
+                        .andExpect(content().json(toJson(chattingRoomDetailResponse))),
                 "chattingRoom-enter-success");
     }
 

--- a/src/test/java/com/cupid/jikting/chatting/controller/ChattingControllerTest.java
+++ b/src/test/java/com/cupid/jikting/chatting/controller/ChattingControllerTest.java
@@ -128,13 +128,13 @@ public class ChattingControllerTest extends ApiDocument {
         printAndMakeSnippet(resultActions
                         .andExpect(status().isOk())
                         .andExpect(content().json(toJson(chattingRoomDetailResponse))),
-                "chattingRoom-enter-success");
+                "chatting-room-enter-success");
     }
 
     private void 채팅방_입장_요청_실패(ResultActions resultActions) throws Exception {
         printAndMakeSnippet(resultActions
                         .andExpect(status().isBadRequest())
                         .andExpect(content().json(toJson(ErrorResponse.from(chattingRoomNotFoundException)))),
-                "chattingRoom-enter-fail");
+                "chatting-room-enter-fail");
     }
 }


### PR DESCRIPTION
## Issue

closed #84 
[SP-124](https://soma-cupid.atlassian.net/browse/SP-124?atlOrigin=eyJpIjoiMDA2ZjdhMjE5MmQ2NDMyZmIzY2U1NjMzZmViNmE2MWQiLCJwIjoiaiJ9)

## 요구사항

- [x] 채팅방 입장 성공 API 명세서 작성
- [x] 채팅방 입장 실패 API 명세서 작성

## 변경사항

- 채팅방 입장 로직을 `ChattingController` 및 `ChattingService`에 추가
- 채팅방 입장 DTO `ChattingRoomResponse` 및 `MemberResponse` 추가
- `index.adoc` 채팅방 입장 추가
- `ChattingControllerTest` 채팅방 입장 추가

## 리뷰 우선순위

🙂보통


[SP-124]: https://soma-cupid.atlassian.net/browse/SP-124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ