### PR TITLE
[SP-139] 엔티티 생성

### DIFF
--- a/src/main/java/com/cupid/jikting/common/entity/BaseEntity.java
+++ b/src/main/java/com/cupid/jikting/common/entity/BaseEntity.java
@@ -1,0 +1,46 @@
+package com.cupid.jikting.common.entity;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.Where;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Getter
+@SuperBuilder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Where(clause = "isDeleted = false")
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public abstract class BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @CreatedBy
+    @Column(updatable = false)
+    private Long createdBy;
+
+    @LastModifiedDate
+    private LocalDateTime lastModifiedAt;
+
+    @LastModifiedBy
+    private Long lastModifiedBy;
+
+    private boolean isDeleted;
+}

--- a/src/main/java/com/cupid/jikting/common/entity/Hobby.java
+++ b/src/main/java/com/cupid/jikting/common/entity/Hobby.java
@@ -1,0 +1,29 @@
+package com.cupid.jikting.common.entity;
+
+import com.cupid.jikting.member.entity.MemberHobby;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLDelete;
+
+import javax.persistence.AttributeOverride;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@SuperBuilder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE hobby SET is_deleted = true WHERE hobby_id = ?")
+@AttributeOverride(name = "id", column = @Column(name = "hobby_id"))
+@Entity
+public class Hobby extends BaseEntity {
+
+    private String keyword;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "hobby")
+    private final List<MemberHobby> memberHobbies = new ArrayList<>();
+}

--- a/src/main/java/com/cupid/jikting/common/entity/Personality.java
+++ b/src/main/java/com/cupid/jikting/common/entity/Personality.java
@@ -1,0 +1,34 @@
+package com.cupid.jikting.common.entity;
+
+import com.cupid.jikting.member.entity.MemberPersonality;
+import com.cupid.jikting.team.entity.TeamPersonality;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLDelete;
+
+import javax.persistence.AttributeOverride;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@SuperBuilder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE personality SET is_deleted = true WHERE personality_id = ?")
+@AttributeOverride(name = "id", column = @Column(name = "personality_id"))
+@Entity
+public class Personality extends BaseEntity {
+
+    private String keyword;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "personality")
+    private final List<MemberPersonality> memberPersonalities = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "personality")
+    private final List<TeamPersonality> teamPersonalities = new ArrayList<>();
+}

--- a/src/main/java/com/cupid/jikting/config/JpaAuditingConfig.java
+++ b/src/main/java/com/cupid/jikting/config/JpaAuditingConfig.java
@@ -1,0 +1,10 @@
+package com.cupid.jikting.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaAuditingConfig {
+
+}

--- a/src/main/java/com/cupid/jikting/meeting/controller/InstantMeetingController.java
+++ b/src/main/java/com/cupid/jikting/meeting/controller/InstantMeetingController.java
@@ -1,7 +1,7 @@
-package com.cupid.jikting.instantmeeting.controller;
+package com.cupid.jikting.meeting.controller;
 
-import com.cupid.jikting.instantmeeting.dto.InstantMeetingResponse;
-import com.cupid.jikting.instantmeeting.service.InstantMeetingService;
+import com.cupid.jikting.meeting.dto.InstantMeetingResponse;
+import com.cupid.jikting.meeting.service.InstantMeetingService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/com/cupid/jikting/meeting/dto/InstantMeetingResponse.java
+++ b/src/main/java/com/cupid/jikting/meeting/dto/InstantMeetingResponse.java
@@ -1,4 +1,4 @@
-package com.cupid.jikting.instantmeeting.dto;
+package com.cupid.jikting.meeting.dto;
 
 import lombok.*;
 

--- a/src/main/java/com/cupid/jikting/meeting/entity/InstantMeeting.java
+++ b/src/main/java/com/cupid/jikting/meeting/entity/InstantMeeting.java
@@ -1,0 +1,32 @@
+package com.cupid.jikting.meeting.entity;
+
+import com.cupid.jikting.common.entity.BaseEntity;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLDelete;
+
+import javax.persistence.AttributeOverride;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.OneToMany;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@SuperBuilder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE instant_meeting SET is_deleted = true WHERE instant_meeting_id = ?")
+@AttributeOverride(name = "id", column = @Column(name = "instant_meeting_id"))
+@Entity
+public class InstantMeeting extends BaseEntity {
+
+    private LocalDateTime schedule;
+    private String place;
+    private int memberCount;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "instantMeeting")
+    private final List<InstantMeetingMember> instantMeetingMembers = new ArrayList<>();
+}

--- a/src/main/java/com/cupid/jikting/meeting/entity/InstantMeetingMember.java
+++ b/src/main/java/com/cupid/jikting/meeting/entity/InstantMeetingMember.java
@@ -1,0 +1,30 @@
+package com.cupid.jikting.meeting.entity;
+
+import com.cupid.jikting.common.entity.BaseEntity;
+import com.cupid.jikting.member.entity.MemberProfile;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLDelete;
+
+import javax.persistence.*;
+
+@Getter
+@SuperBuilder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE instant_meeting_member SET is_deleted = true WHERE instant_meeting_member_id = ?")
+@AttributeOverride(name = "id", column = @Column(name = "instant_meeting_member_id"))
+@Entity
+public class InstantMeetingMember extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_profile_id")
+    private MemberProfile memberProfile;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "instant_meeting_id")
+    private InstantMeeting instantMeeting;
+}

--- a/src/main/java/com/cupid/jikting/meeting/entity/Meeting.java
+++ b/src/main/java/com/cupid/jikting/meeting/entity/Meeting.java
@@ -1,0 +1,34 @@
+package com.cupid.jikting.meeting.entity;
+
+import com.cupid.jikting.common.entity.BaseEntity;
+import com.cupid.jikting.team.entity.Team;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLDelete;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Getter
+@SuperBuilder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE meeting SET is_deleted = true WHERE meeting_id = ?")
+@AttributeOverride(name = "id", column = @Column(name = "meeting_id"))
+@Entity
+public class Meeting extends BaseEntity {
+
+    private LocalDateTime schedule;
+    private String place;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recommended_team_id")
+    private Team recommendedTeam;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "acceptiong_team_id")
+    private Team acceptingTeam;
+}

--- a/src/main/java/com/cupid/jikting/meeting/service/InstantMeetingService.java
+++ b/src/main/java/com/cupid/jikting/meeting/service/InstantMeetingService.java
@@ -1,6 +1,6 @@
-package com.cupid.jikting.instantmeeting.service;
+package com.cupid.jikting.meeting.service;
 
-import com.cupid.jikting.instantmeeting.dto.InstantMeetingResponse;
+import com.cupid.jikting.meeting.dto.InstantMeetingResponse;
 import org.springframework.stereotype.Service;
 
 import java.util.List;

--- a/src/main/java/com/cupid/jikting/member/entity/Company.java
+++ b/src/main/java/com/cupid/jikting/member/entity/Company.java
@@ -1,16 +1,16 @@
 package com.cupid.jikting.member.entity;
 
 import com.cupid.jikting.common.entity.BaseEntity;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.SQLDelete;
 
 import javax.persistence.AttributeOverride;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @SuperBuilder

--- a/src/main/java/com/cupid/jikting/member/entity/Company.java
+++ b/src/main/java/com/cupid/jikting/member/entity/Company.java
@@ -1,0 +1,34 @@
+package com.cupid.jikting.member.entity;
+
+import com.cupid.jikting.common.entity.BaseEntity;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLDelete;
+
+import javax.persistence.AttributeOverride;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+
+@Getter
+@SuperBuilder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE company SET is_deleted = true WHERE company_id = ?")
+@AttributeOverride(name = "id", column = @Column(name = "company_id"))
+@Entity
+public class Company extends BaseEntity {
+
+    private String name;
+    private String email;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "company")
+    private final List<MemberCompany> memberCompanies = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "company")
+    private final List<MemberCertification> memberCertifications = new ArrayList<>();
+}

--- a/src/main/java/com/cupid/jikting/member/entity/Company.java
+++ b/src/main/java/com/cupid/jikting/member/entity/Company.java
@@ -27,8 +27,4 @@ public class Company extends BaseEntity {
     @Builder.Default
     @OneToMany(mappedBy = "company")
     private final List<MemberCompany> memberCompanies = new ArrayList<>();
-
-    @Builder.Default
-    @OneToMany(mappedBy = "company")
-    private final List<MemberCertification> memberCertifications = new ArrayList<>();
 }

--- a/src/main/java/com/cupid/jikting/member/entity/DrinkStatus.java
+++ b/src/main/java/com/cupid/jikting/member/entity/DrinkStatus.java
@@ -1,0 +1,16 @@
+package com.cupid.jikting.member.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum DrinkStatus {
+
+    NEVER("전혀 마시지 않음"),
+    RARELY("거의 마시지 않음"),
+    OFTEN("가끔 마심"),
+    USUALLY("자주 마심");
+
+    private final String value;
+}

--- a/src/main/java/com/cupid/jikting/member/entity/Gender.java
+++ b/src/main/java/com/cupid/jikting/member/entity/Gender.java
@@ -1,0 +1,6 @@
+package com.cupid.jikting.member.entity;
+
+public enum Gender {
+
+    MALE, FEMALE
+}

--- a/src/main/java/com/cupid/jikting/member/entity/MBTI.java
+++ b/src/main/java/com/cupid/jikting/member/entity/MBTI.java
@@ -1,0 +1,7 @@
+package com.cupid.jikting.member.entity;
+
+public enum MBTI {
+
+    ISTJ, ISTP, ISFJ, ISFP, INTJ, INTP, INFJ, INFP,
+    ESTJ, ESTP, ESFJ, ESFP, ENTJ, ENTP, ENFJ, ENFP
+}

--- a/src/main/java/com/cupid/jikting/member/entity/Member.java
+++ b/src/main/java/com/cupid/jikting/member/entity/Member.java
@@ -19,6 +19,13 @@ import java.util.List;
 @Entity
 public class Member extends BaseEntity {
 
+    private String username;
+    private String password;
+    private String phone;
+    private String name;
+    private String type;
+    private Gender gender;
+
     @Builder.Default
     @OneToMany(mappedBy = "member")
     private final List<MemberCompany> memberCompanies = new ArrayList<>();
@@ -26,11 +33,4 @@ public class Member extends BaseEntity {
     @Builder.Default
     @OneToMany(mappedBy = "member")
     private final List<MemberCertification> memberCertifications = new ArrayList<>();
-
-    private String username;
-    private String password;
-    private String phone;
-    private String name;
-    private String type;
-    private Gender gender;
 }

--- a/src/main/java/com/cupid/jikting/member/entity/Member.java
+++ b/src/main/java/com/cupid/jikting/member/entity/Member.java
@@ -4,10 +4,7 @@ import com.cupid.jikting.common.entity.BaseEntity;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 
-import javax.persistence.AttributeOverride;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.OneToMany;
+import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -24,6 +21,8 @@ public class Member extends BaseEntity {
     private String phone;
     private String name;
     private String type;
+
+    @Enumerated(EnumType.STRING)
     private Gender gender;
 
     @Builder.Default

--- a/src/main/java/com/cupid/jikting/member/entity/Member.java
+++ b/src/main/java/com/cupid/jikting/member/entity/Member.java
@@ -1,0 +1,36 @@
+package com.cupid.jikting.member.entity;
+
+import com.cupid.jikting.common.entity.BaseEntity;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import javax.persistence.AttributeOverride;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@SuperBuilder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AttributeOverride(name = "id", column = @Column(name = "member_id"))
+@Entity
+public class Member extends BaseEntity {
+
+    @Builder.Default
+    @OneToMany(mappedBy = "member")
+    private final List<MemberCompany> memberCompanies = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "member")
+    private final List<MemberCertification> memberCertifications = new ArrayList<>();
+
+    private String username;
+    private String password;
+    private String phone;
+    private String name;
+    private String type;
+    private Gender gender;
+}

--- a/src/main/java/com/cupid/jikting/member/entity/MemberCertification.java
+++ b/src/main/java/com/cupid/jikting/member/entity/MemberCertification.java
@@ -1,0 +1,31 @@
+package com.cupid.jikting.member.entity;
+
+import com.cupid.jikting.common.entity.BaseEntity;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLDelete;
+
+import javax.persistence.*;
+
+@Getter
+@SuperBuilder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE member_certification SET is_deleted = true WHERE member_certification_id = ?")
+@AttributeOverride(name = "id", column = @Column(name = "member_certification_id"))
+@Entity
+public class MemberCertification extends BaseEntity {
+
+    private String companyCard;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "company_id")
+    private Company company;
+}

--- a/src/main/java/com/cupid/jikting/member/entity/MemberCompany.java
+++ b/src/main/java/com/cupid/jikting/member/entity/MemberCompany.java
@@ -1,0 +1,29 @@
+package com.cupid.jikting.member.entity;
+
+import com.cupid.jikting.common.entity.BaseEntity;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLDelete;
+
+import javax.persistence.*;
+
+@Getter
+@SuperBuilder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE member_company SET is_deleted = true WHERE member_company_id = ?")
+@AttributeOverride(name = "id", column = @Column(name = "member_company_id"))
+@Entity
+public class MemberCompany extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "company_id")
+    private Company company;
+}

--- a/src/main/java/com/cupid/jikting/member/entity/MemberHobby.java
+++ b/src/main/java/com/cupid/jikting/member/entity/MemberHobby.java
@@ -1,0 +1,30 @@
+package com.cupid.jikting.member.entity;
+
+import com.cupid.jikting.common.entity.BaseEntity;
+import com.cupid.jikting.common.entity.Hobby;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLDelete;
+
+import javax.persistence.*;
+
+@Getter
+@SuperBuilder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE member_hobby SET is_deleted = true WHERE member_hobby_id = ?")
+@AttributeOverride(name = "id", column = @Column(name = "member_hobby_id"))
+@Entity
+public class MemberHobby extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_profile_id")
+    private MemberProfile memberProfile;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "hobby_id")
+    private Hobby hobby;
+}

--- a/src/main/java/com/cupid/jikting/member/entity/MemberPersonality.java
+++ b/src/main/java/com/cupid/jikting/member/entity/MemberPersonality.java
@@ -1,0 +1,30 @@
+package com.cupid.jikting.member.entity;
+
+import com.cupid.jikting.common.entity.BaseEntity;
+import com.cupid.jikting.common.entity.Personality;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLDelete;
+
+import javax.persistence.*;
+
+@Getter
+@SuperBuilder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE member_personality SET is_deleted = true WHERE member_personality_id = ?")
+@AttributeOverride(name = "id", column = @Column(name = "member_personality_id"))
+@Entity
+public class MemberPersonality extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_profile_id")
+    private MemberProfile memberProfile;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "personality_id")
+    private Personality personality;
+}

--- a/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
+++ b/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
@@ -36,5 +36,17 @@ public class MemberProfile extends BaseEntity {
 
     @Builder.Default
     @OneToMany(mappedBy = "memberProfile")
+    private final List<ProfileImage> profileImages = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "memberProfile")
+    private final List<MemberPersonality> memberPersonalities = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "memberProfile")
+    private final List<MemberHobby> memberHobbies = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "memberProfile")
     private final List<InstantMeetingMember> instantMeetingMembers = new ArrayList<>();
 }

--- a/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
+++ b/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
@@ -1,0 +1,40 @@
+package com.cupid.jikting.member.entity;
+
+import com.cupid.jikting.common.entity.BaseEntity;
+import com.cupid.jikting.meeting.entity.InstantMeetingMember;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLDelete;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@SuperBuilder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE member_profile SET is_deleted = true WHERE id = ?")
+@AttributeOverride(name = "id", column = @Column(name = "member_id"))
+@Entity
+public class MemberProfile extends BaseEntity {
+
+    private String nickname;
+    private String birth;
+    private Gender gender;
+    private int height;
+    private MBTI mbti;
+    private String address;
+    private SmokeStatus smokeStatus;
+    private DrinkStatus drinkStatus;
+    private String description;
+    private String school;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "memberProfile")
+    private final List<InstantMeetingMember> instantMeetingMembers = new ArrayList<>();
+}

--- a/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
+++ b/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
@@ -22,14 +22,22 @@ public class MemberProfile extends BaseEntity {
 
     private String nickname;
     private String birth;
-    private Gender gender;
     private int height;
-    private MBTI mbti;
     private String address;
-    private SmokeStatus smokeStatus;
-    private DrinkStatus drinkStatus;
     private String description;
     private String school;
+
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
+
+    @Enumerated(EnumType.STRING)
+    private MBTI mbti;
+
+    @Enumerated(EnumType.STRING)
+    private SmokeStatus smokeStatus;
+
+    @Enumerated(EnumType.STRING)
+    private DrinkStatus drinkStatus;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")

--- a/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
+++ b/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
@@ -2,6 +2,7 @@ package com.cupid.jikting.member.entity;
 
 import com.cupid.jikting.common.entity.BaseEntity;
 import com.cupid.jikting.meeting.entity.InstantMeetingMember;
+import com.cupid.jikting.team.entity.TeamMember;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.SQLDelete;
@@ -45,6 +46,10 @@ public class MemberProfile extends BaseEntity {
     @Builder.Default
     @OneToMany(mappedBy = "memberProfile")
     private final List<MemberHobby> memberHobbies = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "memberProfile")
+    private final List<TeamMember> teamMembers = new ArrayList<>();
 
     @Builder.Default
     @OneToMany(mappedBy = "memberProfile")

--- a/src/main/java/com/cupid/jikting/member/entity/ProfileImage.java
+++ b/src/main/java/com/cupid/jikting/member/entity/ProfileImage.java
@@ -20,6 +20,8 @@ import javax.persistence.*;
 public class ProfileImage extends BaseEntity {
 
     private String url;
+
+    @Enumerated(EnumType.STRING)
     private Sequence sequence;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/cupid/jikting/member/entity/ProfileImage.java
+++ b/src/main/java/com/cupid/jikting/member/entity/ProfileImage.java
@@ -1,0 +1,28 @@
+package com.cupid.jikting.member.entity;
+
+import com.cupid.jikting.common.entity.BaseEntity;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLDelete;
+
+import javax.persistence.*;
+
+@Getter
+@SuperBuilder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE profile_image SET is_deleted = true WHERE profile_image_id = ?")
+@AttributeOverride(name = "id", column = @Column(name = "profile_image_id"))
+@Entity
+public class ProfileImage extends BaseEntity {
+
+    private String url;
+    private Sequence sequence;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_profile_id")
+    private MemberProfile memberProfile;
+}

--- a/src/main/java/com/cupid/jikting/member/entity/Sequence.java
+++ b/src/main/java/com/cupid/jikting/member/entity/Sequence.java
@@ -1,0 +1,6 @@
+package com.cupid.jikting.member.entity;
+
+public enum Sequence {
+
+    MAIN, FIRST, SECOND
+}

--- a/src/main/java/com/cupid/jikting/member/entity/SmokeStatus.java
+++ b/src/main/java/com/cupid/jikting/member/entity/SmokeStatus.java
@@ -1,0 +1,14 @@
+package com.cupid.jikting.member.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SmokeStatus {
+
+    NONSMOKING("비흡연"),
+    SMOKING("흡연");
+
+    private final String value;
+}

--- a/src/main/java/com/cupid/jikting/recommend/entity/Recommend.java
+++ b/src/main/java/com/cupid/jikting/recommend/entity/Recommend.java
@@ -1,0 +1,30 @@
+package com.cupid.jikting.recommend.entity;
+
+import com.cupid.jikting.common.entity.BaseEntity;
+import com.cupid.jikting.team.entity.Team;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLDelete;
+
+import javax.persistence.*;
+
+@Getter
+@SuperBuilder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE recommend SET is_deleted = true WHERE recommend_id = ?")
+@AttributeOverride(name = "id", column = @Column(name = "recommend_id"))
+@Entity
+public class Recommend extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "from_team_id")
+    private Team from;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "to_team_id")
+    private Team to;
+}

--- a/src/main/java/com/cupid/jikting/team/entity/AcceptStatus.java
+++ b/src/main/java/com/cupid/jikting/team/entity/AcceptStatus.java
@@ -1,0 +1,6 @@
+package com.cupid.jikting.team.entity;
+
+public enum AcceptStatus {
+
+    INITIAL, ACCEPT, REJECT
+}

--- a/src/main/java/com/cupid/jikting/team/entity/Team.java
+++ b/src/main/java/com/cupid/jikting/team/entity/Team.java
@@ -1,0 +1,44 @@
+package com.cupid.jikting.team.entity;
+
+import com.cupid.jikting.common.entity.BaseEntity;
+import com.cupid.jikting.meeting.entity.Meeting;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLDelete;
+
+import javax.persistence.AttributeOverride;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@SuperBuilder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE team SET is_deleted = true WHERE team_id = ?")
+@AttributeOverride(name = "id", column = @Column(name = "team_id"))
+@Entity
+public class Team extends BaseEntity {
+
+    private String name;
+    private String description;
+    private int memberCount;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "team")
+    private final List<TeamPersonality> teamPersonalities = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "team")
+    private final List<TeamMember> teamMembers = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "recommendedTeam")
+    private final List<Meeting> recommendedMeetings = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "acceptingTeam")
+    private final List<Meeting> acceptingMeetings = new ArrayList<>();
+}

--- a/src/main/java/com/cupid/jikting/team/entity/Team.java
+++ b/src/main/java/com/cupid/jikting/team/entity/Team.java
@@ -35,6 +35,14 @@ public class Team extends BaseEntity {
     private final List<TeamMember> teamMembers = new ArrayList<>();
 
     @Builder.Default
+    @OneToMany(mappedBy = "receivedTeam")
+    private final List<TeamLike> receivedTeamLikes = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "sentTeam")
+    private final List<TeamLike> sentTeamLikes = new ArrayList<>();
+
+    @Builder.Default
     @OneToMany(mappedBy = "recommendedTeam")
     private final List<Meeting> recommendedMeetings = new ArrayList<>();
 

--- a/src/main/java/com/cupid/jikting/team/entity/Team.java
+++ b/src/main/java/com/cupid/jikting/team/entity/Team.java
@@ -2,6 +2,7 @@ package com.cupid.jikting.team.entity;
 
 import com.cupid.jikting.common.entity.BaseEntity;
 import com.cupid.jikting.meeting.entity.Meeting;
+import com.cupid.jikting.recommend.entity.Recommend;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.SQLDelete;
@@ -41,6 +42,14 @@ public class Team extends BaseEntity {
     @Builder.Default
     @OneToMany(mappedBy = "sentTeam")
     private final List<TeamLike> sentTeamLikes = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "from")
+    private final List<Recommend> recommendsFrom = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "to")
+    private final List<Recommend> recommendsTo = new ArrayList<>();
 
     @Builder.Default
     @OneToMany(mappedBy = "recommendedTeam")

--- a/src/main/java/com/cupid/jikting/team/entity/TeamLike.java
+++ b/src/main/java/com/cupid/jikting/team/entity/TeamLike.java
@@ -19,6 +19,7 @@ import javax.persistence.*;
 @Entity
 public class TeamLike extends BaseEntity {
 
+    @Enumerated(EnumType.STRING)
     private AcceptStatus acceptStatus;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/cupid/jikting/team/entity/TeamLike.java
+++ b/src/main/java/com/cupid/jikting/team/entity/TeamLike.java
@@ -1,0 +1,31 @@
+package com.cupid.jikting.team.entity;
+
+import com.cupid.jikting.common.entity.BaseEntity;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLDelete;
+
+import javax.persistence.*;
+
+@Getter
+@SuperBuilder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE team_like SET is_deleted = true WHERE team_like_id = ?")
+@AttributeOverride(name = "id", column = @Column(name = "team_Like_id"))
+@Entity
+public class TeamLike extends BaseEntity {
+
+    private AcceptStatus acceptStatus;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "received_team_id")
+    private Team receivedTeam;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sent_team_id")
+    private Team sentTeam;
+}

--- a/src/main/java/com/cupid/jikting/team/entity/TeamMember.java
+++ b/src/main/java/com/cupid/jikting/team/entity/TeamMember.java
@@ -1,0 +1,32 @@
+package com.cupid.jikting.team.entity;
+
+import com.cupid.jikting.common.entity.BaseEntity;
+import com.cupid.jikting.member.entity.MemberProfile;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLDelete;
+
+import javax.persistence.*;
+
+@Getter
+@SuperBuilder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE team_member SET is_deleted = true WHERE team_member_id = ?")
+@AttributeOverride(name = "id", column = @Column(name = "team_member__id"))
+@Entity
+public class TeamMember extends BaseEntity {
+
+    private boolean isLeader;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id")
+    private Team team;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_profile_id")
+    private MemberProfile memberProfile;
+}

--- a/src/main/java/com/cupid/jikting/team/entity/TeamPersonality.java
+++ b/src/main/java/com/cupid/jikting/team/entity/TeamPersonality.java
@@ -1,0 +1,30 @@
+package com.cupid.jikting.team.entity;
+
+import com.cupid.jikting.common.entity.BaseEntity;
+import com.cupid.jikting.common.entity.Personality;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLDelete;
+
+import javax.persistence.*;
+
+@Getter
+@SuperBuilder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE team_personality SET is_deleted = true WHERE team_personality_id = ?")
+@AttributeOverride(name = "id", column = @Column(name = "team_personality_id"))
+@Entity
+public class TeamPersonality extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id")
+    private Team team;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "personality_id")
+    private Personality personality;
+}

--- a/src/test/java/com/cupid/jikting/meeting/controller/InstantMeetingControllerTest.java
+++ b/src/test/java/com/cupid/jikting/meeting/controller/InstantMeetingControllerTest.java
@@ -1,12 +1,12 @@
-package com.cupid.jikting.instantmeeting.controller;
+package com.cupid.jikting.meeting.controller;
 
 import com.cupid.jikting.ApiDocument;
 import com.cupid.jikting.common.dto.ErrorResponse;
 import com.cupid.jikting.common.error.ApplicationError;
 import com.cupid.jikting.common.error.ApplicationException;
 import com.cupid.jikting.common.error.BadRequestException;
-import com.cupid.jikting.instantmeeting.dto.InstantMeetingResponse;
-import com.cupid.jikting.instantmeeting.service.InstantMeetingService;
+import com.cupid.jikting.meeting.dto.InstantMeetingResponse;
+import com.cupid.jikting.meeting.service.InstantMeetingService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;


### PR DESCRIPTION
## Issue

closed #86 
[SP-139](https://soma-cupid.atlassian.net/browse/SP-139?atlOrigin=eyJpIjoiODBlNjllM2I0MzMzNDE2ZWE5YzE2NWY0MDBhYzE0ODgiLCJwIjoiaiJ9)

## 요구사항

- [x] 엔티티 생성

## 변경사항

- `BaseEntity` 추가
- `JpaAuditingConfig` 추가
- `Member` 추가
- `Gender` 추가
- `MemberCompany` 추가
- `Company` 추가
- `MemberCertification` 추가
- `MemberProfile` 추가
- `MBTI` 추가
- `SmokeStatus` 추가
- `DrinkStatus` 추가
- `InstantMeetingMember` 추가
- `InstantMeeting` 추가
- `ProfileImage` 추가
- `MemberHobby` 추가
- `Hobby` 추가
- `MemberPersonality` 추가
- `Personality` 추가
- `Sequence` 추가
- `TeamPersonality` 추가
- `TeamMember` 추가
- `Team` 추가
- `TeamLike` 추가
- `Meeting` 추가
- `AcceptStatus` 추가
- `Recommend` 추가

## 리뷰 우선순위

🙂보통

## 코멘트

- 아래 ERD를 참고해서 추가했습니다. 빠진 부분 있으면 코멘트 남겨주세요!

    ![jikting v5 0](https://github.com/SWM-Cupid/jikting-backend/assets/62989828/d24e8454-7653-45bf-b037-f5d14bab4df4)

- 채팅 관련 엔티티는 추가하지 않았습니다.

[SP-139]: https://soma-cupid.atlassian.net/browse/SP-139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ