### PR TITLE
[SP-157] 채팅 메시지 전송 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ ext {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/cupid/jikting/chatting/config/WebSocketConfig.java
+++ b/src/main/java/com/cupid/jikting/chatting/config/WebSocketConfig.java
@@ -1,0 +1,24 @@
+package com.cupid.jikting.chatting.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@EnableWebSocketMessageBroker
+@Configuration
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/chattings")
+                .setAllowedOrigins("*");
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/subscription");
+        registry.setApplicationDestinationPrefixes("/publication");
+    }
+}

--- a/src/main/java/com/cupid/jikting/chatting/controller/ChattingController.java
+++ b/src/main/java/com/cupid/jikting/chatting/controller/ChattingController.java
@@ -17,7 +17,7 @@ public class ChattingController {
     private final SimpMessagingTemplate simpMessagingTemplate;
     private final ChattingService chattingService;
 
-    @MessageMapping("/chattings/room/{chattingRoomId}/messages")
+    @MessageMapping("/chattings/rooms/{chattingRoomId}/messages")
     public void send(@DestinationVariable Long chattingRoomId, ChattingRequest chattingRequest) {
         simpMessagingTemplate.convertAndSend("/subscription/room/" + chattingRoomId, chattingRequest.getContent());
         chattingService.sendMessage(chattingRoomId, chattingRequest);

--- a/src/main/java/com/cupid/jikting/chatting/controller/ChattingController.java
+++ b/src/main/java/com/cupid/jikting/chatting/controller/ChattingController.java
@@ -19,7 +19,7 @@ public class ChattingController {
 
     @MessageMapping("/chattings/rooms/{chattingRoomId}/messages")
     public void send(@DestinationVariable Long chattingRoomId, ChattingRequest chattingRequest) {
-        simpMessagingTemplate.convertAndSend("/subscription/room/" + chattingRoomId, chattingRequest.getContent());
+        simpMessagingTemplate.convertAndSend("/subscription/rooms/" + chattingRoomId, chattingRequest.getContent());
         chattingService.sendMessage(chattingRoomId, chattingRequest);
         log.info("Message [{}] send by member: {} to chatting room: {}", chattingRequest.getContent(), chattingRequest.getSenderId(), chattingRoomId);
     }

--- a/src/main/java/com/cupid/jikting/chatting/controller/ChattingController.java
+++ b/src/main/java/com/cupid/jikting/chatting/controller/ChattingController.java
@@ -1,34 +1,26 @@
 package com.cupid.jikting.chatting.controller;
 
-import com.cupid.jikting.chatting.dto.ChattingRoomDetailResponse;
-import com.cupid.jikting.chatting.dto.ChattingRoomResponse;
+import com.cupid.jikting.chatting.dto.ChattingRequest;
 import com.cupid.jikting.chatting.service.ChattingService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
 
-import java.util.List;
-
+@Slf4j
 @RequiredArgsConstructor
-@RestController
-@RequestMapping("/chattings")
+@Controller
 public class ChattingController {
 
+    private final SimpMessagingTemplate simpMessagingTemplate;
     private final ChattingService chattingService;
 
-    @GetMapping
-    public ResponseEntity<List<ChattingRoomResponse>> getAll() {
-        return ResponseEntity.ok().body(chattingService.getAll());
-    }
-
-    @GetMapping("/{chattingRoomId}")
-    public ResponseEntity<ChattingRoomDetailResponse> get(@PathVariable Long chattingRoomId) {
-        return ResponseEntity.ok().body(chattingService.get(chattingRoomId));
-    }
-
-    @PostMapping("/{chattingRoomId}/confirm")
-    public ResponseEntity<Void> confirm(@PathVariable Long chattingRoomId) {
-        chattingService.confirm(chattingRoomId);
-        return ResponseEntity.ok().build();
+    @MessageMapping("/chattings/room/{chattingRoomId}/messages")
+    public void send(@DestinationVariable Long chattingRoomId, ChattingRequest chattingRequest) {
+        simpMessagingTemplate.convertAndSend("/subscription/room/" + chattingRoomId, chattingRequest.getContent());
+        chattingService.sendMessage(chattingRoomId, chattingRequest);
+        log.info("Message [{}] send by member: {} to chatting room: {}", chattingRequest.getContent(), chattingRequest.getSenderId(), chattingRoomId);
     }
 }

--- a/src/main/java/com/cupid/jikting/chatting/controller/ChattingRoomController.java
+++ b/src/main/java/com/cupid/jikting/chatting/controller/ChattingRoomController.java
@@ -1,0 +1,34 @@
+package com.cupid.jikting.chatting.controller;
+
+import com.cupid.jikting.chatting.dto.ChattingRoomDetailResponse;
+import com.cupid.jikting.chatting.dto.ChattingRoomResponse;
+import com.cupid.jikting.chatting.service.ChattingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/chattings/room")
+public class ChattingRoomController {
+
+    private final ChattingService chattingService;
+
+    @GetMapping
+    public ResponseEntity<List<ChattingRoomResponse>> getAll() {
+        return ResponseEntity.ok().body(chattingService.getAll());
+    }
+
+    @GetMapping("/{chattingRoomId}")
+    public ResponseEntity<ChattingRoomDetailResponse> get(@PathVariable Long chattingRoomId) {
+        return ResponseEntity.ok().body(chattingService.get(chattingRoomId));
+    }
+
+    @PostMapping("/{chattingRoomId}/confirm")
+    public ResponseEntity<Void> confirm(@PathVariable Long chattingRoomId) {
+        chattingService.confirm(chattingRoomId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/cupid/jikting/chatting/controller/ChattingRoomController.java
+++ b/src/main/java/com/cupid/jikting/chatting/controller/ChattingRoomController.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/chattings/room")
+@RequestMapping("/chattings/rooms")
 public class ChattingRoomController {
 
     private final ChattingRoomService chattingRoomService;

--- a/src/main/java/com/cupid/jikting/chatting/controller/ChattingRoomController.java
+++ b/src/main/java/com/cupid/jikting/chatting/controller/ChattingRoomController.java
@@ -2,7 +2,7 @@ package com.cupid.jikting.chatting.controller;
 
 import com.cupid.jikting.chatting.dto.ChattingRoomDetailResponse;
 import com.cupid.jikting.chatting.dto.ChattingRoomResponse;
-import com.cupid.jikting.chatting.service.ChattingService;
+import com.cupid.jikting.chatting.service.ChattingRoomService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -14,21 +14,21 @@ import java.util.List;
 @RequestMapping("/chattings/room")
 public class ChattingRoomController {
 
-    private final ChattingService chattingService;
+    private final ChattingRoomService chattingRoomService;
 
     @GetMapping
     public ResponseEntity<List<ChattingRoomResponse>> getAll() {
-        return ResponseEntity.ok().body(chattingService.getAll());
+        return ResponseEntity.ok().body(chattingRoomService.getAll());
     }
 
     @GetMapping("/{chattingRoomId}")
     public ResponseEntity<ChattingRoomDetailResponse> get(@PathVariable Long chattingRoomId) {
-        return ResponseEntity.ok().body(chattingService.get(chattingRoomId));
+        return ResponseEntity.ok().body(chattingRoomService.get(chattingRoomId));
     }
 
     @PostMapping("/{chattingRoomId}/confirm")
     public ResponseEntity<Void> confirm(@PathVariable Long chattingRoomId) {
-        chattingService.confirm(chattingRoomId);
+        chattingRoomService.confirm(chattingRoomId);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/cupid/jikting/chatting/dto/ChattingRequest.java
+++ b/src/main/java/com/cupid/jikting/chatting/dto/ChattingRequest.java
@@ -1,0 +1,13 @@
+package com.cupid.jikting.chatting.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChattingRequest {
+
+    private Long senderId;
+    private String content;
+}

--- a/src/main/java/com/cupid/jikting/chatting/entity/Chatting.java
+++ b/src/main/java/com/cupid/jikting/chatting/entity/Chatting.java
@@ -1,0 +1,32 @@
+package com.cupid.jikting.chatting.entity;
+
+import com.cupid.jikting.member.entity.BaseEntity;
+import com.cupid.jikting.member.entity.Member;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLDelete;
+
+import javax.persistence.*;
+
+@Getter
+@SuperBuilder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE chatting SET deleted = true WHERE id=?")
+@AttributeOverride(name = "id", column = @Column(name = "chatting_id"))
+@Entity
+public class Chatting extends BaseEntity {
+
+    private String content;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chatting_room_id")
+    private ChattingRoom chattingRoom;
+}

--- a/src/main/java/com/cupid/jikting/chatting/entity/ChattingRoom.java
+++ b/src/main/java/com/cupid/jikting/chatting/entity/ChattingRoom.java
@@ -2,10 +2,7 @@ package com.cupid.jikting.chatting.entity;
 
 import com.cupid.jikting.member.entity.BaseEntity;
 import com.cupid.jikting.member.entity.Member;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.SQLDelete;
 
@@ -23,9 +20,11 @@ import java.util.List;
 @Entity
 public class ChattingRoom extends BaseEntity implements Serializable {
 
+    @Builder.Default
     @OneToMany(mappedBy = "chattingRoom", cascade = CascadeType.ALL)
     private List<Chatting> chattings = new ArrayList<>();
 
+    @Builder.Default
     @OneToMany(mappedBy = "chattingRoom", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
     private List<MemberChattingRoom> memberChattingRooms = new ArrayList<>();
 

--- a/src/main/java/com/cupid/jikting/chatting/entity/ChattingRoom.java
+++ b/src/main/java/com/cupid/jikting/chatting/entity/ChattingRoom.java
@@ -1,0 +1,37 @@
+package com.cupid.jikting.chatting.entity;
+
+import com.cupid.jikting.member.entity.BaseEntity;
+import com.cupid.jikting.member.entity.Member;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+
+import javax.persistence.*;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE chatting SET deleted = true WHERE id=?")
+@AttributeOverride(name = "id", column = @Column(name = "chatting_room_id"))
+@Entity
+public class ChattingRoom extends BaseEntity implements Serializable {
+
+    @OneToMany(mappedBy = "chattingRoom", cascade = CascadeType.ALL)
+    private final List<Chatting> chattings = new ArrayList<>();
+
+    @OneToMany(mappedBy = "chattingRoom", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
+    private final List<MemberChattingRoom> memberChattingRooms = new ArrayList<>();
+
+    public void createChatting(Chatting chatting) {
+        chattings.add(chatting);
+        Member sender = chatting.getMember();
+        MemberChattingRoom memberChattingRoom = MemberChattingRoom.of(sender, this);
+        memberChattingRooms.add(memberChattingRoom);
+        sender.addMemberChattingRoom(memberChattingRoom);
+    }
+}

--- a/src/main/java/com/cupid/jikting/chatting/entity/ChattingRoom.java
+++ b/src/main/java/com/cupid/jikting/chatting/entity/ChattingRoom.java
@@ -6,6 +6,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.SQLDelete;
 
 import javax.persistence.*;
@@ -14,6 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Getter
+@SuperBuilder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE chatting SET deleted = true WHERE id=?")

--- a/src/main/java/com/cupid/jikting/chatting/entity/ChattingRoom.java
+++ b/src/main/java/com/cupid/jikting/chatting/entity/ChattingRoom.java
@@ -22,10 +22,10 @@ import java.util.List;
 public class ChattingRoom extends BaseEntity implements Serializable {
 
     @OneToMany(mappedBy = "chattingRoom", cascade = CascadeType.ALL)
-    private final List<Chatting> chattings = new ArrayList<>();
+    private List<Chatting> chattings = new ArrayList<>();
 
     @OneToMany(mappedBy = "chattingRoom", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
-    private final List<MemberChattingRoom> memberChattingRooms = new ArrayList<>();
+    private List<MemberChattingRoom> memberChattingRooms = new ArrayList<>();
 
     public void createChatting(Chatting chatting) {
         chattings.add(chatting);

--- a/src/main/java/com/cupid/jikting/chatting/entity/MemberChattingRoom.java
+++ b/src/main/java/com/cupid/jikting/chatting/entity/MemberChattingRoom.java
@@ -1,0 +1,32 @@
+package com.cupid.jikting.chatting.entity;
+
+import com.cupid.jikting.member.entity.BaseEntity;
+import com.cupid.jikting.member.entity.Member;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+
+import javax.persistence.*;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE chatting SET deleted = true WHERE id=?")
+@AttributeOverride(name = "id", column = @Column(name = "member_chatting_room_id"))
+@Entity
+public class MemberChattingRoom extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chatting_room_id")
+    private ChattingRoom chattingRoom;
+
+    public static MemberChattingRoom of(Member member, ChattingRoom chattingRoom) {
+        return new MemberChattingRoom(member, chattingRoom);
+    }
+}

--- a/src/main/java/com/cupid/jikting/chatting/repository/ChattingRoomRepository.java
+++ b/src/main/java/com/cupid/jikting/chatting/repository/ChattingRoomRepository.java
@@ -1,0 +1,8 @@
+package com.cupid.jikting.chatting.repository;
+
+import com.cupid.jikting.chatting.entity.ChattingRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChattingRoomRepository extends JpaRepository<ChattingRoom, Long> {
+
+}

--- a/src/main/java/com/cupid/jikting/chatting/service/ChattingRoomService.java
+++ b/src/main/java/com/cupid/jikting/chatting/service/ChattingRoomService.java
@@ -1,0 +1,24 @@
+package com.cupid.jikting.chatting.service;
+
+import com.cupid.jikting.chatting.dto.ChattingRoomDetailResponse;
+import com.cupid.jikting.chatting.dto.ChattingRoomResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class ChattingRoomService {
+
+    public List<ChattingRoomResponse> getAll() {
+        return null;
+    }
+
+    public ChattingRoomDetailResponse get(Long chattingRoomId) {
+        return null;
+    }
+
+    public void confirm(Long chattingRoomId) {
+    }
+}

--- a/src/main/java/com/cupid/jikting/chatting/service/ChattingService.java
+++ b/src/main/java/com/cupid/jikting/chatting/service/ChattingService.java
@@ -1,22 +1,10 @@
 package com.cupid.jikting.chatting.service;
 
-import com.cupid.jikting.chatting.dto.ChattingRoomDetailResponse;
-import com.cupid.jikting.chatting.dto.ChattingRoomResponse;
+import com.cupid.jikting.chatting.dto.ChattingRequest;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-
 @Service
-public class ChattingService {
+public interface ChattingService {
 
-    public List<ChattingRoomResponse> getAll() {
-        return null;
-    }
-
-    public ChattingRoomDetailResponse get(Long chattingRoomId) {
-        return null;
-    }
-
-    public void confirm(Long chattingRoomId) {
-    }
+    void sendMessage(Long chattingRoomId, ChattingRequest chattingRequest);
 }

--- a/src/main/java/com/cupid/jikting/chatting/service/StompChattingService.java
+++ b/src/main/java/com/cupid/jikting/chatting/service/StompChattingService.java
@@ -1,0 +1,36 @@
+package com.cupid.jikting.chatting.service;
+
+import com.cupid.jikting.chatting.dto.ChattingRequest;
+import com.cupid.jikting.chatting.entity.Chatting;
+import com.cupid.jikting.chatting.entity.ChattingRoom;
+import com.cupid.jikting.chatting.repository.ChattingRoomRepository;
+import com.cupid.jikting.common.error.ApplicationError;
+import com.cupid.jikting.common.error.NotFoundException;
+import com.cupid.jikting.member.entity.Member;
+import com.cupid.jikting.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class StompChattingService implements ChattingService {
+
+    private final MemberRepository memberRepository;
+    private final ChattingRoomRepository chattingRoomRepository;
+
+    @Transactional
+    public void sendMessage(Long chattingRoomId, ChattingRequest chattingRequest) {
+        Member sender = memberRepository.findById(chattingRequest.getSenderId())
+                .orElseThrow(() -> new NotFoundException(ApplicationError.MEMBER_NOT_FOUND));
+        ChattingRoom chattingRoom = chattingRoomRepository.findById(chattingRoomId)
+                .orElseThrow(() -> new NotFoundException(ApplicationError.CHATTING_ROOM_NOT_FOUND));
+        Chatting chatting = Chatting.builder()
+                .member(sender)
+                .chattingRoom(chattingRoom)
+                .content(chattingRequest.getContent())
+                .build();
+        chattingRoom.createChatting(chatting);
+        chattingRoomRepository.save(chattingRoom);
+    }
+}

--- a/src/main/java/com/cupid/jikting/common/controller/ApplicationExceptionHandler.java
+++ b/src/main/java/com/cupid/jikting/common/controller/ApplicationExceptionHandler.java
@@ -4,6 +4,7 @@ import com.cupid.jikting.common.dto.ErrorResponse;
 import com.cupid.jikting.common.error.ApplicationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -19,6 +20,12 @@ public class ApplicationExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     protected ResponseEntity<ErrorResponse> handleException(Exception exception) {
+        log.info("{}: {}", exception.getClass().getSimpleName(), exception.getMessage(), exception);
+        return ResponseEntity.internalServerError().body(ErrorResponse.create());
+    }
+
+    @MessageExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorResponse> handleMessageException(Exception exception) {
         log.info("{}: {}", exception.getClass().getSimpleName(), exception.getMessage(), exception);
         return ResponseEntity.internalServerError().body(ErrorResponse.create());
     }

--- a/src/test/java/com/cupid/jikting/chatting/controller/ChattingRoomControllerTest.java
+++ b/src/test/java/com/cupid/jikting/chatting/controller/ChattingRoomControllerTest.java
@@ -1,7 +1,10 @@
 package com.cupid.jikting.chatting.controller;
 
 import com.cupid.jikting.ApiDocument;
-import com.cupid.jikting.chatting.dto.*;
+import com.cupid.jikting.chatting.dto.ChattingRoomDetailResponse;
+import com.cupid.jikting.chatting.dto.ChattingRoomResponse;
+import com.cupid.jikting.chatting.dto.MeetingConfirmRequest;
+import com.cupid.jikting.chatting.dto.MemberResponse;
 import com.cupid.jikting.chatting.service.ChattingService;
 import com.cupid.jikting.common.dto.ErrorResponse;
 import com.cupid.jikting.common.error.ApplicationError;
@@ -28,8 +31,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(ChattingController.class)
-public class ChattingControllerTest extends ApiDocument {
+@WebMvcTest(ChattingRoomController.class)
+public class ChattingRoomControllerTest extends ApiDocument {
 
     private static final String CONTEXT_PATH = "/api/v1";
     private static final String DOMAIN_ROOT_PATH = "/chattings";

--- a/src/test/java/com/cupid/jikting/chatting/controller/ChattingRoomControllerTest.java
+++ b/src/test/java/com/cupid/jikting/chatting/controller/ChattingRoomControllerTest.java
@@ -35,7 +35,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class ChattingRoomControllerTest extends ApiDocument {
 
     private static final String CONTEXT_PATH = "/api/v1";
-    private static final String DOMAIN_ROOT_PATH = "/chattings";
+    private static final String DOMAIN_ROOT_PATH = "/chattings/room";
     private static final String PATH_DELIMITER = "/";
     private static final String URL = "이미지 주소";
     private static final Long ID = 1L;

--- a/src/test/java/com/cupid/jikting/chatting/controller/ChattingRoomControllerTest.java
+++ b/src/test/java/com/cupid/jikting/chatting/controller/ChattingRoomControllerTest.java
@@ -5,7 +5,7 @@ import com.cupid.jikting.chatting.dto.ChattingRoomDetailResponse;
 import com.cupid.jikting.chatting.dto.ChattingRoomResponse;
 import com.cupid.jikting.chatting.dto.MeetingConfirmRequest;
 import com.cupid.jikting.chatting.dto.MemberResponse;
-import com.cupid.jikting.chatting.service.ChattingService;
+import com.cupid.jikting.chatting.service.ChattingRoomService;
 import com.cupid.jikting.common.dto.ErrorResponse;
 import com.cupid.jikting.common.error.ApplicationError;
 import com.cupid.jikting.common.error.ApplicationException;
@@ -54,7 +54,7 @@ public class ChattingRoomControllerTest extends ApiDocument {
     private ApplicationException chattingRoomNotFoundException;
 
     @MockBean
-    private ChattingService chattingService;
+    private ChattingRoomService chattingRoomService;
 
     @BeforeEach
     void setUp() {
@@ -95,7 +95,7 @@ public class ChattingRoomControllerTest extends ApiDocument {
     @Test
     void 채팅방_목록_조회_성공() throws Exception {
         //given
-        willReturn(chattingRoomResponses).given(chattingService).getAll();
+        willReturn(chattingRoomResponses).given(chattingRoomService).getAll();
         //when
         ResultActions resultActions = 채팅방_목록_조회_요청();
         //then
@@ -105,7 +105,7 @@ public class ChattingRoomControllerTest extends ApiDocument {
     @Test
     void 채팅방_입장_성공() throws Exception {
         //given
-        willReturn(chattingRoomDetailResponse).given(chattingService).get(anyLong());
+        willReturn(chattingRoomDetailResponse).given(chattingRoomService).get(anyLong());
         //when
         ResultActions resultActions = 채팅방_입장_요청();
         //then
@@ -115,7 +115,7 @@ public class ChattingRoomControllerTest extends ApiDocument {
     @Test
     void 채팅방_입장_실패() throws Exception {
         //given
-        willThrow(chattingRoomNotFoundException).given(chattingService).get(anyLong());
+        willThrow(chattingRoomNotFoundException).given(chattingRoomService).get(anyLong());
         //when
         ResultActions resultActions = 채팅방_입장_요청();
         //then
@@ -125,7 +125,7 @@ public class ChattingRoomControllerTest extends ApiDocument {
     @Test
     void 미팅_확정_성공() throws Exception {
         //given
-        willDoNothing().given(chattingService).confirm(anyLong());
+        willDoNothing().given(chattingRoomService).confirm(anyLong());
         //when
         ResultActions resultActions = 미팅_확정_요청();
         //then
@@ -135,7 +135,7 @@ public class ChattingRoomControllerTest extends ApiDocument {
     @Test
     void 미팅_확정_양식불일치_실패() throws Exception {
         //given
-        willThrow(wrongFormException).given(chattingService).confirm(anyLong());
+        willThrow(wrongFormException).given(chattingRoomService).confirm(anyLong());
         //when
         ResultActions resultActions = 미팅_확정_요청();
         //then
@@ -145,7 +145,7 @@ public class ChattingRoomControllerTest extends ApiDocument {
     @Test
     void 미팅_확정_채팅방정보없음_실패() throws Exception {
         //given
-        willThrow(chattingRoomNotFoundException).given(chattingService).confirm(anyLong());
+        willThrow(chattingRoomNotFoundException).given(chattingRoomService).confirm(anyLong());
         //when
         ResultActions resultActions = 미팅_확정_요청();
         //then

--- a/src/test/java/com/cupid/jikting/chatting/controller/ChattingRoomControllerTest.java
+++ b/src/test/java/com/cupid/jikting/chatting/controller/ChattingRoomControllerTest.java
@@ -35,7 +35,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class ChattingRoomControllerTest extends ApiDocument {
 
     private static final String CONTEXT_PATH = "/api/v1";
-    private static final String DOMAIN_ROOT_PATH = "/chattings/room";
+    private static final String DOMAIN_ROOT_PATH = "/chattings/rooms";
     private static final String PATH_DELIMITER = "/";
     private static final String URL = "이미지 주소";
     private static final Long ID = 1L;

--- a/src/test/java/com/cupid/jikting/chatting/service/StompChattingServiceTest.java
+++ b/src/test/java/com/cupid/jikting/chatting/service/StompChattingServiceTest.java
@@ -1,0 +1,71 @@
+package com.cupid.jikting.chatting.service;
+
+import com.cupid.jikting.chatting.dto.ChattingRequest;
+import com.cupid.jikting.chatting.entity.ChattingRoom;
+import com.cupid.jikting.chatting.repository.ChattingRoomRepository;
+import com.cupid.jikting.member.entity.Member;
+import com.cupid.jikting.member.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.willReturn;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class StompChattingServiceTest {
+
+    private static final Long ID = 1L;
+    private static final String CONTENT = "채팅 내용";
+
+    private Member member;
+    private ChattingRoom chattingRoom;
+    private ChattingRequest chattingRequest;
+
+    @InjectMocks
+    private StompChattingService chattingService;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private ChattingRoomRepository chattingRoomRepository;
+
+    @BeforeEach
+    void setUp() {
+        chattingRequest = ChattingRequest.builder()
+                .senderId(ID)
+                .content(CONTENT)
+                .build();
+        member = Member.builder()
+                .id(ID)
+                .build();
+        chattingRoom = ChattingRoom.builder()
+                .id(ID)
+                .build();
+    }
+
+    @Test
+    void 채팅_메시지_전송_성공() {
+        // given
+        willReturn(Optional.of(member)).given(memberRepository).findById(anyLong());
+        willReturn(Optional.of(chattingRoom)).given(chattingRoomRepository).findById(anyLong());
+        willReturn(chattingRoom).given(chattingRoomRepository).save(any(ChattingRoom.class));
+        // when
+        chattingService.sendMessage(ID, chattingRequest);
+        // then
+        assertAll(
+                () -> verify(memberRepository).findById(anyLong()),
+                () -> verify(chattingRoomRepository).findById(anyLong()),
+                () -> verify(chattingRoomRepository).save(any(ChattingRoom.class))
+        );
+    }
+}


### PR DESCRIPTION
## Issue

closed #89 
[SP-157](https://soma-cupid.atlassian.net/browse/SP-157?atlOrigin=eyJpIjoiYmNhZjExNDcwN2VjNDlmYjkxNTY2NWEzMTRlZWE4ZWQiLCJwIjoiaiJ9)

## 요구사항

- [x] 채팅 메시지 전송 기능 구현

## 변경사항

- `build.gradle` websocket 의존성 추가
- `ChattingController` -> `ChattingRoomController` 네이밍 수정
- `ChattingRoomController` 루트 경로 '/rooms' 추가
- `ChattingService` -> `ChattingRoomService` 네이밍 수정
- `WebSocketConfig` 추가
- `ChattingController` 추가
- `ChattingService` 추가
- `StompChattingController` 추가
- 채팅 메시지 전송 로직을 `ChattingController` 및 `StompChattingService`에 추가
- `ChattingServiceTest` 추가
- 채팅 메시지 전송 성공 테스트 추가

## 리뷰 우선순위

🙂보통

## 코멘트

- 우선 WebSocket과 STOMP를 사용해서 간단하게 구현했습니다. 추후 Redis 및 MQ를 적용해 고도화할 예정입니다.
- WebMvcTest에서 MessageMapping은 지원하지 않아 Controller 테스트를 추가하지 못했습니다. 이 부분 API 명세서에 어떻게 추가할지 고민해봐야 할 것 같습니다.
- Spring WebSocket + STOMP 적용 문서

    https://github.com/SWM-Cupid/jikting-backend/issues/89#issuecomment-1646648073

- 테스트 코드 작성 일지

    https://github.com/SWM-Cupid/jikting-backend/issues/89#issuecomment-1646810190

[SP-157]: https://soma-cupid.atlassian.net/browse/SP-157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ