### PR TITLE
[SP-159] 아이디 중복 확인 기능 구현

### DIFF
--- a/src/main/java/com/cupid/jikting/common/config/JpaAuditingConfig.java
+++ b/src/main/java/com/cupid/jikting/common/config/JpaAuditingConfig.java
@@ -1,4 +1,4 @@
-package com.cupid.jikting.config;
+package com.cupid.jikting.common.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;

--- a/src/main/java/com/cupid/jikting/common/handler/ApplicationExceptionHandler.java
+++ b/src/main/java/com/cupid/jikting/common/handler/ApplicationExceptionHandler.java
@@ -1,4 +1,4 @@
-package com.cupid.jikting.common.controller;
+package com.cupid.jikting.common.handler;
 
 import com.cupid.jikting.common.dto.ErrorResponse;
 import com.cupid.jikting.common.error.ApplicationException;

--- a/src/main/java/com/cupid/jikting/member/repository/MemberRepository.java
+++ b/src/main/java/com/cupid/jikting/member/repository/MemberRepository.java
@@ -10,4 +10,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByUsername(String email);
 
     Optional<Member> findByRefreshToken(String refreshToken);
+
+    boolean existsByUsername(String username);
 }

--- a/src/main/java/com/cupid/jikting/member/repository/MemberRepository.java
+++ b/src/main/java/com/cupid/jikting/member/repository/MemberRepository.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-    Optional<Member> findByUsername(String email);
+    Optional<Member> findByUsername(String username);
 
     Optional<Member> findByRefreshToken(String refreshToken);
 

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -1,11 +1,18 @@
 package com.cupid.jikting.member.service;
 
+import com.cupid.jikting.common.error.ApplicationError;
+import com.cupid.jikting.common.error.DuplicateException;
 import com.cupid.jikting.member.dto.*;
+import com.cupid.jikting.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+@RequiredArgsConstructor
 @Service
 public class MemberService {
+
+    private final MemberRepository memberRepository;
 
     public void signup(SignupRequest signupRequest) {
     }
@@ -34,6 +41,9 @@ public class MemberService {
     }
 
     public void checkDuplicatedUsername(UsernameCheckRequest usernameCheckRequest) {
+        if (memberRepository.existsByUsername(usernameCheckRequest.getUsername())) {
+            throw new DuplicateException(ApplicationError.DUPLICATE_USERNAME);
+        }
     }
 
     public void createVerificationCodeForSignup(SignUpVerificationCodeRequest signUpVerificationCodeRequest) {

--- a/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
+++ b/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
@@ -1,5 +1,7 @@
 package com.cupid.jikting.member.service;
 
+import com.cupid.jikting.common.error.ApplicationError;
+import com.cupid.jikting.common.error.DuplicateException;
 import com.cupid.jikting.member.dto.UsernameCheckRequest;
 import com.cupid.jikting.member.repository.MemberRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -9,6 +11,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.willReturn;
 import static org.mockito.Mockito.verify;
@@ -41,5 +44,15 @@ class MemberServiceTest {
         memberService.checkDuplicatedUsername(usernameCheckRequest);
         // then
         verify(memberRepository).existsByUsername(anyString());
+    }
+
+    @Test
+    void 아이디_중복_확인_실패_존재하는_아이디() {
+        // given
+        willReturn(true).given(memberRepository).existsByUsername(anyString());
+        // when & then
+        assertThatThrownBy(() -> memberService.checkDuplicatedUsername(usernameCheckRequest))
+                .isInstanceOf(DuplicateException.class)
+                .hasMessage(ApplicationError.DUPLICATE_USERNAME.getMessage());
     }
 }

--- a/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
+++ b/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
@@ -1,0 +1,45 @@
+package com.cupid.jikting.member.service;
+
+import com.cupid.jikting.member.dto.UsernameCheckRequest;
+import com.cupid.jikting.member.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.willReturn;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+    private static final String USERNAME = "아이디";
+
+    private UsernameCheckRequest usernameCheckRequest;
+
+    @InjectMocks
+    private MemberService memberService;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @BeforeEach
+    void setUp() {
+        usernameCheckRequest = UsernameCheckRequest.builder()
+                .username(USERNAME)
+                .build();
+    }
+
+    @Test
+    void 아이디_중복_확인_성공() {
+        // given
+        willReturn(false).given(memberRepository).existsByUsername(anyString());
+        // when
+        memberService.checkDuplicatedUsername(usernameCheckRequest);
+        // then
+        verify(memberRepository).existsByUsername(anyString());
+    }
+}


### PR DESCRIPTION
## Issue

closed #94 
[SP-159](https://soma-cupid.atlassian.net/browse/SP-159?atlOrigin=eyJpIjoiNWVkMTZmM2I3ZTU5NGQyMmExYjNiMDQ0MzY0YmQ4NTMiLCJwIjoiaiJ9)

## 요구사항

- [x] 아이디 중복 확인 기능 구현

## 변경사항

- `JpaAuditingConfig` `config` -> `common/config` 패키지 이동
- `common/controller` -> `common/handler` 패키지명 수정
- `MemberRepository` `findByUsername(email)` 파라미터명 username으로 수정
- 아이디 중복 확인 로직 `MemberService`에 추가
- 아이디 존재 여부 반환 메소드 `MemberRepository`에 추가
- `MemberServiceTest` 추가
- 아이디 중복 확인 성공 테스트 `MemberServiceTest`에 추가
- 아이디 중복 확인 실패(존재하는 아이디) 테스트 `MemberServiceTest`에 추가

## 리뷰 우선순위

🙂보통

[SP-159]: https://soma-cupid.atlassian.net/browse/SP-159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ