### PR TITLE
[BE] 닉네임 중복 확인 기능 구현

### DIFF
--- a/src/main/java/com/cupid/jikting/chatting/entity/Chatting.java
+++ b/src/main/java/com/cupid/jikting/chatting/entity/Chatting.java
@@ -1,6 +1,6 @@
 package com.cupid.jikting.chatting.entity;
 
-import com.cupid.jikting.member.entity.BaseEntity;
+import com.cupid.jikting.common.entity.BaseEntity;
 import com.cupid.jikting.member.entity.Member;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/cupid/jikting/chatting/entity/ChattingRoom.java
+++ b/src/main/java/com/cupid/jikting/chatting/entity/ChattingRoom.java
@@ -1,6 +1,6 @@
 package com.cupid.jikting.chatting.entity;
 
-import com.cupid.jikting.member.entity.BaseEntity;
+import com.cupid.jikting.common.entity.BaseEntity;
 import com.cupid.jikting.member.entity.Member;
 import lombok.*;
 import lombok.experimental.SuperBuilder;

--- a/src/main/java/com/cupid/jikting/chatting/entity/MemberChattingRoom.java
+++ b/src/main/java/com/cupid/jikting/chatting/entity/MemberChattingRoom.java
@@ -1,6 +1,6 @@
 package com.cupid.jikting.chatting.entity;
 
-import com.cupid.jikting.member.entity.BaseEntity;
+import com.cupid.jikting.common.entity.BaseEntity;
 import com.cupid.jikting.member.entity.Member;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/cupid/jikting/member/entity/Member.java
+++ b/src/main/java/com/cupid/jikting/member/entity/Member.java
@@ -46,4 +46,8 @@ public class Member extends BaseEntity {
     public void updateRefreshToken(String updateRefreshToken) {
         this.refreshToken = updateRefreshToken;
     }
+
+    public void addMemberChattingRoom(MemberChattingRoom memberChattingRoom) {
+        memberChattingRooms.add(memberChattingRoom);
+    }
 }

--- a/src/main/java/com/cupid/jikting/member/entity/Member.java
+++ b/src/main/java/com/cupid/jikting/member/entity/Member.java
@@ -1,5 +1,6 @@
 package com.cupid.jikting.member.entity;
 
+import com.cupid.jikting.chatting.entity.MemberChattingRoom;
 import com.cupid.jikting.common.entity.BaseEntity;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
@@ -37,6 +38,10 @@ public class Member extends BaseEntity {
     @Builder.Default
     @OneToMany(mappedBy = "member")
     private final List<MemberCertification> memberCertifications = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "member")
+    private final List<MemberChattingRoom> memberChattingRooms = new ArrayList<>();
 
     public void updateRefreshToken(String updateRefreshToken) {
         this.refreshToken = updateRefreshToken;

--- a/src/main/java/com/cupid/jikting/member/repository/MemberRepository.java
+++ b/src/main/java/com/cupid/jikting/member/repository/MemberRepository.java
@@ -12,4 +12,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByRefreshToken(String refreshToken);
 
     boolean existsByUsername(String username);
+
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -47,6 +47,9 @@ public class MemberService {
     }
 
     public void checkDuplicatedNickname(NicknameCheckRequest nicknameCheckRequest) {
+        if (memberRepository.existsByNickname(nicknameCheckRequest.getNickname())) {
+            throw new DuplicateException(ApplicationError.DUPLICATE_NICKNAME);
+        }
     }
 
     public void createVerificationCodeForSignup(SignUpVerificationCodeRequest signUpVerificationCodeRequest) {

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -46,6 +46,9 @@ public class MemberService {
         }
     }
 
+    public void checkDuplicatedNickname(NicknameCheckRequest nicknameCheckRequest) {
+    }
+
     public void createVerificationCodeForSignup(SignUpVerificationCodeRequest signUpVerificationCodeRequest) {
     }
 
@@ -66,9 +69,6 @@ public class MemberService {
     }
 
     public void resetPassword(PasswordResetRequest passwordResetRequest) {
-    }
-
-    public void checkDuplicatedNickname(NicknameCheckRequest nicknameCheckRequest) {
     }
 
     public void createVerificationCodeForCompany(CompanyVerificationCodeRequest companyVerificationCodeRequest) {

--- a/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
+++ b/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
@@ -71,4 +71,14 @@ class MemberServiceTest {
         // then
         verify(memberRepository).existsByNickname(anyString());
     }
+
+    @Test
+    void 닉네임_중복_확인_실패_존재하는_닉네임() {
+        // given
+        willReturn(true).given(memberRepository).existsByNickname(anyString());
+        // when & then
+        assertThatThrownBy(() -> memberService.checkDuplicatedNickname(nicknameCheckRequest))
+                .isInstanceOf(DuplicateException.class)
+                .hasMessage(ApplicationError.DUPLICATE_NICKNAME.getMessage());
+    }
 }

--- a/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
+++ b/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
@@ -2,6 +2,7 @@ package com.cupid.jikting.member.service;
 
 import com.cupid.jikting.common.error.ApplicationError;
 import com.cupid.jikting.common.error.DuplicateException;
+import com.cupid.jikting.member.dto.NicknameCheckRequest;
 import com.cupid.jikting.member.dto.UsernameCheckRequest;
 import com.cupid.jikting.member.repository.MemberRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -20,8 +21,10 @@ import static org.mockito.Mockito.verify;
 class MemberServiceTest {
 
     private static final String USERNAME = "아이디";
+    private static final String NICKNAME = "닉네임";
 
     private UsernameCheckRequest usernameCheckRequest;
+    private NicknameCheckRequest nicknameCheckRequest;
 
     @InjectMocks
     private MemberService memberService;
@@ -33,6 +36,9 @@ class MemberServiceTest {
     void setUp() {
         usernameCheckRequest = UsernameCheckRequest.builder()
                 .username(USERNAME)
+                .build();
+        nicknameCheckRequest = NicknameCheckRequest.builder()
+                .nickname(NICKNAME)
                 .build();
     }
 
@@ -54,5 +60,15 @@ class MemberServiceTest {
         assertThatThrownBy(() -> memberService.checkDuplicatedUsername(usernameCheckRequest))
                 .isInstanceOf(DuplicateException.class)
                 .hasMessage(ApplicationError.DUPLICATE_USERNAME.getMessage());
+    }
+
+    @Test
+    void 닉네임_중복_확인_성공() {
+        // given
+        willReturn(false).given(memberRepository).existsByNickname(anyString());
+        // when
+        memberService.checkDuplicatedNickname(nicknameCheckRequest);
+        // then
+        verify(memberRepository).existsByNickname(anyString());
     }
 }


### PR DESCRIPTION
## Issue

closed #96 
[SP-160](https://soma-cupid.atlassian.net/browse/SP-160?atlOrigin=eyJpIjoiNGQ4NTA1ZDdlM2ZjNDRjY2I3YTk4NjJlYTQ5NDlhYzMiLCJwIjoiaiJ9)

## 요구사항

- [x] 닉네임 중복 확인 기능 구현

## 변경사항

- `MemberService` checkDuplicatedNickname 메소드 순서 수정
- `Chatting`, `ChattingRoom`, `MemberChattingRoom`에서 `BaseEntity` import 패키지 수정
- `Member`에 연관관계 필드 `MemberChattingRoom` 리스트 추가
- `Member`에 연관관계 메소드 `addMemberChattingRoom` 추가
- `MemberService`에 닉네임 중복 확인 로직 추가
- `MemberRepository`에 닉네임 존재 여부 확인 메소드 추가
- `MemberServiceTest`에 닉네임 중복 확인 성공 테스트 추가
- `MemberServiceTest`에 닉네임 중복 확인 실패 테스트 추가

## 리뷰 우선순위

🙂보통

[SP-160]: https://soma-cupid.atlassian.net/browse/SP-160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ