### PR TITLE
[SP-158] 채팅방 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/cupid/jikting/chatting/controller/ChattingRoomController.java
+++ b/src/main/java/com/cupid/jikting/chatting/controller/ChattingRoomController.java
@@ -18,7 +18,7 @@ public class ChattingRoomController {
 
     @GetMapping
     public ResponseEntity<List<ChattingRoomResponse>> getAll() {
-        return ResponseEntity.ok().body(chattingRoomService.getAll());
+        return ResponseEntity.ok().body(chattingRoomService.getAll(1L));
     }
 
     @GetMapping("/{chattingRoomId}")

--- a/src/main/java/com/cupid/jikting/chatting/entity/Chatting.java
+++ b/src/main/java/com/cupid/jikting/chatting/entity/Chatting.java
@@ -1,7 +1,7 @@
 package com.cupid.jikting.chatting.entity;
 
 import com.cupid.jikting.common.entity.BaseEntity;
-import com.cupid.jikting.member.entity.Member;
+import com.cupid.jikting.member.entity.MemberProfile;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -23,8 +23,8 @@ public class Chatting extends BaseEntity {
     private String content;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
-    private Member member;
+    @JoinColumn(name = "member_profile_id")
+    private MemberProfile memberProfile;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "chatting_room_id")

--- a/src/main/java/com/cupid/jikting/chatting/entity/ChattingRoom.java
+++ b/src/main/java/com/cupid/jikting/chatting/entity/ChattingRoom.java
@@ -3,6 +3,7 @@ package com.cupid.jikting.chatting.entity;
 import com.cupid.jikting.common.entity.BaseEntity;
 import com.cupid.jikting.meeting.entity.Meeting;
 import com.cupid.jikting.member.entity.MemberProfile;
+import com.cupid.jikting.team.entity.Team;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.SQLDelete;
@@ -39,5 +40,9 @@ public class ChattingRoom extends BaseEntity implements Serializable {
         MemberChattingRoom memberChattingRoom = MemberChattingRoom.of(sender, this);
         memberChattingRooms.add(memberChattingRoom);
         sender.addMemberChattingRoom(memberChattingRoom);
+    }
+
+    public String getOppositeTeamName(Team team) {
+        return meeting.getOppositeTeamName(team);
     }
 }

--- a/src/main/java/com/cupid/jikting/chatting/entity/ChattingRoom.java
+++ b/src/main/java/com/cupid/jikting/chatting/entity/ChattingRoom.java
@@ -1,7 +1,7 @@
 package com.cupid.jikting.chatting.entity;
 
 import com.cupid.jikting.common.entity.BaseEntity;
-import com.cupid.jikting.member.entity.Member;
+import com.cupid.jikting.member.entity.MemberProfile;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.SQLDelete;
@@ -30,7 +30,7 @@ public class ChattingRoom extends BaseEntity implements Serializable {
 
     public void createChatting(Chatting chatting) {
         chattings.add(chatting);
-        Member sender = chatting.getMember();
+        MemberProfile sender = chatting.getMemberProfile();
         MemberChattingRoom memberChattingRoom = MemberChattingRoom.of(sender, this);
         memberChattingRooms.add(memberChattingRoom);
         sender.addMemberChattingRoom(memberChattingRoom);

--- a/src/main/java/com/cupid/jikting/chatting/entity/ChattingRoom.java
+++ b/src/main/java/com/cupid/jikting/chatting/entity/ChattingRoom.java
@@ -1,6 +1,7 @@
 package com.cupid.jikting.chatting.entity;
 
 import com.cupid.jikting.common.entity.BaseEntity;
+import com.cupid.jikting.meeting.entity.Meeting;
 import com.cupid.jikting.member.entity.MemberProfile;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
@@ -19,6 +20,10 @@ import java.util.List;
 @AttributeOverride(name = "id", column = @Column(name = "chatting_room_id"))
 @Entity
 public class ChattingRoom extends BaseEntity implements Serializable {
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "meeting_id")
+    private Meeting meeting;
 
     @Builder.Default
     @OneToMany(mappedBy = "chattingRoom", cascade = CascadeType.ALL)

--- a/src/main/java/com/cupid/jikting/chatting/entity/MemberChattingRoom.java
+++ b/src/main/java/com/cupid/jikting/chatting/entity/MemberChattingRoom.java
@@ -1,7 +1,7 @@
 package com.cupid.jikting.chatting.entity;
 
 import com.cupid.jikting.common.entity.BaseEntity;
-import com.cupid.jikting.member.entity.Member;
+import com.cupid.jikting.member.entity.MemberProfile;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -19,14 +19,14 @@ import javax.persistence.*;
 public class MemberChattingRoom extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
-    private Member member;
+    @JoinColumn(name = "member_profile_id")
+    private MemberProfile memberProfile;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "chatting_room_id")
     private ChattingRoom chattingRoom;
 
-    public static MemberChattingRoom of(Member member, ChattingRoom chattingRoom) {
-        return new MemberChattingRoom(member, chattingRoom);
+    public static MemberChattingRoom of(MemberProfile memberProfile, ChattingRoom chattingRoom) {
+        return new MemberChattingRoom(memberProfile, chattingRoom);
     }
 }

--- a/src/main/java/com/cupid/jikting/chatting/service/ChattingRoomService.java
+++ b/src/main/java/com/cupid/jikting/chatting/service/ChattingRoomService.java
@@ -2,17 +2,39 @@ package com.cupid.jikting.chatting.service;
 
 import com.cupid.jikting.chatting.dto.ChattingRoomDetailResponse;
 import com.cupid.jikting.chatting.dto.ChattingRoomResponse;
+import com.cupid.jikting.chatting.entity.Chatting;
+import com.cupid.jikting.chatting.entity.ChattingRoom;
+import com.cupid.jikting.chatting.entity.MemberChattingRoom;
+import com.cupid.jikting.chatting.repository.ChattingRoomRepository;
+import com.cupid.jikting.common.error.ApplicationError;
+import com.cupid.jikting.common.error.NotFoundException;
+import com.cupid.jikting.member.entity.MemberProfile;
+import com.cupid.jikting.member.entity.ProfileImage;
+import com.cupid.jikting.member.repository.MemberProfileRepository;
+import com.cupid.jikting.team.entity.Team;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
 public class ChattingRoomService {
 
-    public List<ChattingRoomResponse> getAll() {
-        return null;
+    private static final String NO_MESSAGE = "";
+
+    private MemberProfileRepository memberProfileRepository;
+    private ChattingRoomRepository chattingRoomRepository;
+
+    public List<ChattingRoomResponse> getAll(Long memberProfileId) {
+        MemberProfile memberProfile = memberProfileRepository.findById(memberProfileId)
+                .orElseThrow(() -> new NotFoundException(ApplicationError.MEMBER_NOT_FOUND));
+        return chattingRoomRepository.findAll()
+                .stream()
+                .map(chattingRoom -> toChattingRoomResponse(chattingRoom, memberProfile.getTeam()))
+                .collect(Collectors.toList());
     }
 
     public ChattingRoomDetailResponse get(Long chattingRoomId) {
@@ -20,5 +42,31 @@ public class ChattingRoomService {
     }
 
     public void confirm(Long chattingRoomId) {
+    }
+
+    private ChattingRoomResponse toChattingRoomResponse(ChattingRoom chattingRoom, Team team) {
+        return ChattingRoomResponse.builder()
+                .chattingRoomId(chattingRoom.getId())
+                .opposingTeamName(chattingRoom.getOppositeTeamName(team))
+                .lastMessage(getLastMessage(chattingRoom.getChattings()))
+                .images(getImages(chattingRoom.getMemberChattingRooms()))
+                .build();
+    }
+
+    private String getLastMessage(List<Chatting> chattings) {
+        if (chattings.size() == 0) {
+            return NO_MESSAGE;
+        }
+        return chattings.get(chattings.size() - 1).getContent();
+    }
+
+    private List<String> getImages(List<MemberChattingRoom> memberChattingRooms) {
+        return memberChattingRooms.stream()
+                .flatMap(memberChattingRoom -> Arrays.stream(memberChattingRoom.getMemberProfile()
+                        .getProfileImages()
+                        .stream()
+                        .map(ProfileImage::getUrl)
+                        .toArray(String[]::new)))
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/cupid/jikting/chatting/service/ChattingRoomService.java
+++ b/src/main/java/com/cupid/jikting/chatting/service/ChattingRoomService.java
@@ -54,7 +54,7 @@ public class ChattingRoomService {
     }
 
     private String getLastMessage(List<Chatting> chattings) {
-        if (chattings.size() == 0) {
+        if (chattings.isEmpty()) {
             return NO_MESSAGE;
         }
         return chattings.get(chattings.size() - 1).getContent();

--- a/src/main/java/com/cupid/jikting/chatting/service/StompChattingService.java
+++ b/src/main/java/com/cupid/jikting/chatting/service/StompChattingService.java
@@ -6,8 +6,8 @@ import com.cupid.jikting.chatting.entity.ChattingRoom;
 import com.cupid.jikting.chatting.repository.ChattingRoomRepository;
 import com.cupid.jikting.common.error.ApplicationError;
 import com.cupid.jikting.common.error.NotFoundException;
-import com.cupid.jikting.member.entity.Member;
-import com.cupid.jikting.member.repository.MemberRepository;
+import com.cupid.jikting.member.entity.MemberProfile;
+import com.cupid.jikting.member.repository.MemberProfileRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,17 +16,17 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class StompChattingService implements ChattingService {
 
-    private final MemberRepository memberRepository;
+    private final MemberProfileRepository memberProfileRepository;
     private final ChattingRoomRepository chattingRoomRepository;
 
     @Transactional
     public void sendMessage(Long chattingRoomId, ChattingRequest chattingRequest) {
-        Member sender = memberRepository.findById(chattingRequest.getSenderId())
+        MemberProfile sender = memberProfileRepository.findById(chattingRequest.getSenderId())
                 .orElseThrow(() -> new NotFoundException(ApplicationError.MEMBER_NOT_FOUND));
         ChattingRoom chattingRoom = chattingRoomRepository.findById(chattingRoomId)
                 .orElseThrow(() -> new NotFoundException(ApplicationError.CHATTING_ROOM_NOT_FOUND));
         Chatting chatting = Chatting.builder()
-                .member(sender)
+                .memberProfile(sender)
                 .chattingRoom(chattingRoom)
                 .content(chattingRequest.getContent())
                 .build();

--- a/src/main/java/com/cupid/jikting/common/error/ApplicationError.java
+++ b/src/main/java/com/cupid/jikting/common/error/ApplicationError.java
@@ -27,6 +27,7 @@ public enum ApplicationError {
     INVALID_COMPANY(HttpStatus.BAD_REQUEST, "U006", "지원하지 않는 회사입니다."),
     NOT_EQUAL_ID_OR_PASSWORD(HttpStatus.BAD_REQUEST, "U007", "아이디 또는 비밀번호가 일치하지 않습니다."),
     INVALID_GENDER(HttpStatus.BAD_REQUEST, "U008", "지원하지 않는 성별입니다."),
+    NOT_EXIST_REGISTERED_TEAM(HttpStatus.BAD_REQUEST, "U009", "등록된 팀이 존재하지 않습니다."),
 
     TEAM_NOT_FOUND(HttpStatus.BAD_REQUEST, "T001", "팀을 찾을 수 없습니다."),
     GENDER_MISMATCH(HttpStatus.BAD_REQUEST, "T002", "해당 성별은 팀에 참여할 수 없습니다."),

--- a/src/main/java/com/cupid/jikting/meeting/entity/ConfirmStatus.java
+++ b/src/main/java/com/cupid/jikting/meeting/entity/ConfirmStatus.java
@@ -1,0 +1,6 @@
+package com.cupid.jikting.meeting.entity;
+
+public enum ConfirmStatus {
+
+    DECIDED, NOT_DECIDED
+}

--- a/src/main/java/com/cupid/jikting/meeting/entity/ConfirmStatus.java
+++ b/src/main/java/com/cupid/jikting/meeting/entity/ConfirmStatus.java
@@ -2,5 +2,5 @@ package com.cupid.jikting.meeting.entity;
 
 public enum ConfirmStatus {
 
-    DECIDED, NOT_DECIDED
+    DECIDED, UNDECIDED
 }

--- a/src/main/java/com/cupid/jikting/meeting/entity/Meeting.java
+++ b/src/main/java/com/cupid/jikting/meeting/entity/Meeting.java
@@ -23,6 +23,10 @@ public class Meeting extends BaseEntity {
 
     private LocalDateTime schedule;
     private String place;
+    private LocalDateTime confirmAt;
+
+    @Enumerated(EnumType.STRING)
+    private ConfirmStatus confirmStatus;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "recommended_team_id")

--- a/src/main/java/com/cupid/jikting/meeting/entity/Meeting.java
+++ b/src/main/java/com/cupid/jikting/meeting/entity/Meeting.java
@@ -35,4 +35,11 @@ public class Meeting extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "acceptiong_team_id")
     private Team acceptingTeam;
+
+    public String getOppositeTeamName(Team team) {
+        if (recommendedTeam.equals(team)) {
+            return acceptingTeam.getName();
+        }
+        return recommendedTeam.getName();
+    }
 }

--- a/src/main/java/com/cupid/jikting/member/entity/Member.java
+++ b/src/main/java/com/cupid/jikting/member/entity/Member.java
@@ -39,10 +39,6 @@ public class Member extends BaseEntity {
     @OneToMany(mappedBy = "member")
     private final List<MemberCertification> memberCertifications = new ArrayList<>();
 
-    @Builder.Default
-    @OneToMany(mappedBy = "member")
-    private final List<MemberChattingRoom> memberChattingRooms = new ArrayList<>();
-
     public void updateRefreshToken(String updateRefreshToken) {
         this.refreshToken = updateRefreshToken;
     }

--- a/src/main/java/com/cupid/jikting/member/entity/Member.java
+++ b/src/main/java/com/cupid/jikting/member/entity/Member.java
@@ -1,6 +1,5 @@
 package com.cupid.jikting.member.entity;
 
-import com.cupid.jikting.chatting.entity.MemberChattingRoom;
 import com.cupid.jikting.common.entity.BaseEntity;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
@@ -41,9 +40,5 @@ public class Member extends BaseEntity {
 
     public void updateRefreshToken(String updateRefreshToken) {
         this.refreshToken = updateRefreshToken;
-    }
-
-    public void addMemberChattingRoom(MemberChattingRoom memberChattingRoom) {
-        memberChattingRooms.add(memberChattingRoom);
     }
 }

--- a/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
+++ b/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
@@ -67,4 +67,8 @@ public class MemberProfile extends BaseEntity {
     @Builder.Default
     @OneToMany(mappedBy = "memberProfile")
     private List<InstantMeetingMember> instantMeetingMembers = new ArrayList<>();
+
+    public void addMemberChattingRoom(MemberChattingRoom memberChattingRoom) {
+        memberChattingRooms.add(memberChattingRoom);
+    }
 }

--- a/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
+++ b/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
@@ -1,5 +1,6 @@
 package com.cupid.jikting.member.entity;
 
+import com.cupid.jikting.chatting.entity.MemberChattingRoom;
 import com.cupid.jikting.common.entity.BaseEntity;
 import com.cupid.jikting.meeting.entity.InstantMeetingMember;
 import com.cupid.jikting.team.entity.TeamMember;
@@ -58,6 +59,10 @@ public class MemberProfile extends BaseEntity {
     @Builder.Default
     @OneToMany(mappedBy = "memberProfile")
     private List<TeamMember> teamMembers = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "memberProfile")
+    private List<MemberChattingRoom> memberChattingRooms = new ArrayList<>();
 
     @Builder.Default
     @OneToMany(mappedBy = "memberProfile")

--- a/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
+++ b/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
@@ -2,7 +2,10 @@ package com.cupid.jikting.member.entity;
 
 import com.cupid.jikting.chatting.entity.MemberChattingRoom;
 import com.cupid.jikting.common.entity.BaseEntity;
+import com.cupid.jikting.common.error.ApplicationError;
+import com.cupid.jikting.common.error.BadRequestException;
 import com.cupid.jikting.meeting.entity.InstantMeetingMember;
+import com.cupid.jikting.team.entity.Team;
 import com.cupid.jikting.team.entity.TeamMember;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
@@ -17,7 +20,7 @@ import java.util.List;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE member_profile SET is_deleted = true WHERE id = ?")
-@AttributeOverride(name = "id", column = @Column(name = "member_id"))
+@AttributeOverride(name = "id", column = @Column(name = "member_profile_id"))
 @Entity
 public class MemberProfile extends BaseEntity {
 
@@ -70,5 +73,12 @@ public class MemberProfile extends BaseEntity {
 
     public void addMemberChattingRoom(MemberChattingRoom memberChattingRoom) {
         memberChattingRooms.add(memberChattingRoom);
+    }
+
+    public Team getTeam() {
+        return teamMembers.stream()
+                .findFirst()
+                .orElseThrow(() -> new BadRequestException(ApplicationError.NOT_EXIST_REGISTERED_TEAM))
+                .getTeam();
     }
 }

--- a/src/test/java/com/cupid/jikting/chatting/controller/ChattingRoomControllerTest.java
+++ b/src/test/java/com/cupid/jikting/chatting/controller/ChattingRoomControllerTest.java
@@ -100,7 +100,7 @@ public class ChattingRoomControllerTest extends ApiDocument {
     @Test
     void 채팅방_목록_조회_성공() throws Exception {
         //given
-        willReturn(chattingRoomResponses).given(chattingRoomService).getAll();
+        willReturn(chattingRoomResponses).given(chattingRoomService).getAll(anyLong());
         //when
         ResultActions resultActions = 채팅방_목록_조회_요청();
         //then

--- a/src/test/java/com/cupid/jikting/chatting/service/ChattingRoomServiceTest.java
+++ b/src/test/java/com/cupid/jikting/chatting/service/ChattingRoomServiceTest.java
@@ -84,7 +84,7 @@ class ChattingRoomServiceTest {
         // when
         List<ChattingRoomResponse> chattingRoomResponses = chattingRoomService.getAll(ID);
         // then
-        assertThat(chattingRoomResponses.size()).isEqualTo(3);
+        assertThat(chattingRoomResponses.size()).isEqualTo(chattingRooms.size());
     }
 
     @Test

--- a/src/test/java/com/cupid/jikting/chatting/service/ChattingRoomServiceTest.java
+++ b/src/test/java/com/cupid/jikting/chatting/service/ChattingRoomServiceTest.java
@@ -1,0 +1,82 @@
+package com.cupid.jikting.chatting.service;
+
+import com.cupid.jikting.chatting.dto.ChattingRoomResponse;
+import com.cupid.jikting.chatting.entity.ChattingRoom;
+import com.cupid.jikting.chatting.repository.ChattingRoomRepository;
+import com.cupid.jikting.meeting.entity.Meeting;
+import com.cupid.jikting.member.entity.MemberProfile;
+import com.cupid.jikting.member.repository.MemberProfileRepository;
+import com.cupid.jikting.team.entity.Team;
+import com.cupid.jikting.team.entity.TeamMember;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.willReturn;
+
+@WebMvcTest(MockitoExtension.class)
+class ChattingRoomServiceTest {
+
+    private static final Long ID = 1L;
+    private static final String TEAM_NAME = "팀 이름";
+
+    private MemberProfile memberProfile;
+    private List<ChattingRoom> chattingRooms;
+
+    @InjectMocks
+    private ChattingRoomService chattingRoomService;
+
+    @Mock
+    private MemberProfileRepository memberProfileRepository;
+
+    @Mock
+    private ChattingRoomRepository chattingRoomRepository;
+
+    @BeforeEach
+    void setUp() {
+        Team team = Team.builder()
+                .id(ID)
+                .name(TEAM_NAME)
+                .build();
+        List<TeamMember> teamMembers = List.of(TeamMember.builder()
+                .id(ID)
+                .memberProfile(memberProfile)
+                .team(team)
+                .build());
+        memberProfile = MemberProfile.builder()
+                .id(ID)
+                .teamMembers(teamMembers)
+                .build();
+        chattingRooms = IntStream.range(0, 3)
+                .mapToObj(n -> ChattingRoom.builder()
+                        .id(n + ID)
+                        .meeting(Meeting.builder()
+                                .id(ID)
+                                .recommendedTeam(team)
+                                .acceptingTeam(team)
+                                .build())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    @Test
+    void 채팅_목록_조회_성공() {
+        // given
+        willReturn(Optional.of(memberProfile)).given(memberProfileRepository).findById(anyLong());
+        willReturn(chattingRooms).given(chattingRoomRepository).findAll();
+        // when
+        List<ChattingRoomResponse> chattingRoomResponses = chattingRoomService.getAll(ID);
+        // then
+        assertThat(chattingRoomResponses.size()).isEqualTo(3);
+    }
+}

--- a/src/test/java/com/cupid/jikting/chatting/service/StompChattingServiceTest.java
+++ b/src/test/java/com/cupid/jikting/chatting/service/StompChattingServiceTest.java
@@ -4,7 +4,8 @@ import com.cupid.jikting.chatting.dto.ChattingRequest;
 import com.cupid.jikting.chatting.entity.ChattingRoom;
 import com.cupid.jikting.chatting.repository.ChattingRoomRepository;
 import com.cupid.jikting.member.entity.Member;
-import com.cupid.jikting.member.repository.MemberRepository;
+import com.cupid.jikting.member.entity.MemberProfile;
+import com.cupid.jikting.member.repository.MemberProfileRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,7 +27,7 @@ public class StompChattingServiceTest {
     private static final Long ID = 1L;
     private static final String CONTENT = "채팅 내용";
 
-    private Member member;
+    private MemberProfile memberProfile;
     private ChattingRoom chattingRoom;
     private ChattingRequest chattingRequest;
 
@@ -34,7 +35,7 @@ public class StompChattingServiceTest {
     private StompChattingService chattingService;
 
     @Mock
-    private MemberRepository memberRepository;
+    private MemberProfileRepository memberProfileRepository;
 
     @Mock
     private ChattingRoomRepository chattingRoomRepository;
@@ -45,7 +46,7 @@ public class StompChattingServiceTest {
                 .senderId(ID)
                 .content(CONTENT)
                 .build();
-        member = Member.builder()
+        memberProfile = MemberProfile.builder()
                 .id(ID)
                 .build();
         chattingRoom = ChattingRoom.builder()
@@ -56,14 +57,14 @@ public class StompChattingServiceTest {
     @Test
     void 채팅_메시지_전송_성공() {
         // given
-        willReturn(Optional.of(member)).given(memberRepository).findById(anyLong());
+        willReturn(Optional.of(memberProfile)).given(memberProfileRepository).findById(anyLong());
         willReturn(Optional.of(chattingRoom)).given(chattingRoomRepository).findById(anyLong());
         willReturn(chattingRoom).given(chattingRoomRepository).save(any(ChattingRoom.class));
         // when
         chattingService.sendMessage(ID, chattingRequest);
         // then
         assertAll(
-                () -> verify(memberRepository).findById(anyLong()),
+                () -> verify(memberProfileRepository).findById(anyLong()),
                 () -> verify(chattingRoomRepository).findById(anyLong()),
                 () -> verify(chattingRoomRepository).save(any(ChattingRoom.class))
         );


### PR DESCRIPTION
## Issue

closed #102 
[SP-158](https://soma-cupid.atlassian.net/browse/SP-158?atlOrigin=eyJpIjoiMGUwY2M3ZmNkNmRjNGYzMDg0YzU5ZTAwMDdlY2RkYWUiLCJwIjoiaiJ9)

## 요구사항

- [x] 채팅방 목록 조회 기능 구현

## 변경사항

- `ChattingRoomService` 채팅 목록 조회 로직 추가
- `ChattingRoomServiceTest` 채팅 목록 조회 성공 및 실패 테스트 추가
- `Meeting`에 확정 시간, 확정 상태 필드 추가
- `ConfirmStatus` 추가
- `MemberProfile` 기본키 컬럼명 수정
- `ApplicationError` 등록된 팀 없음 에러 추가
- `ChattingRoom` - `Member` 연관관계 `ChattingRoom` - `MemberProfile`로 수정

## 리뷰 우선순위

🙂보통

## 코멘트

- 기능 구현 중 MemberProfile과 연관관계 매핑이 되어있어야할 곳에 Member가 매핑된 엔티티들을 발견해 수정했습니다.
- 채팅 목록에서 상대 팀 정보를 가져오기 위해 미팅 엔티티를 미팅 확정 전에 만들고, 확정 상태(`ConfirmStatus`)를 통해 상태 관리를 하도록 수정했습니다.

[SP-158]: https://soma-cupid.atlassian.net/browse/SP-158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ