### PR TITLE
[SP-208] 미팅 추천 - 팀 조회 구현

### DIFF
--- a/src/main/java/com/cupid/jikting/common/error/ApplicationError.java
+++ b/src/main/java/com/cupid/jikting/common/error/ApplicationError.java
@@ -27,6 +27,7 @@ public enum ApplicationError {
     INVALID_COMPANY(HttpStatus.BAD_REQUEST, "U006", "지원하지 않는 회사입니다."),
     NOT_EQUAL_ID_OR_PASSWORD(HttpStatus.BAD_REQUEST, "U007", "아이디 또는 비밀번호가 일치하지 않습니다."),
     INVALID_GENDER(HttpStatus.BAD_REQUEST, "U008", "지원하지 않는 성별입니다."),
+    NOT_EXIST_REGISTERED_TEAM(HttpStatus.BAD_REQUEST, "U009", "등록된 팀이 존재하지 않습니다."),
 
     TEAM_NOT_FOUND(HttpStatus.BAD_REQUEST, "T001", "팀을 찾을 수 없습니다."),
     GENDER_MISMATCH(HttpStatus.BAD_REQUEST, "T002", "해당 성별은 팀에 참여할 수 없습니다."),

--- a/src/main/java/com/cupid/jikting/jwt/filter/JwtAuthenticationProcessingFilter.java
+++ b/src/main/java/com/cupid/jikting/jwt/filter/JwtAuthenticationProcessingFilter.java
@@ -49,7 +49,7 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
         Member member = memberRepository.findByRefreshToken(refreshToken)
                 .orElseThrow(() -> new InvalidJwtException(ApplicationError.INVALID_TOKEN));
         String reIssuedRefreshToken = reIssueRefreshToken(member);
-        jwtService.sendAccessAndRefreshToken(response, jwtService.createAccessToken(member.getMemberProfile().getId()), reIssuedRefreshToken);
+        jwtService.sendAccessAndRefreshToken(response, jwtService.createAccessToken(member.getMemberProfileId()), reIssuedRefreshToken);
     }
 
     public void checkAccessTokenAndAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)

--- a/src/main/java/com/cupid/jikting/jwt/filter/JwtAuthenticationProcessingFilter.java
+++ b/src/main/java/com/cupid/jikting/jwt/filter/JwtAuthenticationProcessingFilter.java
@@ -49,7 +49,7 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
         Member member = memberRepository.findByRefreshToken(refreshToken)
                 .orElseThrow(() -> new InvalidJwtException(ApplicationError.INVALID_TOKEN));
         String reIssuedRefreshToken = reIssueRefreshToken(member);
-        jwtService.sendAccessAndRefreshToken(response, jwtService.createAccessToken(member.getUsername()), reIssuedRefreshToken);
+        jwtService.sendAccessAndRefreshToken(response, jwtService.createAccessToken(member.getMemberProfile().getId()), reIssuedRefreshToken);
     }
 
     public void checkAccessTokenAndAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
@@ -57,15 +57,15 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
         log.info("checkAccessTokenAndAuthentication() 호출");
         jwtService.extractAccessToken(request)
                 .filter(jwtService::isTokenValid)
-                .flatMap(jwtService::extractUsername)
-                .flatMap(memberRepository::findByUsername)
+                .flatMap(jwtService::extractMemberProfileId)
+                .flatMap(memberRepository::findById)
                 .ifPresent(this::saveAuthentication);
         filterChain.doFilter(request, response);
     }
 
     public void saveAuthentication(Member member) {
         UserDetails userDetails = User.builder()
-                .username(member.getUsername())
+                .username(member.getId().toString())
                 .password(member.getPassword())
                 .roles(member.getRole().name())
                 .build();

--- a/src/main/java/com/cupid/jikting/jwt/service/JwtService.java
+++ b/src/main/java/com/cupid/jikting/jwt/service/JwtService.java
@@ -91,6 +91,15 @@ public class JwtService {
         }
     }
 
+    public Long extractValidMemberProfileId(String accessToken) {
+        return Optional.ofNullable(JWT.require(Algorithm.HMAC512(secretKey))
+                        .build()
+                        .verify(accessToken)
+                        .getClaim(MEMBER_PROFILE_ID_CLAIM)
+                        .asLong())
+                .orElseThrow(() -> new JwtException(ApplicationError.INVALID_TOKEN));
+    }
+
     public boolean isTokenValid(String token) {
         try {
             JWT.require(Algorithm.HMAC512(secretKey)).build().verify(token);

--- a/src/main/java/com/cupid/jikting/jwt/service/JwtService.java
+++ b/src/main/java/com/cupid/jikting/jwt/service/JwtService.java
@@ -24,7 +24,7 @@ public class JwtService {
 
     private static final String ACCESS_TOKEN_SUBJECT = "AccessToken";
     private static final String REFRESH_TOKEN_SUBJECT = "RefreshToken";
-    private static final String USERNAME_CLAIM = "username";
+    private static final String MEMBER_PROFILE_ID_CLAIM = "MemberProfileId";
     private static final String BEARER = "Bearer ";
 
     private final MemberRepository memberRepository;
@@ -44,11 +44,11 @@ public class JwtService {
     @Value("${jwt.refreshToken.header}")
     private String refreshHeader;
 
-    public String createAccessToken(String username) {
+    public String createAccessToken(Long memberProfileId) {
         return JWT.create()
                 .withSubject(ACCESS_TOKEN_SUBJECT)
                 .withExpiresAt(new Date(new Date().getTime() + accessTokenExpirationPeriod))
-                .withClaim(USERNAME_CLAIM, username)
+                .withClaim(MEMBER_PROFILE_ID_CLAIM, memberProfileId)
                 .sign(Algorithm.HMAC512(secretKey));
     }
 
@@ -78,13 +78,13 @@ public class JwtService {
                 .map(refreshToken -> refreshToken.replace(BEARER, ""));
     }
 
-    public Optional<String> extractUsername(String accessToken) {
+    public Optional<Long> extractMemberProfileId(String accessToken) {
         try {
             return Optional.ofNullable(JWT.require(Algorithm.HMAC512(secretKey))
                     .build()
                     .verify(accessToken)
-                    .getClaim(USERNAME_CLAIM)
-                    .asString());
+                    .getClaim(MEMBER_PROFILE_ID_CLAIM)
+                    .asLong());
         } catch (Exception e) {
             log.error("액세스 토큰이 유효하지 않습니다.");
             return Optional.empty();

--- a/src/main/java/com/cupid/jikting/member/entity/Member.java
+++ b/src/main/java/com/cupid/jikting/member/entity/Member.java
@@ -33,15 +33,15 @@ public class Member extends BaseEntity {
 
     @Builder.Default
     @OneToMany(mappedBy = "member")
-    private final List<MemberCompany> memberCompanies = new ArrayList<>();
+    private List<MemberCompany> memberCompanies = new ArrayList<>();
 
     @Builder.Default
     @OneToMany(mappedBy = "member")
-    private final List<MemberCertification> memberCertifications = new ArrayList<>();
+    private List<MemberCertification> memberCertifications = new ArrayList<>();
 
     @Builder.Default
     @OneToMany(mappedBy = "member")
-    private final List<MemberChattingRoom> memberChattingRooms = new ArrayList<>();
+    private List<MemberChattingRoom> memberChattingRooms = new ArrayList<>();
 
     public void updateRefreshToken(String updateRefreshToken) {
         this.refreshToken = updateRefreshToken;

--- a/src/main/java/com/cupid/jikting/member/entity/Member.java
+++ b/src/main/java/com/cupid/jikting/member/entity/Member.java
@@ -54,4 +54,8 @@ public class Member extends BaseEntity {
     public void addMemberChattingRoom(MemberChattingRoom memberChattingRoom) {
         memberChattingRooms.add(memberChattingRoom);
     }
+
+    public Long getMemberProfileId() {
+        return memberProfile.getId();
+    }
 }

--- a/src/main/java/com/cupid/jikting/member/entity/Member.java
+++ b/src/main/java/com/cupid/jikting/member/entity/Member.java
@@ -32,6 +32,10 @@ public class Member extends BaseEntity {
     private String refreshToken;
 
     @Builder.Default
+    @OneToOne(mappedBy = "member", cascade = CascadeType.PERSIST)
+    private MemberProfile memberProfile = new MemberProfile();
+
+    @Builder.Default
     @OneToMany(mappedBy = "member")
     private List<MemberCompany> memberCompanies = new ArrayList<>();
 

--- a/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
+++ b/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
@@ -21,11 +21,11 @@ import java.util.List;
 public class MemberProfile extends BaseEntity {
 
     private String nickname;
-    private String birth;
+    private LocalDate birth;
     private int height;
     private String address;
     private String description;
-    private String school;
+    private String college;
 
     @Enumerated(EnumType.STRING)
     private Gender gender;

--- a/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
+++ b/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
@@ -62,4 +62,28 @@ public class MemberProfile extends BaseEntity {
     @Builder.Default
     @OneToMany(mappedBy = "memberProfile")
     private List<InstantMeetingMember> instantMeetingMembers = new ArrayList<>();
+
+    public Team getTeam() {
+        return teamMembers.stream()
+                .findFirst()
+                .orElseThrow(() -> new BadRequestException(ApplicationError.NOT_EXIST_REGISTERED_TEAM))
+                .getTeam();
+    }
+
+    public List<Recommend> getRecommends() {
+        return getTeam().getRecommendsFrom();
+    }
+
+    public int getAge() {
+        return LocalDate.now().getYear() - birth.getYear() + 1;
+    }
+
+    public String getCompany() {
+        return member.getMemberCompanies()
+                .stream()
+                .findFirst()
+                .orElseThrow(() -> new WrongAccessException(ApplicationError.FORBIDDEN_MEMBER))
+                .getCompany()
+                .getName();
+    }
 }

--- a/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
+++ b/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
@@ -1,13 +1,19 @@
 package com.cupid.jikting.member.entity;
 
 import com.cupid.jikting.common.entity.BaseEntity;
+import com.cupid.jikting.common.error.ApplicationError;
+import com.cupid.jikting.common.error.BadRequestException;
+import com.cupid.jikting.common.error.WrongAccessException;
 import com.cupid.jikting.meeting.entity.InstantMeetingMember;
+import com.cupid.jikting.recommend.entity.Recommend;
+import com.cupid.jikting.team.entity.Team;
 import com.cupid.jikting.team.entity.TeamMember;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.SQLDelete;
 
 import javax.persistence.*;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
+++ b/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
@@ -16,7 +16,7 @@ import java.util.List;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE member_profile SET is_deleted = true WHERE id = ?")
-@AttributeOverride(name = "id", column = @Column(name = "member_id"))
+@AttributeOverride(name = "id", column = @Column(name = "member_profile_id"))
 @Entity
 public class MemberProfile extends BaseEntity {
 

--- a/src/main/java/com/cupid/jikting/member/entity/ProfileImage.java
+++ b/src/main/java/com/cupid/jikting/member/entity/ProfileImage.java
@@ -27,4 +27,12 @@ public class ProfileImage extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_profile_id")
     private MemberProfile memberProfile;
+
+    public String getSequenceName() {
+        return sequence.name();
+    }
+
+    public Long getMemberProfileId() {
+        return memberProfile.getId();
+    }
 }

--- a/src/main/java/com/cupid/jikting/member/handler/LoginSuccessHandler.java
+++ b/src/main/java/com/cupid/jikting/member/handler/LoginSuccessHandler.java
@@ -4,7 +4,6 @@ import com.cupid.jikting.common.error.ApplicationError;
 import com.cupid.jikting.common.error.NotFoundException;
 import com.cupid.jikting.jwt.service.JwtService;
 import com.cupid.jikting.member.entity.Member;
-import com.cupid.jikting.member.entity.MemberProfile;
 import com.cupid.jikting.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -50,8 +49,7 @@ public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
     private Long getMemberProfileIdByUsername(String username) {
         return memberRepository.findByUsername(username)
-                .map(Member::getMemberProfile)
-                .map(MemberProfile::getId)
+                .map(Member::getMemberProfileId)
                 .orElseThrow(() -> new NotFoundException(ApplicationError.MEMBER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/cupid/jikting/recommend/controller/RecommendController.java
+++ b/src/main/java/com/cupid/jikting/recommend/controller/RecommendController.java
@@ -1,5 +1,6 @@
 package com.cupid.jikting.recommend.controller;
 
+import com.cupid.jikting.jwt.service.JwtService;
 import com.cupid.jikting.recommend.dto.RecommendResponse;
 import com.cupid.jikting.recommend.service.RecommendService;
 import lombok.RequiredArgsConstructor;
@@ -14,10 +15,11 @@ import java.util.List;
 public class RecommendController {
 
     private final RecommendService recommendService;
+    private final JwtService jwtService;
 
     @GetMapping
-    public ResponseEntity<List<RecommendResponse>> get() {
-        return ResponseEntity.ok().body(recommendService.get());
+    public ResponseEntity<List<RecommendResponse>> get(@RequestHeader("Authorization") String token) {
+        return ResponseEntity.ok().body(recommendService.get(jwtService.extractValidMemberProfileId(token)));
     }
 
     @PostMapping("/{recommendId}/like")

--- a/src/main/java/com/cupid/jikting/recommend/dto/ImageResponse.java
+++ b/src/main/java/com/cupid/jikting/recommend/dto/ImageResponse.java
@@ -15,10 +15,10 @@ public class ImageResponse {
     private Long memberId;
     private String url;
 
-    public static ImageResponse toImageResponse(ProfileImage profileImage) {
+    public static ImageResponse from(ProfileImage profileImage) {
         return new ImageResponse(
-                profileImage.getSequence().name(),
-                profileImage.getMemberProfile().getId(),
+                profileImage.getSequenceName(),
+                profileImage.getMemberProfileId(),
                 profileImage.getUrl());
     }
 }

--- a/src/main/java/com/cupid/jikting/recommend/dto/ImageResponse.java
+++ b/src/main/java/com/cupid/jikting/recommend/dto/ImageResponse.java
@@ -1,14 +1,24 @@
 package com.cupid.jikting.recommend.dto;
 
-import lombok.*;
+import com.cupid.jikting.member.entity.ProfileImage;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ImageResponse {
 
-    private boolean isMain;
+    private String sequence;
     private Long memberId;
     private String url;
+
+    public static ImageResponse toImageResponse(ProfileImage profileImage) {
+        return new ImageResponse(
+                profileImage.getSequence().name(),
+                profileImage.getMemberProfile().getId(),
+                profileImage.getUrl());
+    }
 }

--- a/src/main/java/com/cupid/jikting/recommend/dto/MemberResponse.java
+++ b/src/main/java/com/cupid/jikting/recommend/dto/MemberResponse.java
@@ -32,7 +32,7 @@ public class MemberResponse {
     private List<String> hobbies;
     private String college;
 
-    public static MemberResponse toMemberResponse(MemberProfile memberProfile) {
+    public static MemberResponse from(MemberProfile memberProfile) {
         return new MemberResponse(
                 memberProfile.getNickname(),
                 getImageResponses(memberProfile),
@@ -51,10 +51,9 @@ public class MemberResponse {
 
     private static List<ImageResponse> getImageResponses(MemberProfile memberProfile) {
         return memberProfile.getProfileImages().stream()
-                .map(ImageResponse::toImageResponse)
+                .map(ImageResponse::from)
                 .collect(Collectors.toList());
     }
-
 
     private static List<String> getMemberProfilePersonalities(MemberProfile memberProfile) {
         return memberProfile.getMemberPersonalities().stream()
@@ -64,7 +63,8 @@ public class MemberResponse {
     }
 
     private static List<String> getHobbies(MemberProfile memberProfile) {
-        return memberProfile.getMemberHobbies().stream()
+        return memberProfile.getMemberHobbies()
+                .stream()
                 .map(MemberHobby::getHobby)
                 .map(Hobby::getKeyword)
                 .collect(Collectors.toList());

--- a/src/main/java/com/cupid/jikting/recommend/dto/MemberResponse.java
+++ b/src/main/java/com/cupid/jikting/recommend/dto/MemberResponse.java
@@ -1,11 +1,19 @@
 package com.cupid.jikting.recommend.dto;
 
-import lombok.*;
+import com.cupid.jikting.common.entity.Hobby;
+import com.cupid.jikting.common.entity.Personality;
+import com.cupid.jikting.member.entity.MemberHobby;
+import com.cupid.jikting.member.entity.MemberPersonality;
+import com.cupid.jikting.member.entity.MemberProfile;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
-@Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberResponse {
@@ -23,4 +31,42 @@ public class MemberResponse {
     private List<String> personalities;
     private List<String> hobbies;
     private String college;
+
+    public static MemberResponse toMemberResponse(MemberProfile memberProfile) {
+        return new MemberResponse(
+                memberProfile.getNickname(),
+                getImageResponses(memberProfile),
+                memberProfile.getAge(),
+                memberProfile.getMbti().toString(),
+                memberProfile.getAddress(),
+                memberProfile.getCompany(),
+                memberProfile.getSmokeStatus().getValue(),
+                memberProfile.getDrinkStatus().getValue(),
+                memberProfile.getHeight(),
+                memberProfile.getDescription(),
+                getMemberProfilePersonalities(memberProfile),
+                getHobbies(memberProfile),
+                memberProfile.getCollege());
+    }
+
+    private static List<ImageResponse> getImageResponses(MemberProfile memberProfile) {
+        return memberProfile.getProfileImages().stream()
+                .map(ImageResponse::toImageResponse)
+                .collect(Collectors.toList());
+    }
+
+
+    private static List<String> getMemberProfilePersonalities(MemberProfile memberProfile) {
+        return memberProfile.getMemberPersonalities().stream()
+                .map(MemberPersonality::getPersonality)
+                .map(Personality::getKeyword)
+                .collect(Collectors.toList());
+    }
+
+    private static List<String> getHobbies(MemberProfile memberProfile) {
+        return memberProfile.getMemberHobbies().stream()
+                .map(MemberHobby::getHobby)
+                .map(Hobby::getKeyword)
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/cupid/jikting/recommend/dto/MemberResponse.java
+++ b/src/main/java/com/cupid/jikting/recommend/dto/MemberResponse.java
@@ -50,13 +50,15 @@ public class MemberResponse {
     }
 
     private static List<ImageResponse> getImageResponses(MemberProfile memberProfile) {
-        return memberProfile.getProfileImages().stream()
+        return memberProfile.getProfileImages()
+                .stream()
                 .map(ImageResponse::from)
                 .collect(Collectors.toList());
     }
 
     private static List<String> getMemberProfilePersonalities(MemberProfile memberProfile) {
-        return memberProfile.getMemberPersonalities().stream()
+        return memberProfile.getMemberPersonalities()
+                .stream()
                 .map(MemberPersonality::getPersonality)
                 .map(Personality::getKeyword)
                 .collect(Collectors.toList());

--- a/src/main/java/com/cupid/jikting/recommend/dto/MemberResponse.java
+++ b/src/main/java/com/cupid/jikting/recommend/dto/MemberResponse.java
@@ -16,7 +16,7 @@ public class MemberResponse {
     private String mbti;
     private String address;
     private String company;
-    private boolean isSmoke;
+    private String smokeStatus;
     private String drinkStatus;
     private int height;
     private String description;

--- a/src/main/java/com/cupid/jikting/recommend/dto/RecommendResponse.java
+++ b/src/main/java/com/cupid/jikting/recommend/dto/RecommendResponse.java
@@ -1,8 +1,12 @@
 package com.cupid.jikting.recommend.dto;
 
+import com.cupid.jikting.common.entity.Personality;
+import com.cupid.jikting.recommend.entity.Recommend;
+import com.cupid.jikting.team.entity.TeamPersonality;
 import lombok.*;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @Builder
@@ -13,4 +17,28 @@ public class RecommendResponse {
     private Long recommendId;
     private List<MemberResponse> members;
     private List<String> personalities;
+
+    public static RecommendResponse from(Recommend recommend) {
+        return new RecommendResponse(
+                recommend.getId(),
+                getMemberResponses(recommend),
+                getTeamPersonalities(recommend));
+    }
+
+    private static List<MemberResponse> getMemberResponses(Recommend recommend) {
+        return recommend.getFrom()
+                .getMemberProfiles()
+                .stream()
+                .map(MemberResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    private static List<String> getTeamPersonalities(Recommend recommend) {
+        return recommend.getFrom()
+                .getTeamPersonalities()
+                .stream()
+                .map(TeamPersonality::getPersonality)
+                .map(Personality::getKeyword)
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/cupid/jikting/recommend/dto/RecommendResponse.java
+++ b/src/main/java/com/cupid/jikting/recommend/dto/RecommendResponse.java
@@ -34,8 +34,7 @@ public class RecommendResponse {
     }
 
     private static List<String> getTeamPersonalities(Recommend recommend) {
-        return recommend.getFrom()
-                .getTeamPersonalities()
+        return recommend.getFromTeamPersonalities()
                 .stream()
                 .map(TeamPersonality::getPersonality)
                 .map(Personality::getKeyword)

--- a/src/main/java/com/cupid/jikting/recommend/entity/Recommend.java
+++ b/src/main/java/com/cupid/jikting/recommend/entity/Recommend.java
@@ -2,6 +2,7 @@ package com.cupid.jikting.recommend.entity;
 
 import com.cupid.jikting.common.entity.BaseEntity;
 import com.cupid.jikting.team.entity.Team;
+import com.cupid.jikting.team.entity.TeamPersonality;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,6 +11,7 @@ import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.SQLDelete;
 
 import javax.persistence.*;
+import java.util.List;
 
 @Getter
 @SuperBuilder
@@ -27,4 +29,8 @@ public class Recommend extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "to_team_id")
     private Team to;
+
+    public List<TeamPersonality> getFromTeamPersonalities() {
+        return from.getTeamPersonalities();
+    }
 }

--- a/src/main/java/com/cupid/jikting/recommend/service/RecommendService.java
+++ b/src/main/java/com/cupid/jikting/recommend/service/RecommendService.java
@@ -1,14 +1,10 @@
 package com.cupid.jikting.recommend.service;
 
-import com.cupid.jikting.common.entity.Personality;
 import com.cupid.jikting.common.error.ApplicationError;
 import com.cupid.jikting.common.error.NotFoundException;
 import com.cupid.jikting.member.entity.MemberProfile;
 import com.cupid.jikting.member.repository.MemberProfileRepository;
-import com.cupid.jikting.recommend.dto.MemberResponse;
 import com.cupid.jikting.recommend.dto.RecommendResponse;
-import com.cupid.jikting.recommend.entity.Recommend;
-import com.cupid.jikting.team.entity.TeamPersonality;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -26,31 +22,10 @@ public class RecommendService {
                 .orElseThrow(() -> new NotFoundException(ApplicationError.MEMBER_NOT_FOUND));
         return memberProfile.getRecommends()
                 .stream()
-                .map(recommend -> RecommendResponse.builder()
-                        .recommendId(recommend.getId())
-                        .members(getMemberResponses(recommend))
-                        .personalities(getTeamPersonalities(recommend))
-                        .build())
+                .map(RecommendResponse::from)
                 .collect(Collectors.toList());
     }
 
     public void sendLike(Long recommendId) {
-    }
-
-    private List<MemberResponse> getMemberResponses(Recommend recommend) {
-        return recommend.getFrom()
-                .getMemberProfiles()
-                .stream()
-                .map(MemberResponse::toMemberResponse)
-                .collect(Collectors.toList());
-    }
-
-    private List<String> getTeamPersonalities(Recommend recommend) {
-        return recommend.getFrom()
-                .getTeamPersonalities()
-                .stream()
-                .map(TeamPersonality::getPersonality)
-                .map(Personality::getKeyword)
-                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/cupid/jikting/recommend/service/RecommendService.java
+++ b/src/main/java/com/cupid/jikting/recommend/service/RecommendService.java
@@ -1,17 +1,93 @@
 package com.cupid.jikting.recommend.service;
 
+import com.cupid.jikting.common.entity.Hobby;
+import com.cupid.jikting.common.entity.Personality;
+import com.cupid.jikting.common.error.ApplicationError;
+import com.cupid.jikting.common.error.NotFoundException;
+import com.cupid.jikting.member.entity.MemberHobby;
+import com.cupid.jikting.member.entity.MemberPersonality;
+import com.cupid.jikting.member.entity.MemberProfile;
+import com.cupid.jikting.member.repository.MemberProfileRepository;
+import com.cupid.jikting.recommend.dto.ImageResponse;
+import com.cupid.jikting.recommend.dto.MemberResponse;
 import com.cupid.jikting.recommend.dto.RecommendResponse;
+import com.cupid.jikting.recommend.entity.Recommend;
+import com.cupid.jikting.team.entity.TeamPersonality;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
+@RequiredArgsConstructor
 @Service
 public class RecommendService {
 
-    public List<RecommendResponse> get() {
-        return null;
+    private final MemberProfileRepository memberProfileRepository;
+
+    public List<RecommendResponse> get(Long memberProfileId) {
+        MemberProfile memberProfile = memberProfileRepository.findById(memberProfileId)
+                .orElseThrow(() -> new NotFoundException(ApplicationError.MEMBER_NOT_FOUND));
+        return memberProfile.getRecommends()
+                .stream()
+                .map(recommend -> RecommendResponse.builder()
+                        .recommendId(recommend.getId())
+                        .members(getMemberResponses(recommend))
+                        .personalities(getTeamPersonalities(recommend))
+                        .build())
+                .collect(Collectors.toList());
     }
 
     public void sendLike(Long recommendId) {
+    }
+
+    private static List<MemberResponse> getMemberResponses(Recommend recommend) {
+        return recommend.getFrom()
+                .getMemberProfiles()
+                .stream()
+                .map(RecommendService::toMemberResponse)
+                .collect(Collectors.toList());
+    }
+
+    private static MemberResponse toMemberResponse(MemberProfile memberProfile) {
+        return MemberResponse.builder()
+                .nickname(memberProfile.getNickname())
+                .images(List.of(ImageResponse.builder().build())) // TODO
+                .age(memberProfile.getAge())
+                .mbti(memberProfile.getMbti().toString())
+                .address(memberProfile.getAddress())
+                .company(memberProfile.getCompany())
+                .smokeStatus(memberProfile.getSmokeStatus().getValue())
+                .drinkStatus(memberProfile.getDrinkStatus().getValue())
+                .height(memberProfile.getHeight())
+                .description(memberProfile.getDescription())
+                .personalities(getMemberProfilePersonalities(memberProfile))
+                .hobbies(getHobbies(memberProfile))
+                .college(memberProfile.getCollege())
+                .build();
+    }
+
+
+    private static List<String> getMemberProfilePersonalities(MemberProfile memberProfile) {
+        return memberProfile.getMemberPersonalities().stream()
+                .map(MemberPersonality::getPersonality)
+                .map(Personality::getKeyword)
+                .collect(Collectors.toList());
+    }
+
+    private static List<String> getHobbies(MemberProfile memberProfile) {
+        return memberProfile.getMemberHobbies().stream()
+                .map(MemberHobby::getHobby)
+                .map(Hobby::getKeyword)
+                .collect(Collectors.toList());
+    }
+
+    private static List<String> getTeamPersonalities(Recommend recommend) {
+        return recommend.getFrom()
+                .getTeamPersonalities()
+                .stream()
+                .map(TeamPersonality::getPersonality)
+                .map(Personality::getKeyword)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/cupid/jikting/recommend/service/RecommendService.java
+++ b/src/main/java/com/cupid/jikting/recommend/service/RecommendService.java
@@ -1,14 +1,10 @@
 package com.cupid.jikting.recommend.service;
 
-import com.cupid.jikting.common.entity.Hobby;
 import com.cupid.jikting.common.entity.Personality;
 import com.cupid.jikting.common.error.ApplicationError;
 import com.cupid.jikting.common.error.NotFoundException;
-import com.cupid.jikting.member.entity.MemberHobby;
-import com.cupid.jikting.member.entity.MemberPersonality;
 import com.cupid.jikting.member.entity.MemberProfile;
 import com.cupid.jikting.member.repository.MemberProfileRepository;
-import com.cupid.jikting.recommend.dto.ImageResponse;
 import com.cupid.jikting.recommend.dto.MemberResponse;
 import com.cupid.jikting.recommend.dto.RecommendResponse;
 import com.cupid.jikting.recommend.entity.Recommend;
@@ -41,48 +37,15 @@ public class RecommendService {
     public void sendLike(Long recommendId) {
     }
 
-    private static List<MemberResponse> getMemberResponses(Recommend recommend) {
+    private List<MemberResponse> getMemberResponses(Recommend recommend) {
         return recommend.getFrom()
                 .getMemberProfiles()
                 .stream()
-                .map(RecommendService::toMemberResponse)
+                .map(MemberResponse::toMemberResponse)
                 .collect(Collectors.toList());
     }
 
-    private static MemberResponse toMemberResponse(MemberProfile memberProfile) {
-        return MemberResponse.builder()
-                .nickname(memberProfile.getNickname())
-                .images(List.of(ImageResponse.builder().build())) // TODO
-                .age(memberProfile.getAge())
-                .mbti(memberProfile.getMbti().toString())
-                .address(memberProfile.getAddress())
-                .company(memberProfile.getCompany())
-                .smokeStatus(memberProfile.getSmokeStatus().getValue())
-                .drinkStatus(memberProfile.getDrinkStatus().getValue())
-                .height(memberProfile.getHeight())
-                .description(memberProfile.getDescription())
-                .personalities(getMemberProfilePersonalities(memberProfile))
-                .hobbies(getHobbies(memberProfile))
-                .college(memberProfile.getCollege())
-                .build();
-    }
-
-
-    private static List<String> getMemberProfilePersonalities(MemberProfile memberProfile) {
-        return memberProfile.getMemberPersonalities().stream()
-                .map(MemberPersonality::getPersonality)
-                .map(Personality::getKeyword)
-                .collect(Collectors.toList());
-    }
-
-    private static List<String> getHobbies(MemberProfile memberProfile) {
-        return memberProfile.getMemberHobbies().stream()
-                .map(MemberHobby::getHobby)
-                .map(Hobby::getKeyword)
-                .collect(Collectors.toList());
-    }
-
-    private static List<String> getTeamPersonalities(Recommend recommend) {
+    private List<String> getTeamPersonalities(Recommend recommend) {
         return recommend.getFrom()
                 .getTeamPersonalities()
                 .stream()

--- a/src/main/java/com/cupid/jikting/team/entity/Team.java
+++ b/src/main/java/com/cupid/jikting/team/entity/Team.java
@@ -2,6 +2,7 @@ package com.cupid.jikting.team.entity;
 
 import com.cupid.jikting.common.entity.BaseEntity;
 import com.cupid.jikting.meeting.entity.Meeting;
+import com.cupid.jikting.member.entity.MemberProfile;
 import com.cupid.jikting.recommend.entity.Recommend;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
@@ -13,6 +14,7 @@ import javax.persistence.Entity;
 import javax.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @SuperBuilder
@@ -58,4 +60,10 @@ public class Team extends BaseEntity {
     @Builder.Default
     @OneToMany(mappedBy = "acceptingTeam")
     private List<Meeting> acceptingMeetings = new ArrayList<>();
+
+    public List<MemberProfile> getMemberProfiles() {
+        return teamMembers.stream()
+                .map(TeamMember::getMemberProfile)
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/cupid/jikting/team/entity/TeamMember.java
+++ b/src/main/java/com/cupid/jikting/team/entity/TeamMember.java
@@ -16,7 +16,7 @@ import javax.persistence.*;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE team_member SET is_deleted = true WHERE team_member_id = ?")
-@AttributeOverride(name = "id", column = @Column(name = "team_member__id"))
+@AttributeOverride(name = "id", column = @Column(name = "team_member_id"))
 @Entity
 public class TeamMember extends BaseEntity {
 

--- a/src/test/java/com/cupid/jikting/recommend/controller/RecommendControllerTest.java
+++ b/src/test/java/com/cupid/jikting/recommend/controller/RecommendControllerTest.java
@@ -45,7 +45,6 @@ public class RecommendControllerTest extends ApiDocument {
     private static final String URL = "http://test-url";
     private static final String COMPANY = "회사";
     private static final String DESCRIPTION = "소개";
-    private static final String DRINK_STATUS = "안마심";
     private static final String ADDRESS = "거주지";
     private static final String COLLEGE = "대학";
     private static final LocalDate BIRTH = LocalDate.of(1997, 9, 11);
@@ -54,8 +53,7 @@ public class RecommendControllerTest extends ApiDocument {
     private static final String AUTHORIZATION = "Authorization";
     private static final String BEARER = "Bearer ";
 
-    private static String ACCESS_TOKEN;
-
+    private String accessToken;
     private List<RecommendResponse> recommendResponses;
     private ApplicationException teamNotFoundException;
 
@@ -117,7 +115,7 @@ public class RecommendControllerTest extends ApiDocument {
                 .college(COLLEGE)
                 .build();
         List<MemberResponse> memberResponses = IntStream.rangeClosed(0, 2)
-                .mapToObj(n -> MemberResponse.toMemberResponse(memberProfile))
+                .mapToObj(n -> MemberResponse.from(memberProfile))
                 .collect(Collectors.toList());
         RecommendResponse recommendResponse = RecommendResponse.builder()
                 .recommendId(ID)
@@ -128,7 +126,7 @@ public class RecommendControllerTest extends ApiDocument {
                 .mapToObj(n -> recommendResponse)
                 .collect(Collectors.toList());
         teamNotFoundException = new NotFoundException(ApplicationError.TEAM_NOT_FOUND);
-        ACCESS_TOKEN = jwtService.createAccessToken(ID);
+        accessToken = jwtService.createAccessToken(ID);
     }
 
     @WithMockUser
@@ -178,7 +176,7 @@ public class RecommendControllerTest extends ApiDocument {
     private ResultActions 추천팀_조회_요청() throws Exception {
         return mockMvc.perform(get(CONTEXT_PATH + DOMAIN_ROOT_PATH)
                 .contextPath(CONTEXT_PATH)
-                .header(AUTHORIZATION, BEARER + ACCESS_TOKEN));
+                .header(AUTHORIZATION, BEARER + accessToken));
     }
 
     private void 추천팀_조회_요청_성공(ResultActions resultActions) throws Exception {

--- a/src/test/java/com/cupid/jikting/recommend/controller/RecommendControllerTest.java
+++ b/src/test/java/com/cupid/jikting/recommend/controller/RecommendControllerTest.java
@@ -3,12 +3,13 @@ package com.cupid.jikting.recommend.controller;
 import com.cupid.jikting.ApiDocument;
 import com.cupid.jikting.TestSecurityConfig;
 import com.cupid.jikting.common.dto.ErrorResponse;
+import com.cupid.jikting.common.entity.Hobby;
+import com.cupid.jikting.common.entity.Personality;
 import com.cupid.jikting.common.error.ApplicationError;
 import com.cupid.jikting.common.error.ApplicationException;
 import com.cupid.jikting.common.error.NotFoundException;
 import com.cupid.jikting.jwt.service.JwtService;
-import com.cupid.jikting.member.entity.SmokeStatus;
-import com.cupid.jikting.recommend.dto.ImageResponse;
+import com.cupid.jikting.member.entity.*;
 import com.cupid.jikting.recommend.dto.MemberResponse;
 import com.cupid.jikting.recommend.dto.RecommendResponse;
 import com.cupid.jikting.recommend.service.RecommendService;
@@ -20,10 +21,10 @@ import org.springframework.context.annotation.Import;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.ResultActions;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import java.util.stream.LongStream;
 
 import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -45,13 +46,11 @@ public class RecommendControllerTest extends ApiDocument {
     private static final String COMPANY = "회사";
     private static final String DESCRIPTION = "소개";
     private static final String DRINK_STATUS = "안마심";
-    private static final String MBTI = "mbti";
     private static final String ADDRESS = "거주지";
     private static final String COLLEGE = "대학";
-    private static final int AGE = 20;
+    private static final LocalDate BIRTH = LocalDate.of(1997, 9, 11);
     private static final int HEIGHT = 180;
     private static final Long ID = 1L;
-    private static final boolean TRUE = true;
     private static final String AUTHORIZATION = "Authorization";
     private static final String BEARER = "Bearer ";
 
@@ -68,34 +67,57 @@ public class RecommendControllerTest extends ApiDocument {
 
     @BeforeEach
     void setUp() {
-        List<String> hobbies = IntStream.rangeClosed(1, 3)
-                .mapToObj(n -> HOBBY + n)
-                .collect(Collectors.toList());
         List<String> personalities = IntStream.rangeClosed(1, 3)
                 .mapToObj(n -> PERSONALITY + n)
                 .collect(Collectors.toList());
-        List<ImageResponse> imageResponses = LongStream.rangeClosed(1, 3)
-                .mapToObj(n -> ImageResponse.builder()
-                        .isMain(TRUE)
-                        .memberId(n)
-                        .url(URL + n)
+        MemberProfile tmpMemberProfile = MemberProfile.builder()
+                .id(ID)
+                .build();
+        List<ProfileImage> profileImages = IntStream.rangeClosed(0, 2)
+                .mapToObj(n -> ProfileImage.builder()
+                        .memberProfile(tmpMemberProfile)
+                        .sequence(Sequence.MAIN)
+                        .url(URL)
                         .build())
                 .collect(Collectors.toList());
-        List<MemberResponse> memberResponses = IntStream.rangeClosed(1, 2)
-                .mapToObj(n -> MemberResponse.builder()
-                        .nickname(NICKNAME)
-                        .age(AGE)
-                        .mbti(MBTI)
-                        .address(ADDRESS)
-                        .company(COMPANY)
-                        .smokeStatus(SmokeStatus.SMOKING.getValue())
-                        .drinkStatus(DRINK_STATUS)
-                        .height(HEIGHT)
-                        .description(DESCRIPTION)
-                        .hobbies(hobbies)
-                        .images(imageResponses)
-                        .college(COLLEGE)
-                        .build())
+        Company company = Company.builder()
+                .name(COMPANY)
+                .build();
+        MemberCompany memberCompany = MemberCompany.builder()
+                .company(company)
+                .build();
+        Member member = Member.builder()
+                .memberCompanies(List.of(memberCompany))
+                .build();
+        Hobby hobby = Hobby.builder()
+                .keyword(HOBBY)
+                .build();
+        Personality personality = Personality.builder()
+                .keyword(PERSONALITY)
+                .build();
+        MemberHobby memberHobby = MemberHobby.builder()
+                .hobby(hobby)
+                .build();
+        MemberPersonality memberPersonality = MemberPersonality.builder()
+                .personality(personality)
+                .build();
+        MemberProfile memberProfile = MemberProfile.builder()
+                .member(member)
+                .nickname(NICKNAME)
+                .birth(BIRTH)
+                .mbti(MBTI.ENFJ)
+                .address(ADDRESS)
+                .smokeStatus(SmokeStatus.SMOKING)
+                .drinkStatus(DrinkStatus.NEVER)
+                .height(HEIGHT)
+                .description(DESCRIPTION)
+                .memberHobbies(List.of(memberHobby))
+                .memberPersonalities(List.of(memberPersonality))
+                .profileImages(profileImages)
+                .college(COLLEGE)
+                .build();
+        List<MemberResponse> memberResponses = IntStream.rangeClosed(0, 2)
+                .mapToObj(n -> MemberResponse.toMemberResponse(memberProfile))
                 .collect(Collectors.toList());
         RecommendResponse recommendResponse = RecommendResponse.builder()
                 .recommendId(ID)

--- a/src/test/java/com/cupid/jikting/recommend/service/RecommendServiceTest.java
+++ b/src/test/java/com/cupid/jikting/recommend/service/RecommendServiceTest.java
@@ -1,0 +1,79 @@
+package com.cupid.jikting.recommend.service;
+
+import com.cupid.jikting.common.error.ApplicationError;
+import com.cupid.jikting.common.error.ApplicationException;
+import com.cupid.jikting.common.error.NotFoundException;
+import com.cupid.jikting.member.entity.MemberProfile;
+import com.cupid.jikting.member.repository.MemberProfileRepository;
+import com.cupid.jikting.recommend.dto.RecommendResponse;
+import com.cupid.jikting.team.entity.Team;
+import com.cupid.jikting.team.entity.TeamMember;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.willReturn;
+import static org.mockito.BDDMockito.willThrow;
+
+@WebMvcTest(MockitoExtension.class)
+public class RecommendServiceTest {
+
+    private static final Long ID = 1L;
+    private static final String TEAM_NAME = "팀 이름";
+
+    private MemberProfile memberProfile;
+    private ApplicationException memberNotFoundException;
+
+    @InjectMocks
+    private RecommendService recommendService;
+
+    @Mock
+    private MemberProfileRepository memberProfileRepository;
+
+    @BeforeEach
+    void setUp() {
+        Team team = Team.builder()
+                .id(ID)
+                .name(TEAM_NAME)
+                .build();
+        List<TeamMember> teamMembers = List.of(TeamMember.builder()
+                .id(ID)
+                .memberProfile(memberProfile)
+                .team(team)
+                .build());
+        memberProfile = MemberProfile.builder()
+                .id(ID)
+                .teamMembers(teamMembers)
+                .build();
+        memberNotFoundException = new NotFoundException(ApplicationError.MEMBER_NOT_FOUND);
+    }
+
+    @Test
+    void 추천팀_조회_성공() {
+        //given
+        willReturn(Optional.of(memberProfile)).given(memberProfileRepository).findById(anyLong());
+        //when
+        List<RecommendResponse> recommendResponses = recommendService.get(ID);
+        //then
+        assertThat(recommendResponses.size()).isEqualTo(3);
+    }
+
+    @Test
+    void 추천팀_조회_실패_회원_프로필_없음() {
+        // given
+        willThrow(memberNotFoundException).given(memberProfileRepository).findById(anyLong());
+        // when & then
+        assertThatThrownBy(() -> recommendService.get(ID))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage(ApplicationError.MEMBER_NOT_FOUND.getMessage());
+    }
+}

--- a/src/test/java/com/cupid/jikting/recommend/service/RecommendServiceTest.java
+++ b/src/test/java/com/cupid/jikting/recommend/service/RecommendServiceTest.java
@@ -70,7 +70,7 @@ public class RecommendServiceTest {
         List<MemberHobby> memberHobbies = List.of(MemberHobby.builder()
                 .hobby(hobby)
                 .build());
-        MemberProfile memberProfile1 = MemberProfile.builder()
+        MemberProfile memberProfile = MemberProfile.builder()
                 .birth(BIRTH)
                 .mbti(MBTI.ENFJ)
                 .address(ADDRESS)
@@ -83,33 +83,28 @@ public class RecommendServiceTest {
                 .memberHobbies(memberHobbies)
                 .college(COLLEGE)
                 .build();
-        List<TeamMember> teamMembers = List.of(TeamMember.builder()
-                .memberProfile(memberProfile1)
+        List<TeamMember> teamMembersFrom = List.of(TeamMember.builder()
+                .memberProfile(memberProfile)
                 .build());
         Team teamFrom = Team.builder()
-                .teamMembers(teamMembers)
+                .teamMembers(teamMembersFrom)
                 .build();
         List<Recommend> recommends = IntStream.rangeClosed(0, 2)
                 .mapToObj(n -> Recommend.builder()
-                        .id(ID)
                         .from(teamFrom)
                         .build())
                 .collect(Collectors.toList());
         Team team = Team.builder()
-                .id(ID)
-                .name(TEAM_NAME)
                 .recommendsFrom(recommends)
                 .build();
-        List<TeamMember> teamMembers1 = IntStream.rangeClosed(0, 2)
+        List<TeamMember> teamMembers = IntStream.rangeClosed(0, 2)
                 .mapToObj(n -> TeamMember.builder()
-                        .id(ID)
-                        .memberProfile(memberProfile)
                         .team(team)
                         .build())
                 .collect(Collectors.toList());
-        memberProfile = MemberProfile.builder()
+        this.memberProfile = MemberProfile.builder()
                 .id(ID)
-                .teamMembers(teamMembers1)
+                .teamMembers(teamMembers)
                 .build();
         memberNotFoundException = new NotFoundException(ApplicationError.MEMBER_NOT_FOUND);
     }

--- a/src/test/java/com/cupid/jikting/recommend/service/RecommendServiceTest.java
+++ b/src/test/java/com/cupid/jikting/recommend/service/RecommendServiceTest.java
@@ -1,11 +1,14 @@
 package com.cupid.jikting.recommend.service;
 
+import com.cupid.jikting.common.entity.Hobby;
+import com.cupid.jikting.common.entity.Personality;
 import com.cupid.jikting.common.error.ApplicationError;
 import com.cupid.jikting.common.error.ApplicationException;
 import com.cupid.jikting.common.error.NotFoundException;
-import com.cupid.jikting.member.entity.MemberProfile;
+import com.cupid.jikting.member.entity.*;
 import com.cupid.jikting.member.repository.MemberProfileRepository;
 import com.cupid.jikting.recommend.dto.RecommendResponse;
+import com.cupid.jikting.recommend.entity.Recommend;
 import com.cupid.jikting.team.entity.Team;
 import com.cupid.jikting.team.entity.TeamMember;
 import org.junit.jupiter.api.BeforeEach;
@@ -15,8 +18,11 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
@@ -29,6 +35,12 @@ public class RecommendServiceTest {
 
     private static final Long ID = 1L;
     private static final String TEAM_NAME = "팀 이름";
+    private static final LocalDate BIRTH = LocalDate.now();
+    private static final String ADDRESS = "지역";
+    private static final String COMPANY = "회사";
+    private static final int HEIGHT = 180;
+    private static final String DESCRIPTION = "자기소개";
+    private static final String COLLEGE = "대학";
 
     private MemberProfile memberProfile;
     private ApplicationException memberNotFoundException;
@@ -41,18 +53,63 @@ public class RecommendServiceTest {
 
     @BeforeEach
     void setUp() {
+        Company company = Company.builder()
+                .name(COMPANY)
+                .build();
+        List<MemberCompany> memberCompanies = List.of(MemberCompany.builder()
+                .company(company)
+                .build());
+        Member member = Member.builder()
+                .memberCompanies(memberCompanies)
+                .build();
+        Personality personality = Personality.builder().build();
+        List<MemberPersonality> memberPersonalities = List.of(MemberPersonality.builder()
+                .personality(personality)
+                .build());
+        Hobby hobby = Hobby.builder().build();
+        List<MemberHobby> memberHobbies = List.of(MemberHobby.builder()
+                .hobby(hobby)
+                .build());
+        MemberProfile memberProfile1 = MemberProfile.builder()
+                .birth(BIRTH)
+                .mbti(MBTI.ENFJ)
+                .address(ADDRESS)
+                .member(member)
+                .smokeStatus(SmokeStatus.SMOKING)
+                .drinkStatus(DrinkStatus.NEVER)
+                .height(HEIGHT)
+                .description(DESCRIPTION)
+                .memberPersonalities(memberPersonalities)
+                .memberHobbies(memberHobbies)
+                .college(COLLEGE)
+                .build();
+        List<TeamMember> teamMembers = List.of(TeamMember.builder()
+                .memberProfile(memberProfile1)
+                .build());
+        Team teamFrom = Team.builder()
+                .teamMembers(teamMembers)
+                .build();
+        List<Recommend> recommends = IntStream.rangeClosed(0, 2)
+                .mapToObj(n -> Recommend.builder()
+                        .id(ID)
+                        .from(teamFrom)
+                        .build())
+                .collect(Collectors.toList());
         Team team = Team.builder()
                 .id(ID)
                 .name(TEAM_NAME)
+                .recommendsFrom(recommends)
                 .build();
-        List<TeamMember> teamMembers = List.of(TeamMember.builder()
-                .id(ID)
-                .memberProfile(memberProfile)
-                .team(team)
-                .build());
+        List<TeamMember> teamMembers1 = IntStream.rangeClosed(0, 2)
+                .mapToObj(n -> TeamMember.builder()
+                        .id(ID)
+                        .memberProfile(memberProfile)
+                        .team(team)
+                        .build())
+                .collect(Collectors.toList());
         memberProfile = MemberProfile.builder()
                 .id(ID)
-                .teamMembers(teamMembers)
+                .teamMembers(teamMembers1)
                 .build();
         memberNotFoundException = new NotFoundException(ApplicationError.MEMBER_NOT_FOUND);
     }


### PR DESCRIPTION
## Issue

closed #105 
[SP-208](https://soma-cupid.atlassian.net/browse/SP-208?atlOrigin=eyJpIjoiMDY5YmU4N2IwZTE5NDUyZjk3N2RlZmQ2NDk3M2NiOWYiLCJwIjoiaiJ9)

## 요구사항

- [x] 미팅 추천 - 팀 조회 기능 구현

## 변경사항

- `JwtAuthenticationFilter`, `JwtService`, `LoginSucessHandler`에 jwt token claim username -> memberProfileId로 변경
- `RecommendService`에 get 메서드 구현
- `RecommendController`, `RecommendControllerTest`에 token 추출 추가
- `RecommendServiceTest` 추가 및 추천팀 조회 테스트 추가
- `MemberProfile`, `Team`에 연관관계 get 메서드 추가

## 리뷰 우선순위

🙂보통

## 코멘트

- 자잘한 오타 수정은 변경사항에 넣지 않았습니다.



[SP-208]: https://soma-cupid.atlassian.net/browse/SP-208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ