### PR TITLE
[SP-186] 팀 등록 기능 구현

### DIFF
--- a/src/main/java/com/cupid/jikting/common/entity/Personality.java
+++ b/src/main/java/com/cupid/jikting/common/entity/Personality.java
@@ -1,17 +1,15 @@
 package com.cupid.jikting.common.entity;
 
-import com.cupid.jikting.member.entity.MemberPersonality;
-import com.cupid.jikting.team.entity.TeamPersonality;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.SQLDelete;
 
 import javax.persistence.AttributeOverride;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.OneToMany;
-import java.util.ArrayList;
-import java.util.List;
 
 @Getter
 @SuperBuilder
@@ -23,12 +21,4 @@ import java.util.List;
 public class Personality extends BaseEntity {
 
     private String keyword;
-
-    @Builder.Default
-    @OneToMany(mappedBy = "personality")
-    private List<MemberPersonality> memberPersonalities = new ArrayList<>();
-
-    @Builder.Default
-    @OneToMany(mappedBy = "personality")
-    private List<TeamPersonality> teamPersonalities = new ArrayList<>();
 }

--- a/src/main/java/com/cupid/jikting/common/error/ApplicationError.java
+++ b/src/main/java/com/cupid/jikting/common/error/ApplicationError.java
@@ -18,6 +18,7 @@ public enum ApplicationError {
     INVALID_TOKEN(HttpStatus.BAD_REQUEST, "C008", "token이 유효하지 않습니다."),
     EXPIRED_TOKEN(HttpStatus.BAD_REQUEST, "C009", "token 유효기간이 만료되었습니다."),
     VERIFICATION_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "C010", "인증번호가 유효하지 않습니다."),
+    PERSONALITY_NOT_FOUND(HttpStatus.BAD_REQUEST, "C011", "성격 키워드를 찾을 수 없습니다."),
 
     UNAUTHORIZED_MEMBER(HttpStatus.UNAUTHORIZED, "U001", "인증되지 않은 사용자입니다."),
     FORBIDDEN_MEMBER(HttpStatus.FORBIDDEN, "U002", "권한이 없는 사용자입니다."),

--- a/src/main/java/com/cupid/jikting/team/dto/TeamRegisterRequest.java
+++ b/src/main/java/com/cupid/jikting/team/dto/TeamRegisterRequest.java
@@ -11,5 +11,6 @@ import java.util.List;
 public class TeamRegisterRequest {
 
     private String description;
+    private int memberCount;
     private List<String> keywords;
 }

--- a/src/main/java/com/cupid/jikting/team/dto/TeamRegisterResponse.java
+++ b/src/main/java/com/cupid/jikting/team/dto/TeamRegisterResponse.java
@@ -3,10 +3,13 @@ package com.cupid.jikting.team.dto;
 import lombok.*;
 
 @Getter
-@Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TeamRegisterResponse {
 
     private String invitationUrl;
+
+    public static TeamRegisterResponse from(String invitationUrl) {
+        return new TeamRegisterResponse(invitationUrl);
+    }
 }

--- a/src/main/java/com/cupid/jikting/team/entity/Team.java
+++ b/src/main/java/com/cupid/jikting/team/entity/Team.java
@@ -1,6 +1,7 @@
 package com.cupid.jikting.team.entity;
 
 import com.cupid.jikting.common.entity.BaseEntity;
+import com.cupid.jikting.common.entity.Personality;
 import com.cupid.jikting.meeting.entity.Meeting;
 import com.cupid.jikting.recommend.entity.Recommend;
 import lombok.*;
@@ -58,4 +59,13 @@ public class Team extends BaseEntity {
     @Builder.Default
     @OneToMany(mappedBy = "acceptingTeam")
     private List<Meeting> acceptingMeetings = new ArrayList<>();
+
+    public void addTeamPersonalities(List<Personality> personalities) {
+        personalities.stream()
+                .map(personality -> TeamPersonality.builder()
+                        .team(this)
+                        .personality(personality)
+                        .build())
+                .forEach(teamPersonalities::add);
+    }
 }

--- a/src/main/java/com/cupid/jikting/team/repository/PersonalityRepository.java
+++ b/src/main/java/com/cupid/jikting/team/repository/PersonalityRepository.java
@@ -3,6 +3,9 @@ package com.cupid.jikting.team.repository;
 import com.cupid.jikting.common.entity.Personality;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface PersonalityRepository extends JpaRepository<Personality, Long> {
 
+    Optional<Personality> findByKeyword(String keyword);
 }

--- a/src/main/java/com/cupid/jikting/team/repository/PersonalityRepository.java
+++ b/src/main/java/com/cupid/jikting/team/repository/PersonalityRepository.java
@@ -1,0 +1,8 @@
+package com.cupid.jikting.team.repository;
+
+import com.cupid.jikting.common.entity.Personality;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PersonalityRepository extends JpaRepository<Personality, Long> {
+
+}

--- a/src/main/java/com/cupid/jikting/team/repository/TeamRepository.java
+++ b/src/main/java/com/cupid/jikting/team/repository/TeamRepository.java
@@ -1,0 +1,8 @@
+package com.cupid.jikting.team.repository;
+
+import com.cupid.jikting.team.entity.Team;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TeamRepository extends JpaRepository<Team, Long> {
+
+}

--- a/src/main/java/com/cupid/jikting/team/service/TeamService.java
+++ b/src/main/java/com/cupid/jikting/team/service/TeamService.java
@@ -1,16 +1,41 @@
 package com.cupid.jikting.team.service;
 
+import com.cupid.jikting.common.entity.Personality;
+import com.cupid.jikting.common.error.ApplicationError;
+import com.cupid.jikting.common.error.BadRequestException;
 import com.cupid.jikting.team.dto.TeamRegisterRequest;
 import com.cupid.jikting.team.dto.TeamRegisterResponse;
 import com.cupid.jikting.team.dto.TeamResponse;
 import com.cupid.jikting.team.dto.TeamUpdateRequest;
+import com.cupid.jikting.team.entity.Team;
+import com.cupid.jikting.team.repository.PersonalityRepository;
+import com.cupid.jikting.team.repository.TeamRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
 @Service
 public class TeamService {
 
+    private static final String TEAM_URL = "https://jikting.com/teams/";
+    private static final String INVITE = "/invite";
+
+    private final TeamRepository teamRepository;
+    private final PersonalityRepository personalityRepository;
+
     public TeamRegisterResponse register(TeamRegisterRequest teamRegisterRequest) {
-        return null;
+        Team team = Team.builder()
+                .name(String.valueOf(UUID.randomUUID()))
+                .description(teamRegisterRequest.getDescription())
+                .memberCount(teamRegisterRequest.getMemberCount())
+                .build();
+        team.addTeamPersonalities(getPersonalities(teamRegisterRequest.getKeywords()));
+        Team savedTeam = teamRepository.save(team);
+        return TeamRegisterResponse.from(TEAM_URL + savedTeam.getId() + INVITE);
     }
 
     public void attend(Long teamId) {
@@ -27,5 +52,16 @@ public class TeamService {
     }
 
     public void deleteMember(Long teamId, Long memberId) {
+    }
+
+    private List<Personality> getPersonalities(List<String> keywords) {
+        return keywords.stream()
+                .map(this::getPersonality)
+                .collect(Collectors.toList());
+    }
+
+    private Personality getPersonality(String keyword) {
+        return personalityRepository.findByKeyword(keyword)
+                .orElseThrow(() -> new BadRequestException(ApplicationError.PERSONALITY_NOT_FOUND));
     }
 }

--- a/src/main/java/com/cupid/jikting/team/service/TeamService.java
+++ b/src/main/java/com/cupid/jikting/team/service/TeamService.java
@@ -2,7 +2,7 @@ package com.cupid.jikting.team.service;
 
 import com.cupid.jikting.common.entity.Personality;
 import com.cupid.jikting.common.error.ApplicationError;
-import com.cupid.jikting.common.error.BadRequestException;
+import com.cupid.jikting.common.error.NotFoundException;
 import com.cupid.jikting.team.dto.TeamRegisterRequest;
 import com.cupid.jikting.team.dto.TeamRegisterResponse;
 import com.cupid.jikting.team.dto.TeamResponse;
@@ -62,6 +62,6 @@ public class TeamService {
 
     private Personality getPersonality(String keyword) {
         return personalityRepository.findByKeyword(keyword)
-                .orElseThrow(() -> new BadRequestException(ApplicationError.PERSONALITY_NOT_FOUND));
+                .orElseThrow(() -> new NotFoundException(ApplicationError.PERSONALITY_NOT_FOUND));
     }
 }

--- a/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
+++ b/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
@@ -93,7 +93,8 @@ public class MemberServiceTest {
         //given
         willThrow(rollbackException).given(memberRepository).save(any(Member.class));
         //when & then
-        assertThatThrownBy(() -> memberService.signup(signupRequest)).isInstanceOf(RollbackException.class);
+        assertThatThrownBy(() -> memberService.signup(signupRequest))
+                .isInstanceOf(RollbackException.class);
     }
 
     @Test

--- a/src/test/java/com/cupid/jikting/team/controller/TeamControllerTest.java
+++ b/src/test/java/com/cupid/jikting/team/controller/TeamControllerTest.java
@@ -82,9 +82,7 @@ public class TeamControllerTest extends ApiDocument {
                 .description(DESCRIPTION)
                 .keywords(keywords)
                 .build();
-        teamRegisterResponse = TeamRegisterResponse.builder()
-                .invitationUrl(INVITATION_URL)
-                .build();
+        teamRegisterResponse = TeamRegisterResponse.from(INVITATION_URL);
         teamResponse = TeamResponse.builder()
                 .description(DESCRIPTION)
                 .keywords(keywords)

--- a/src/test/java/com/cupid/jikting/team/repository/PersonalityRepositoryTest.java
+++ b/src/test/java/com/cupid/jikting/team/repository/PersonalityRepositoryTest.java
@@ -1,0 +1,30 @@
+package com.cupid.jikting.team.repository;
+
+import com.cupid.jikting.common.entity.Personality;
+import com.cupid.jikting.common.error.ApplicationError;
+import com.cupid.jikting.common.error.NotFoundException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class PersonalityRepositoryTest {
+
+    @Autowired
+    private PersonalityRepository personalityRepository;
+
+    @Test
+    void 키워드로_팀성격_조회_성공() {
+        // given
+        String keyword = "활발한";
+        // when
+        Personality personality = personalityRepository.findByKeyword(keyword)
+                .orElseThrow(() -> new NotFoundException(ApplicationError.PERSONALITY_NOT_FOUND));
+        // then
+        assertThat(personality.getKeyword()).isEqualTo(keyword);
+    }
+}

--- a/src/test/java/com/cupid/jikting/team/repository/TeamRepositoryTest.java
+++ b/src/test/java/com/cupid/jikting/team/repository/TeamRepositoryTest.java
@@ -1,0 +1,49 @@
+package com.cupid.jikting.team.repository;
+
+import com.cupid.jikting.common.entity.Personality;
+import com.cupid.jikting.team.entity.Team;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class TeamRepositoryTest {
+
+    private static final String NAME = "이름";
+    private static final int MEMBER_COUNT = 3;
+    private static final String DESCRIPTION = "한줄소개";
+
+    @Autowired
+    private TeamRepository teamRepository;
+
+    @Autowired
+    private PersonalityRepository personalityRepository;
+
+    @Test
+    void 팀_저장_성공() {
+        // given
+        Team team = Team.builder()
+                .name(NAME)
+                .memberCount(MEMBER_COUNT)
+                .description(DESCRIPTION)
+                .build();
+        List<Personality> personalities = personalityRepository.findAll();
+        team.addTeamPersonalities(personalities);
+        // when
+        Team savedTeam = teamRepository.save(team);
+        // then
+        assertAll(
+                () -> assertThat(savedTeam.getName()).isEqualTo(NAME),
+                () -> assertThat(savedTeam.getMemberCount()).isEqualTo(MEMBER_COUNT),
+                () -> assertThat(savedTeam.getDescription()).isEqualTo(DESCRIPTION),
+                () -> assertThat(savedTeam.getTeamPersonalities().size()).isEqualTo(personalities.size())
+        );
+    }
+}

--- a/src/test/java/com/cupid/jikting/team/service/TeamServiceTest.java
+++ b/src/test/java/com/cupid/jikting/team/service/TeamServiceTest.java
@@ -1,0 +1,87 @@
+package com.cupid.jikting.team.service;
+
+import com.cupid.jikting.common.entity.Personality;
+import com.cupid.jikting.team.dto.TeamRegisterRequest;
+import com.cupid.jikting.team.dto.TeamRegisterResponse;
+import com.cupid.jikting.team.entity.Team;
+import com.cupid.jikting.team.repository.PersonalityRepository;
+import com.cupid.jikting.team.repository.TeamRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.willReturn;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class TeamServiceTest {
+
+    private static final String KEYWORD = "성격 키워드";
+    private static final Long ID = 1L;
+    private static final String NAME = "이름";
+    private static final String DESCRIPTION = "한줄소개";
+    private static final int MEMBER_COUNT = 3;
+    private static final String INVITATION_URL = "https://jikting.com/teams/" + ID + "/invite";
+
+    private Personality personality;
+    private Team team;
+    private TeamRegisterRequest teamRegisterRequest;
+
+    @InjectMocks
+    private TeamService teamService;
+
+    @Mock
+    private TeamRepository teamRepository;
+
+    @Mock
+    private PersonalityRepository personalityRepository;
+
+    @BeforeEach
+    void setUp() {
+        List<Personality> personalities = IntStream.range(0, 3)
+                .mapToObj(n -> personality)
+                .collect(Collectors.toList());
+        personality = Personality.builder()
+                .keyword(KEYWORD)
+                .build();
+        team = Team.builder()
+                .id(ID)
+                .name(NAME)
+                .description(DESCRIPTION)
+                .memberCount(MEMBER_COUNT)
+                .build();
+        team.addTeamPersonalities(personalities);
+        teamRegisterRequest = TeamRegisterRequest.builder()
+                .description(DESCRIPTION)
+                .memberCount(MEMBER_COUNT)
+                .keywords(List.of(KEYWORD))
+                .build();
+    }
+
+    @Test
+    void 팀_등록_성공() {
+        // given
+        willReturn(Optional.of(personality)).given(personalityRepository).findByKeyword(anyString());
+        willReturn(team).given(teamRepository).save(any(Team.class));
+        // when
+        TeamRegisterResponse teamRegisterResponse = teamService.register(teamRegisterRequest);
+        // then
+        assertAll(
+                () -> verify(personalityRepository).findByKeyword(anyString()),
+                () -> verify(teamRepository).save(any(Team.class)),
+                () -> assertThat(teamRegisterResponse.getInvitationUrl()).isEqualTo(INVITATION_URL)
+        );
+    }
+}

--- a/src/test/java/com/cupid/jikting/team/service/TeamServiceTest.java
+++ b/src/test/java/com/cupid/jikting/team/service/TeamServiceTest.java
@@ -1,6 +1,8 @@
 package com.cupid.jikting.team.service;
 
 import com.cupid.jikting.common.entity.Personality;
+import com.cupid.jikting.common.error.ApplicationError;
+import com.cupid.jikting.common.error.NotFoundException;
 import com.cupid.jikting.team.dto.TeamRegisterRequest;
 import com.cupid.jikting.team.dto.TeamRegisterResponse;
 import com.cupid.jikting.team.entity.Team;
@@ -19,10 +21,12 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.willReturn;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -83,5 +87,15 @@ class TeamServiceTest {
                 () -> verify(teamRepository).save(any(Team.class)),
                 () -> assertThat(teamRegisterResponse.getInvitationUrl()).isEqualTo(INVITATION_URL)
         );
+    }
+
+    @Test
+    void 팀_등록_실패_키워드_없음() {
+        // given
+        willThrow(new NotFoundException(ApplicationError.PERSONALITY_NOT_FOUND)).given(personalityRepository).findByKeyword(anyString());
+        // when & then
+        assertThatThrownBy(() -> teamService.register(teamRegisterRequest))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage(ApplicationError.PERSONALITY_NOT_FOUND.getMessage());
     }
 }

--- a/src/test/java/com/cupid/jikting/team/service/TeamServiceTest.java
+++ b/src/test/java/com/cupid/jikting/team/service/TeamServiceTest.java
@@ -15,6 +15,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import javax.persistence.RollbackException;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -97,5 +98,15 @@ class TeamServiceTest {
         assertThatThrownBy(() -> teamService.register(teamRegisterRequest))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage(ApplicationError.PERSONALITY_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    void 팀_등록_실패_저장되지_않음() {
+        // given
+        willReturn(Optional.of(personality)).given(personalityRepository).findByKeyword(anyString());
+        willThrow(new RollbackException()).given(teamRepository).save(any(Team.class));
+        // when & then
+        assertThatThrownBy(() -> teamService.register(teamRegisterRequest))
+                .isInstanceOf(RollbackException.class);
     }
 }


### PR DESCRIPTION
## Issue

closed #107 
[SP-186](https://soma-cupid.atlassian.net/browse/SP-186?atlOrigin=eyJpIjoiZGM1NWIxN2RjYjVkNDZjYjlmMjBkNDBmMTVhZGZiOTQiLCJwIjoiaiJ9)

## 요구사항

- [x] 팀 등록 기능 구현

## 변경사항

- `TeamRegisterRequest` 팀 인원 필드 추가
- Response DTO에 정적 팩토리 메소드 적용
- 성격 키워드 조회 실패 예외 `BadRequestException` -> `NotFoundException`으로 수정

## 리뷰 우선순위

🙂보통

## 코멘트

- 실패 테스트 코드 작성 시 발생하는 예외를 `setUp()`에서 초기화하는 대신 각 테스트 코드에서 사용하도록 수정했습니다.

[SP-186]: https://soma-cupid.atlassian.net/browse/SP-186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ