### PR TITLE
[SP-187] 팀 참여 기능 구현

### DIFF
--- a/src/main/java/com/cupid/jikting/chatting/controller/ChattingRoomController.java
+++ b/src/main/java/com/cupid/jikting/chatting/controller/ChattingRoomController.java
@@ -3,6 +3,7 @@ package com.cupid.jikting.chatting.controller;
 import com.cupid.jikting.chatting.dto.ChattingRoomDetailResponse;
 import com.cupid.jikting.chatting.dto.ChattingRoomResponse;
 import com.cupid.jikting.chatting.service.ChattingRoomService;
+import com.cupid.jikting.jwt.service.JwtService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -15,10 +16,11 @@ import java.util.List;
 public class ChattingRoomController {
 
     private final ChattingRoomService chattingRoomService;
+    private final JwtService jwtService;
 
     @GetMapping
-    public ResponseEntity<List<ChattingRoomResponse>> getAll() {
-        return ResponseEntity.ok().body(chattingRoomService.getAll(1L));
+    public ResponseEntity<List<ChattingRoomResponse>> getAll(@RequestHeader("Authorization") String token) {
+        return ResponseEntity.ok().body(chattingRoomService.getAll(jwtService.extractValidMemberProfileId(token)));
     }
 
     @GetMapping("/{chattingRoomId}")

--- a/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
+++ b/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
@@ -63,7 +63,7 @@ public class MemberProfile extends BaseEntity {
     private List<MemberHobby> memberHobbies = new ArrayList<>();
 
     @Builder.Default
-    @OneToMany(mappedBy = "memberProfile")
+    @OneToMany(mappedBy = "memberProfile", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
     private List<TeamMember> teamMembers = new ArrayList<>();
 
     @Builder.Default

--- a/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
+++ b/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
@@ -98,6 +98,10 @@ public class MemberProfile extends BaseEntity {
                 .getName();
     }
 
+    public void addTeam(TeamMember teamMember) {
+        teamMembers.add(teamMember);
+    }
+
     public void addMemberChattingRoom(MemberChattingRoom memberChattingRoom) {
         memberChattingRooms.add(memberChattingRoom);
     }

--- a/src/main/java/com/cupid/jikting/team/controller/TeamController.java
+++ b/src/main/java/com/cupid/jikting/team/controller/TeamController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.*;
 public class TeamController {
 
     private final TeamService teamService;
+    private final JwtService jwtService;
 
     @PostMapping
     public ResponseEntity<TeamRegisterResponse> register(@RequestBody TeamRegisterRequest teamRegisterRequest) {
@@ -22,8 +23,8 @@ public class TeamController {
     }
 
     @PostMapping("/{teamId}/attend")
-    public ResponseEntity<Void> attend(@PathVariable Long teamId) {
-        teamService.attend(teamId);
+    public ResponseEntity<Void> attend(@RequestHeader("Authorization") String token, @PathVariable Long teamId) {
+        teamService.attend(teamId, jwtService.extractValidMemberProfileId(token));
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/cupid/jikting/team/controller/TeamController.java
+++ b/src/main/java/com/cupid/jikting/team/controller/TeamController.java
@@ -1,5 +1,6 @@
 package com.cupid.jikting.team.controller;
 
+import com.cupid.jikting.jwt.service.JwtService;
 import com.cupid.jikting.team.dto.TeamRegisterRequest;
 import com.cupid.jikting.team.dto.TeamRegisterResponse;
 import com.cupid.jikting.team.dto.TeamResponse;
@@ -18,8 +19,10 @@ public class TeamController {
     private final JwtService jwtService;
 
     @PostMapping
-    public ResponseEntity<TeamRegisterResponse> register(@RequestBody TeamRegisterRequest teamRegisterRequest) {
-        return ResponseEntity.ok().body(teamService.register(teamRegisterRequest));
+    public ResponseEntity<TeamRegisterResponse> register(@RequestHeader("Authorization") String token,
+                                                         @RequestBody TeamRegisterRequest teamRegisterRequest) {
+        return ResponseEntity.ok()
+                .body(teamService.register(jwtService.extractValidMemberProfileId(token), teamRegisterRequest));
     }
 
     @PostMapping("/{teamId}/attend")

--- a/src/main/java/com/cupid/jikting/team/entity/Team.java
+++ b/src/main/java/com/cupid/jikting/team/entity/Team.java
@@ -62,6 +62,10 @@ public class Team extends BaseEntity {
     @OneToMany(mappedBy = "acceptingTeam")
     private List<Meeting> acceptingMeetings = new ArrayList<>();
 
+    public void addMemberProfile(TeamMember teamMember) {
+        teamMembers.add(teamMember);
+    }
+
     public void addTeamPersonalities(List<Personality> personalities) {
         personalities.stream()
                 .map(personality -> TeamPersonality.builder()

--- a/src/main/java/com/cupid/jikting/team/entity/TeamMember.java
+++ b/src/main/java/com/cupid/jikting/team/entity/TeamMember.java
@@ -6,13 +6,11 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.SQLDelete;
 
 import javax.persistence.*;
 
 @Getter
-@SuperBuilder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE team_member SET is_deleted = true WHERE team_member_id = ?")
@@ -29,4 +27,11 @@ public class TeamMember extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_profile_id")
     private MemberProfile memberProfile;
+
+    public static TeamMember of(boolean isLeader, Team team, MemberProfile memberProfile) {
+        TeamMember teamMember = new TeamMember(isLeader, team, memberProfile);
+        team.addMemberProfile(teamMember);
+        memberProfile.addTeam(teamMember);
+        return teamMember;
+    }
 }

--- a/src/main/java/com/cupid/jikting/team/service/TeamService.java
+++ b/src/main/java/com/cupid/jikting/team/service/TeamService.java
@@ -32,7 +32,7 @@ public class TeamService {
     private final MemberProfileRepository memberProfileRepository;
     private final PersonalityRepository personalityRepository;
 
-    public TeamRegisterResponse register(TeamRegisterRequest teamRegisterRequest) {
+    public TeamRegisterResponse register(Long memberProfileId, TeamRegisterRequest teamRegisterRequest) {
         Team team = Team.builder()
                 .name(String.valueOf(UUID.randomUUID()))
                 .description(teamRegisterRequest.getDescription())
@@ -71,5 +71,15 @@ public class TeamService {
     private Personality getPersonality(String keyword) {
         return personalityRepository.findByKeyword(keyword)
                 .orElseThrow(() -> new NotFoundException(ApplicationError.PERSONALITY_NOT_FOUND));
+    }
+
+    private Team getTeamBy(Long teamId) {
+        return teamRepository.findById(teamId)
+                .orElseThrow(() -> new NotFoundException(ApplicationError.TEAM_NOT_FOUND));
+    }
+
+    private MemberProfile getMemberProfileBy(Long memberProfileId) {
+        return memberProfileRepository.findById(memberProfileId)
+                .orElseThrow(() -> new NotFoundException(ApplicationError.MEMBER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/cupid/jikting/team/service/TeamService.java
+++ b/src/main/java/com/cupid/jikting/team/service/TeamService.java
@@ -35,7 +35,7 @@ public class TeamService {
     private final PersonalityRepository personalityRepository;
 
     public TeamRegisterResponse register(Long memberProfileId, TeamRegisterRequest teamRegisterRequest) {
-        MemberProfile memberProfile = getMemberProfileBy(memberProfileId);
+        MemberProfile memberProfile = getMemberProfileById(memberProfileId);
         Team team = Team.builder()
                 .name(String.valueOf(UUID.randomUUID()))
                 .description(teamRegisterRequest.getDescription())
@@ -48,7 +48,7 @@ public class TeamService {
     }
 
     public void attend(Long teamId, Long memberProfileId) {
-        MemberProfile memberProfile = getMemberProfileBy(memberProfileId);
+        MemberProfile memberProfile = getMemberProfileById(memberProfileId);
         TeamMember.of(!LEADER, getTeamBy(teamId), memberProfile);
         memberProfileRepository.save(memberProfile);
     }
@@ -82,7 +82,7 @@ public class TeamService {
                 .orElseThrow(() -> new NotFoundException(ApplicationError.TEAM_NOT_FOUND));
     }
 
-    private MemberProfile getMemberProfileBy(Long memberProfileId) {
+    private MemberProfile getMemberProfileById(Long memberProfileId) {
         return memberProfileRepository.findById(memberProfileId)
                 .orElseThrow(() -> new NotFoundException(ApplicationError.MEMBER_NOT_FOUND));
     }

--- a/src/main/java/com/cupid/jikting/team/service/TeamService.java
+++ b/src/main/java/com/cupid/jikting/team/service/TeamService.java
@@ -15,12 +15,14 @@ import com.cupid.jikting.team.repository.PersonalityRepository;
 import com.cupid.jikting.team.repository.TeamRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
+@Transactional
 @Service
 public class TeamService {
 

--- a/src/main/java/com/cupid/jikting/team/service/TeamService.java
+++ b/src/main/java/com/cupid/jikting/team/service/TeamService.java
@@ -66,11 +66,11 @@ public class TeamService {
 
     private List<Personality> getPersonalities(List<String> keywords) {
         return keywords.stream()
-                .map(this::getPersonality)
+                .map(this::getPersonalityBy)
                 .collect(Collectors.toList());
     }
 
-    private Personality getPersonality(String keyword) {
+    private Personality getPersonalityBy(String keyword) {
         return personalityRepository.findByKeyword(keyword)
                 .orElseThrow(() -> new NotFoundException(ApplicationError.PERSONALITY_NOT_FOUND));
     }

--- a/src/main/java/com/cupid/jikting/team/service/TeamService.java
+++ b/src/main/java/com/cupid/jikting/team/service/TeamService.java
@@ -33,14 +33,16 @@ public class TeamService {
     private final PersonalityRepository personalityRepository;
 
     public TeamRegisterResponse register(Long memberProfileId, TeamRegisterRequest teamRegisterRequest) {
+        MemberProfile memberProfile = getMemberProfileBy(memberProfileId);
         Team team = Team.builder()
                 .name(String.valueOf(UUID.randomUUID()))
                 .description(teamRegisterRequest.getDescription())
                 .memberCount(teamRegisterRequest.getMemberCount())
                 .build();
         team.addTeamPersonalities(getPersonalities(teamRegisterRequest.getKeywords()));
-        Team savedTeam = teamRepository.save(team);
-        return TeamRegisterResponse.from(TEAM_URL + savedTeam.getId() + INVITE);
+        TeamMember.of(LEADER, team, memberProfile);
+        MemberProfile savedMemberProfile = memberProfileRepository.save(memberProfile);
+        return TeamRegisterResponse.from(TEAM_URL + savedMemberProfile.getTeam().getId() + INVITE);
     }
 
     public void attend(Long teamId, Long memberProfileId) {

--- a/src/main/java/com/cupid/jikting/team/service/TeamService.java
+++ b/src/main/java/com/cupid/jikting/team/service/TeamService.java
@@ -49,7 +49,7 @@ public class TeamService {
 
     public void attend(Long teamId, Long memberProfileId) {
         MemberProfile memberProfile = getMemberProfileById(memberProfileId);
-        TeamMember.of(!LEADER, getTeamBy(teamId), memberProfile);
+        TeamMember.of(!LEADER, getTeamById(teamId), memberProfile);
         memberProfileRepository.save(memberProfile);
     }
 
@@ -77,7 +77,7 @@ public class TeamService {
                 .orElseThrow(() -> new NotFoundException(ApplicationError.PERSONALITY_NOT_FOUND));
     }
 
-    private Team getTeamBy(Long teamId) {
+    private Team getTeamById(Long teamId) {
         return teamRepository.findById(teamId)
                 .orElseThrow(() -> new NotFoundException(ApplicationError.TEAM_NOT_FOUND));
     }

--- a/src/main/java/com/cupid/jikting/team/service/TeamService.java
+++ b/src/main/java/com/cupid/jikting/team/service/TeamService.java
@@ -3,11 +3,14 @@ package com.cupid.jikting.team.service;
 import com.cupid.jikting.common.entity.Personality;
 import com.cupid.jikting.common.error.ApplicationError;
 import com.cupid.jikting.common.error.NotFoundException;
+import com.cupid.jikting.member.entity.MemberProfile;
+import com.cupid.jikting.member.repository.MemberProfileRepository;
 import com.cupid.jikting.team.dto.TeamRegisterRequest;
 import com.cupid.jikting.team.dto.TeamRegisterResponse;
 import com.cupid.jikting.team.dto.TeamResponse;
 import com.cupid.jikting.team.dto.TeamUpdateRequest;
 import com.cupid.jikting.team.entity.Team;
+import com.cupid.jikting.team.entity.TeamMember;
 import com.cupid.jikting.team.repository.PersonalityRepository;
 import com.cupid.jikting.team.repository.TeamRepository;
 import lombok.RequiredArgsConstructor;
@@ -21,10 +24,12 @@ import java.util.stream.Collectors;
 @Service
 public class TeamService {
 
+    private static final boolean LEADER = true;
     private static final String TEAM_URL = "https://jikting.com/teams/";
     private static final String INVITE = "/invite";
 
     private final TeamRepository teamRepository;
+    private final MemberProfileRepository memberProfileRepository;
     private final PersonalityRepository personalityRepository;
 
     public TeamRegisterResponse register(TeamRegisterRequest teamRegisterRequest) {
@@ -38,7 +43,10 @@ public class TeamService {
         return TeamRegisterResponse.from(TEAM_URL + savedTeam.getId() + INVITE);
     }
 
-    public void attend(Long teamId) {
+    public void attend(Long teamId, Long memberProfileId) {
+        MemberProfile memberProfile = getMemberProfileBy(memberProfileId);
+        TeamMember.of(!LEADER, getTeamBy(teamId), memberProfile);
+        memberProfileRepository.save(memberProfile);
     }
 
     public TeamResponse get(Long teamId) {

--- a/src/main/java/com/cupid/jikting/team/service/TeamService.java
+++ b/src/main/java/com/cupid/jikting/team/service/TeamService.java
@@ -66,6 +66,11 @@ public class TeamService {
     public void deleteMember(Long teamId, Long memberId) {
     }
 
+    private MemberProfile getMemberProfileById(Long memberProfileId) {
+        return memberProfileRepository.findById(memberProfileId)
+                .orElseThrow(() -> new NotFoundException(ApplicationError.MEMBER_NOT_FOUND));
+    }
+
     private List<Personality> getPersonalities(List<String> keywords) {
         return keywords.stream()
                 .map(this::getPersonalityBy)
@@ -80,10 +85,5 @@ public class TeamService {
     private Team getTeamById(Long teamId) {
         return teamRepository.findById(teamId)
                 .orElseThrow(() -> new NotFoundException(ApplicationError.TEAM_NOT_FOUND));
-    }
-
-    private MemberProfile getMemberProfileById(Long memberProfileId) {
-        return memberProfileRepository.findById(memberProfileId)
-                .orElseThrow(() -> new NotFoundException(ApplicationError.MEMBER_NOT_FOUND));
     }
 }

--- a/src/test/java/com/cupid/jikting/chatting/controller/ChattingRoomControllerTest.java
+++ b/src/test/java/com/cupid/jikting/chatting/controller/ChattingRoomControllerTest.java
@@ -12,6 +12,7 @@ import com.cupid.jikting.common.error.ApplicationError;
 import com.cupid.jikting.common.error.ApplicationException;
 import com.cupid.jikting.common.error.NotFoundException;
 import com.cupid.jikting.common.error.WrongFormException;
+import com.cupid.jikting.jwt.service.JwtService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -41,6 +42,8 @@ public class ChattingRoomControllerTest extends ApiDocument {
     private static final String CONTEXT_PATH = "/api/v1";
     private static final String DOMAIN_ROOT_PATH = "/chattings/rooms";
     private static final String PATH_DELIMITER = "/";
+    private static final String AUTHORIZATION = "Authorization";
+    private static final String BEARER = "Bearer ";
     private static final String URL = "이미지 주소";
     private static final Long ID = 1L;
     private static final String PLACE = "미팅장소";
@@ -51,6 +54,7 @@ public class ChattingRoomControllerTest extends ApiDocument {
     private static final String KEYWORD = "키워드";
     private static final String NICKNAME = "닉네임";
 
+    private String accessToken;
     private MeetingConfirmRequest meetingConfirmRequest;
     private List<ChattingRoomResponse> chattingRoomResponses;
     private ChattingRoomDetailResponse chattingRoomDetailResponse;
@@ -60,8 +64,12 @@ public class ChattingRoomControllerTest extends ApiDocument {
     @MockBean
     private ChattingRoomService chattingRoomService;
 
+    @MockBean
+    private JwtService jwtService;
+
     @BeforeEach
     void setUp() {
+        accessToken = jwtService.createAccessToken(ID);
         List<String> images = IntStream.rangeClosed(0, 2)
                 .mapToObj(n -> URL)
                 .collect(Collectors.toList());
@@ -164,6 +172,7 @@ public class ChattingRoomControllerTest extends ApiDocument {
 
     private ResultActions 채팅방_목록_조회_요청() throws Exception {
         return mockMvc.perform(get(CONTEXT_PATH + DOMAIN_ROOT_PATH)
+                .header(AUTHORIZATION, BEARER + accessToken)
                 .contextPath(CONTEXT_PATH));
     }
 

--- a/src/test/java/com/cupid/jikting/chatting/service/ChattingRoomServiceTest.java
+++ b/src/test/java/com/cupid/jikting/chatting/service/ChattingRoomServiceTest.java
@@ -34,6 +34,7 @@ class ChattingRoomServiceTest {
 
     private static final Long ID = 1L;
     private static final String TEAM_NAME = "팀 이름";
+    private static final boolean LEADER = true;
 
     private MemberProfile memberProfile;
     private List<ChattingRoom> chattingRooms;
@@ -54,15 +55,10 @@ class ChattingRoomServiceTest {
                 .id(ID)
                 .name(TEAM_NAME)
                 .build();
-        List<TeamMember> teamMembers = List.of(TeamMember.builder()
-                .id(ID)
-                .memberProfile(memberProfile)
-                .team(team)
-                .build());
         memberProfile = MemberProfile.builder()
                 .id(ID)
-                .teamMembers(teamMembers)
                 .build();
+        TeamMember.of(LEADER, team, memberProfile);
         chattingRooms = IntStream.range(0, 3)
                 .mapToObj(n -> ChattingRoom.builder()
                         .id(n + ID)

--- a/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
+++ b/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
@@ -18,13 +18,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-import javax.persistence.RollbackException;
-
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.willReturn;
-import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -40,7 +36,6 @@ public class MemberServiceTest {
     private SignupRequest signupRequest;
     private UsernameCheckRequest usernameCheckRequest;
     private NicknameCheckRequest nicknameCheckRequest;
-    private RollbackException rollbackException;
 
     @InjectMocks
     private MemberService memberService;
@@ -75,7 +70,6 @@ public class MemberServiceTest {
         nicknameCheckRequest = NicknameCheckRequest.builder()
                 .nickname(NICKNAME)
                 .build();
-        rollbackException = new RollbackException();
     }
 
     @Test
@@ -86,15 +80,6 @@ public class MemberServiceTest {
         memberService.signup(signupRequest);
         // then
         verify(memberRepository).save(any(Member.class));
-    }
-
-    @Test
-    void 회원_가입_실패() {
-        //given
-        willThrow(rollbackException).given(memberRepository).save(any(Member.class));
-        //when & then
-        assertThatThrownBy(() -> memberService.signup(signupRequest))
-                .isInstanceOf(RollbackException.class);
     }
 
     @Test

--- a/src/test/java/com/cupid/jikting/recommend/service/RecommendServiceTest.java
+++ b/src/test/java/com/cupid/jikting/recommend/service/RecommendServiceTest.java
@@ -41,6 +41,7 @@ public class RecommendServiceTest {
     private static final int HEIGHT = 180;
     private static final String DESCRIPTION = "자기소개";
     private static final String COLLEGE = "대학";
+    private static final boolean LEADER = true;
 
     private MemberProfile memberProfile;
     private ApplicationException memberNotFoundException;
@@ -70,7 +71,10 @@ public class RecommendServiceTest {
         List<MemberHobby> memberHobbies = List.of(MemberHobby.builder()
                 .hobby(hobby)
                 .build());
-        MemberProfile memberProfile = MemberProfile.builder()
+        Team teamFrom = Team.builder()
+                .id(ID)
+                .build();
+        memberProfile = MemberProfile.builder()
                 .birth(BIRTH)
                 .mbti(MBTI.ENFJ)
                 .address(ADDRESS)
@@ -83,29 +87,16 @@ public class RecommendServiceTest {
                 .memberHobbies(memberHobbies)
                 .college(COLLEGE)
                 .build();
-        List<TeamMember> teamMembersFrom = List.of(TeamMember.builder()
-                .memberProfile(memberProfile)
-                .build());
-        Team teamFrom = Team.builder()
-                .teamMembers(teamMembersFrom)
-                .build();
+        TeamMember.of(LEADER, teamFrom, memberProfile);
         List<Recommend> recommends = IntStream.rangeClosed(0, 2)
                 .mapToObj(n -> Recommend.builder()
                         .from(teamFrom)
                         .build())
                 .collect(Collectors.toList());
-        Team team = Team.builder()
+        Team teamTo = Team.builder()
                 .recommendsFrom(recommends)
                 .build();
-        List<TeamMember> teamMembers = IntStream.rangeClosed(0, 2)
-                .mapToObj(n -> TeamMember.builder()
-                        .team(team)
-                        .build())
-                .collect(Collectors.toList());
-        this.memberProfile = MemberProfile.builder()
-                .id(ID)
-                .teamMembers(teamMembers)
-                .build();
+        TeamMember.of(LEADER, teamTo, memberProfile);
         memberNotFoundException = new NotFoundException(ApplicationError.MEMBER_NOT_FOUND);
     }
 

--- a/src/test/java/com/cupid/jikting/recommend/service/RecommendServiceTest.java
+++ b/src/test/java/com/cupid/jikting/recommend/service/RecommendServiceTest.java
@@ -107,7 +107,7 @@ public class RecommendServiceTest {
         //when
         List<RecommendResponse> recommendResponses = recommendService.get(ID);
         //then
-        assertThat(recommendResponses.size()).isEqualTo(3);
+        assertThat(recommendResponses.size()).isEqualTo(memberProfile.getRecommends().size());
     }
 
     @Test

--- a/src/test/java/com/cupid/jikting/team/controller/TeamControllerTest.java
+++ b/src/test/java/com/cupid/jikting/team/controller/TeamControllerTest.java
@@ -127,7 +127,7 @@ public class TeamControllerTest extends ApiDocument {
     @Test
     void 팀_참여_성공() throws Exception {
         // given
-        willDoNothing().given(teamService).attend(anyLong());
+        willDoNothing().given(teamService).attend(anyLong(), anyLong());
         // when
         ResultActions resultActions = 팀_참여_요청();
         // then
@@ -138,7 +138,7 @@ public class TeamControllerTest extends ApiDocument {
     @Test
     void 팀_참여_실패() throws Exception {
         // given
-        willThrow(teamNotFoundException).given(teamService).attend(anyLong());
+        willThrow(teamNotFoundException).given(teamService).attend(anyLong(), anyLong());
         // when
         ResultActions resultActions = 팀_참여_요청();
         // then

--- a/src/test/java/com/cupid/jikting/team/controller/TeamControllerTest.java
+++ b/src/test/java/com/cupid/jikting/team/controller/TeamControllerTest.java
@@ -268,6 +268,7 @@ public class TeamControllerTest extends ApiDocument {
 
     private ResultActions 팀_참여_요청() throws Exception {
         return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH + PATH_DELIMITER + ID + "/attend")
+                .header(AUTHORIZATION, BEARER + accessToken)
                 .contextPath(CONTEXT_PATH));
     }
 

--- a/src/test/java/com/cupid/jikting/team/controller/TeamControllerTest.java
+++ b/src/test/java/com/cupid/jikting/team/controller/TeamControllerTest.java
@@ -97,7 +97,7 @@ public class TeamControllerTest extends ApiDocument {
     @Test
     void 팀_등록_성공() throws Exception {
         // given
-        willReturn(teamRegisterResponse).given(teamService).register(any(TeamRegisterRequest.class));
+        willReturn(teamRegisterResponse).given(teamService).register(anyLong(), any(TeamRegisterRequest.class));
         // when
         ResultActions resultActions = 팀_등록_요청();
         // then
@@ -108,7 +108,7 @@ public class TeamControllerTest extends ApiDocument {
     @Test
     void 팀_등록_실패() throws Exception {
         // given
-        willThrow(invalidFormatException).given(teamService).register(any(TeamRegisterRequest.class));
+        willThrow(invalidFormatException).given(teamService).register(anyLong(), any(TeamRegisterRequest.class));
         // when
         ResultActions resultActions = 팀_등록_요청();
         // then

--- a/src/test/java/com/cupid/jikting/team/controller/TeamControllerTest.java
+++ b/src/test/java/com/cupid/jikting/team/controller/TeamControllerTest.java
@@ -7,6 +7,7 @@ import com.cupid.jikting.common.error.ApplicationError;
 import com.cupid.jikting.common.error.ApplicationException;
 import com.cupid.jikting.common.error.BadRequestException;
 import com.cupid.jikting.common.error.NotFoundException;
+import com.cupid.jikting.jwt.service.JwtService;
 import com.cupid.jikting.team.dto.*;
 import com.cupid.jikting.team.service.TeamService;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,6 +37,8 @@ public class TeamControllerTest extends ApiDocument {
     private static final String CONTEXT_PATH = "/api/v1";
     private static final String DOMAIN_ROOT_PATH = "/teams";
     private static final String PATH_DELIMITER = "/";
+    private static final String AUTHORIZATION = "Authorization";
+    private static final String BEARER = "Bearer ";
     private static final Long ID = 1L;
     private static final String KEYWORD = "키워드";
     private static final String DESCRIPTION = "한줄 소개";
@@ -46,6 +49,7 @@ public class TeamControllerTest extends ApiDocument {
     private static final String MBTI = "mbti";
     private static final String ADDRESS = "거주지";
 
+    private String accessToken;
     private TeamRegisterRequest teamRegisterRequest;
     private TeamUpdateRequest teamUpdateRequest;
     private TeamRegisterResponse teamRegisterResponse;
@@ -57,8 +61,12 @@ public class TeamControllerTest extends ApiDocument {
     @MockBean
     private TeamService teamService;
 
+    @MockBean
+    private JwtService jwtService;
+
     @BeforeEach
     void setUp() {
+        accessToken = jwtService.createAccessToken(ID);
         List<String> keywords = IntStream.rangeClosed(1, 3)
                 .mapToObj(n -> KEYWORD + n)
                 .collect(Collectors.toList());
@@ -238,6 +246,7 @@ public class TeamControllerTest extends ApiDocument {
 
     private ResultActions 팀_등록_요청() throws Exception {
         return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH)
+                .header(AUTHORIZATION, BEARER + accessToken)
                 .contextPath(CONTEXT_PATH)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(toJson(teamRegisterRequest)));

--- a/src/test/java/com/cupid/jikting/team/service/TeamServiceTest.java
+++ b/src/test/java/com/cupid/jikting/team/service/TeamServiceTest.java
@@ -109,13 +109,13 @@ class TeamServiceTest {
     }
 
     @Test
-    void 팀_등록_실패_키워드_없음() {
+    void 팀_등록_실패_회원_없음() {
         // given
-        willThrow(new NotFoundException(ApplicationError.PERSONALITY_NOT_FOUND)).given(personalityRepository).findByKeyword(anyString());
+        willThrow(new NotFoundException(ApplicationError.MEMBER_NOT_FOUND)).given(memberProfileRepository).findById(anyLong());
         // when & then
-        assertThatThrownBy(() -> teamService.register(teamRegisterRequest))
+        assertThatThrownBy(() -> teamService.register(ID, teamRegisterRequest))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage(ApplicationError.PERSONALITY_NOT_FOUND.getMessage());
+                .hasMessage(ApplicationError.MEMBER_NOT_FOUND.getMessage());
     }
 
     @Test

--- a/src/test/java/com/cupid/jikting/team/service/TeamServiceTest.java
+++ b/src/test/java/com/cupid/jikting/team/service/TeamServiceTest.java
@@ -18,7 +18,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import javax.persistence.RollbackException;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -119,12 +118,13 @@ class TeamServiceTest {
     }
 
     @Test
-    void 팀_등록_실패_저장되지_않음() {
+    void 팀_등록_실패_키워드_없음() {
         // given
-        willReturn(Optional.of(personality)).given(personalityRepository).findByKeyword(anyString());
-        willThrow(new RollbackException()).given(teamRepository).save(any(Team.class));
+        willReturn(Optional.of(leader)).given(memberProfileRepository).findById(anyLong());
+        willThrow(new NotFoundException(ApplicationError.PERSONALITY_NOT_FOUND)).given(personalityRepository).findByKeyword(anyString());
         // when & then
-        assertThatThrownBy(() -> teamService.register(teamRegisterRequest))
-                .isInstanceOf(RollbackException.class);
+        assertThatThrownBy(() -> teamService.register(ID, teamRegisterRequest))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage(ApplicationError.PERSONALITY_NOT_FOUND.getMessage());
     }
 }

--- a/src/test/java/com/cupid/jikting/team/service/TeamServiceTest.java
+++ b/src/test/java/com/cupid/jikting/team/service/TeamServiceTest.java
@@ -3,9 +3,12 @@ package com.cupid.jikting.team.service;
 import com.cupid.jikting.common.entity.Personality;
 import com.cupid.jikting.common.error.ApplicationError;
 import com.cupid.jikting.common.error.NotFoundException;
+import com.cupid.jikting.member.entity.MemberProfile;
+import com.cupid.jikting.member.repository.MemberProfileRepository;
 import com.cupid.jikting.team.dto.TeamRegisterRequest;
 import com.cupid.jikting.team.dto.TeamRegisterResponse;
 import com.cupid.jikting.team.entity.Team;
+import com.cupid.jikting.team.entity.TeamMember;
 import com.cupid.jikting.team.repository.PersonalityRepository;
 import com.cupid.jikting.team.repository.TeamRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -26,8 +29,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.BDDMockito.willReturn;
-import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.BDDMockito.*;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -38,8 +40,11 @@ class TeamServiceTest {
     private static final String NAME = "이름";
     private static final String DESCRIPTION = "한줄소개";
     private static final int MEMBER_COUNT = 3;
+    private static final boolean LEADER = true;
     private static final String INVITATION_URL = "https://jikting.com/teams/" + ID + "/invite";
 
+    private MemberProfile leader;
+    private MemberProfile member;
     private Personality personality;
     private Team team;
     private TeamRegisterRequest teamRegisterRequest;
@@ -51,6 +56,9 @@ class TeamServiceTest {
     private TeamRepository teamRepository;
 
     @Mock
+    private MemberProfileRepository memberProfileRepository;
+
+    @Mock
     private PersonalityRepository personalityRepository;
 
     @BeforeEach
@@ -58,6 +66,12 @@ class TeamServiceTest {
         List<Personality> personalities = IntStream.range(0, 3)
                 .mapToObj(n -> personality)
                 .collect(Collectors.toList());
+        leader = MemberProfile.builder()
+                .id(ID)
+                .build();
+        member = MemberProfile.builder()
+                .id(ID)
+                .build();
         personality = Personality.builder()
                 .keyword(KEYWORD)
                 .build();
@@ -68,6 +82,8 @@ class TeamServiceTest {
                 .memberCount(MEMBER_COUNT)
                 .build();
         team.addTeamPersonalities(personalities);
+        TeamMember.of(LEADER, team, leader);
+        TeamMember.of(!LEADER, team, member);
         teamRegisterRequest = TeamRegisterRequest.builder()
                 .description(DESCRIPTION)
                 .memberCount(MEMBER_COUNT)
@@ -78,14 +94,16 @@ class TeamServiceTest {
     @Test
     void 팀_등록_성공() {
         // given
+        willReturn(Optional.of(leader)).given(memberProfileRepository).findById(anyLong());
         willReturn(Optional.of(personality)).given(personalityRepository).findByKeyword(anyString());
-        willReturn(team).given(teamRepository).save(any(Team.class));
+        willReturn(leader).given(memberProfileRepository).save(any(MemberProfile.class));
         // when
-        TeamRegisterResponse teamRegisterResponse = teamService.register(teamRegisterRequest);
+        TeamRegisterResponse teamRegisterResponse = teamService.register(ID, teamRegisterRequest);
         // then
         assertAll(
+                () -> verify(memberProfileRepository).findById(anyLong()),
                 () -> verify(personalityRepository).findByKeyword(anyString()),
-                () -> verify(teamRepository).save(any(Team.class)),
+                () -> verify(memberProfileRepository).save(any(MemberProfile.class)),
                 () -> assertThat(teamRegisterResponse.getInvitationUrl()).isEqualTo(INVITATION_URL)
         );
     }

--- a/src/test/java/com/cupid/jikting/team/service/TeamServiceTest.java
+++ b/src/test/java/com/cupid/jikting/team/service/TeamServiceTest.java
@@ -153,4 +153,15 @@ class TeamServiceTest {
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage(ApplicationError.MEMBER_NOT_FOUND.getMessage());
     }
+
+    @Test
+    void 팀_참여_실패_팀_없음() {
+        // given
+        willReturn(Optional.of(member)).given(memberProfileRepository).findById(anyLong());
+        willThrow(new NotFoundException(ApplicationError.TEAM_NOT_FOUND)).given(teamRepository).findById(anyLong());
+        // when & then
+        assertThatThrownBy(() -> teamService.attend(ID, ID))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage(ApplicationError.TEAM_NOT_FOUND.getMessage());
+    }
 }

--- a/src/test/java/com/cupid/jikting/team/service/TeamServiceTest.java
+++ b/src/test/java/com/cupid/jikting/team/service/TeamServiceTest.java
@@ -127,4 +127,20 @@ class TeamServiceTest {
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage(ApplicationError.PERSONALITY_NOT_FOUND.getMessage());
     }
+
+    @Test
+    void 팀_참여_성공() {
+        // given
+        willReturn(Optional.of(member)).given(memberProfileRepository).findById(anyLong());
+        willReturn(Optional.of(team)).given(teamRepository).findById(anyLong());
+        willReturn(member).given(memberProfileRepository).save(any(MemberProfile.class));
+        // when
+        teamService.attend(ID, ID);
+        // then
+        assertAll(
+                () -> verify(memberProfileRepository).findById(anyLong()),
+                () -> verify(teamRepository).findById(anyLong()),
+                () -> verify(memberProfileRepository).save(any(MemberProfile.class))
+        );
+    }
 }

--- a/src/test/java/com/cupid/jikting/team/service/TeamServiceTest.java
+++ b/src/test/java/com/cupid/jikting/team/service/TeamServiceTest.java
@@ -143,4 +143,14 @@ class TeamServiceTest {
                 () -> verify(memberProfileRepository).save(any(MemberProfile.class))
         );
     }
+
+    @Test
+    void 팀_참여_실패_회원_없음() {
+        // given
+        willThrow(new NotFoundException(ApplicationError.MEMBER_NOT_FOUND)).given(memberProfileRepository).findById(anyLong());
+        // when & then
+        assertThatThrownBy(() -> teamService.attend(ID, ID))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage(ApplicationError.MEMBER_NOT_FOUND.getMessage());
+    }
 }


### PR DESCRIPTION
## Issue

closed #112 
[SP-187](https://soma-cupid.atlassian.net/browse/SP-187?atlOrigin=eyJpIjoiZGIzNWVmMjU5Yzk3NDQ4YWFiZmFlZWRmOTVhZmJiZDQiLCJwIjoiaiJ9)

## 요구사항

- [x] 팀 참여 기능 구현

## 변경사항

- 팀 등록 로직에 등록자 팀장으로 참여 로직 추가
- TeamMember 빌더 패턴 삭제 및 정적 팩토리 메소드 적용
- 채팅 목록 조회 메소드 jwt 헤더 추가
- RollbackException 반환하는 실패 테스트 삭제

## 리뷰 우선순위

🙂보통

## 코멘트

- UnCheckedException까지 테스트하는 것은 어렵다고 판단되어 전체 테스트 코드에서 일괄 삭제했습니다.

[SP-187]: https://soma-cupid.atlassian.net/browse/SP-187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ