### PR TITLE
[SP-178] 회원 프로필 조회 기능 구현

### DIFF
--- a/src/main/java/com/cupid/jikting/member/dto/ImageResponse.java
+++ b/src/main/java/com/cupid/jikting/member/dto/ImageResponse.java
@@ -1,13 +1,20 @@
 package com.cupid.jikting.member.dto;
 
-import lombok.*;
+import com.cupid.jikting.member.entity.ProfileImage;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ImageResponse {
 
     private String url;
     private String sequence;
+
+    public static ImageResponse of(ProfileImage profileImage) {
+        return new ImageResponse(profileImage.getUrl(), profileImage.getSequence().name());
+    }
 }

--- a/src/main/java/com/cupid/jikting/member/dto/MemberProfileResponse.java
+++ b/src/main/java/com/cupid/jikting/member/dto/MemberProfileResponse.java
@@ -1,11 +1,15 @@
 package com.cupid.jikting.member.dto;
 
-import lombok.*;
+import com.cupid.jikting.member.entity.MemberProfile;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
-@Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberProfileResponse {
@@ -16,10 +20,30 @@ public class MemberProfileResponse {
     private String gender;
     private String address;
     private String mbti;
-    private boolean isSmoke;
+    private String smokeStatus;
     private String drinkStatus;
     private String college;
     private List<String> personalities;
     private List<String> hobbies;
     private String description;
+
+    public static MemberProfileResponse of(MemberProfile memberProfile) {
+        List<ImageResponse> images = memberProfile.getProfileImages()
+                .stream()
+                .map(ImageResponse::of)
+                .collect(Collectors.toList());
+        return new MemberProfileResponse(
+                images,
+                memberProfile.getAge(),
+                memberProfile.getHeight(),
+                memberProfile.getGender().getKey(),
+                memberProfile.getAddress(),
+                memberProfile.getMbti().name(),
+                memberProfile.getSmokeStatus().getValue(),
+                memberProfile.getDrinkStatus().getValue(),
+                memberProfile.getCollege(),
+                memberProfile.getPersonalities(),
+                memberProfile.getHobbies(),
+                memberProfile.getDescription());
+    }
 }

--- a/src/main/java/com/cupid/jikting/member/entity/MBTI.java
+++ b/src/main/java/com/cupid/jikting/member/entity/MBTI.java
@@ -1,6 +1,6 @@
 package com.cupid.jikting.member.entity;
 
-public enum MBTI {
+public enum Mbti {
 
     ISTJ, ISTP, ISFJ, ISFP, INTJ, INTP, INFJ, INFP,
     ESTJ, ESTP, ESFJ, ESFP, ENTJ, ENTP, ENFJ, ENFP

--- a/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
+++ b/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
@@ -2,6 +2,7 @@ package com.cupid.jikting.member.entity;
 
 import com.cupid.jikting.chatting.entity.MemberChattingRoom;
 import com.cupid.jikting.common.entity.BaseEntity;
+import com.cupid.jikting.common.entity.Personality;
 import com.cupid.jikting.common.error.ApplicationError;
 import com.cupid.jikting.common.error.BadRequestException;
 import com.cupid.jikting.common.error.WrongAccessException;
@@ -17,6 +18,7 @@ import javax.persistence.*;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @SuperBuilder
@@ -96,6 +98,13 @@ public class MemberProfile extends BaseEntity {
                 .orElseThrow(() -> new WrongAccessException(ApplicationError.FORBIDDEN_MEMBER))
                 .getCompany()
                 .getName();
+    }
+
+    public List<String> getPersonalities() {
+        return memberPersonalities.stream()
+                .map(MemberPersonality::getPersonality)
+                .map(Personality::getKeyword)
+                .collect(Collectors.toList());
     }
 
     public void addMemberChattingRoom(MemberChattingRoom memberChattingRoom) {

--- a/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
+++ b/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
@@ -41,7 +41,7 @@ public class MemberProfile extends BaseEntity {
     private Gender gender;
 
     @Enumerated(EnumType.STRING)
-    private MBTI mbti;
+    private Mbti mbti;
 
     @Enumerated(EnumType.STRING)
     private SmokeStatus smokeStatus;

--- a/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
+++ b/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
@@ -2,6 +2,7 @@ package com.cupid.jikting.member.entity;
 
 import com.cupid.jikting.chatting.entity.MemberChattingRoom;
 import com.cupid.jikting.common.entity.BaseEntity;
+import com.cupid.jikting.common.entity.Hobby;
 import com.cupid.jikting.common.entity.Personality;
 import com.cupid.jikting.common.error.ApplicationError;
 import com.cupid.jikting.common.error.BadRequestException;
@@ -104,6 +105,13 @@ public class MemberProfile extends BaseEntity {
         return memberPersonalities.stream()
                 .map(MemberPersonality::getPersonality)
                 .map(Personality::getKeyword)
+                .collect(Collectors.toList());
+    }
+
+    public List<String> getHobbies() {
+        return memberHobbies.stream()
+                .map(MemberHobby::getHobby)
+                .map(Hobby::getKeyword)
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/cupid/jikting/member/entity/ProfileImage.java
+++ b/src/main/java/com/cupid/jikting/member/entity/ProfileImage.java
@@ -28,10 +28,6 @@ public class ProfileImage extends BaseEntity {
     @JoinColumn(name = "member_profile_id")
     private MemberProfile memberProfile;
 
-    public String getSequenceName() {
-        return sequence.name();
-    }
-
     public Long getMemberProfileId() {
         return memberProfile.getId();
     }

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -2,9 +2,11 @@ package com.cupid.jikting.member.service;
 
 import com.cupid.jikting.common.error.ApplicationError;
 import com.cupid.jikting.common.error.DuplicateException;
+import com.cupid.jikting.common.error.NotFoundException;
 import com.cupid.jikting.member.dto.*;
 import com.cupid.jikting.member.entity.Gender;
 import com.cupid.jikting.member.entity.Member;
+import com.cupid.jikting.member.entity.MemberProfile;
 import com.cupid.jikting.member.entity.Role;
 import com.cupid.jikting.member.repository.MemberProfileRepository;
 import com.cupid.jikting.member.repository.MemberRepository;
@@ -40,8 +42,8 @@ public class MemberService {
         return null;
     }
 
-    public MemberProfileResponse getProfile(Long memberId) {
-        return null;
+    public MemberProfileResponse getProfile(Long memberProfileId) {
+        return MemberProfileResponse.of(getMemberProfileById(memberProfileId));
     }
 
     public void update(NicknameUpdateRequest nicknameUpdateRequest) {
@@ -103,5 +105,11 @@ public class MemberService {
     }
 
     public void login(LoginRequest loginRequest) {
+    }
+
+    // no commit
+    private MemberProfile getMemberProfileById(Long memberProfileId) {
+        return memberProfileRepository.findById(memberProfileId)
+                .orElseThrow(() -> new NotFoundException(ApplicationError.MEMBER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -106,10 +106,4 @@ public class MemberService {
 
     public void login(LoginRequest loginRequest) {
     }
-
-    // no commit
-    private MemberProfile getMemberProfileById(Long memberProfileId) {
-        return memberProfileRepository.findById(memberProfileId)
-                .orElseThrow(() -> new NotFoundException(ApplicationError.MEMBER_NOT_FOUND));
-    }
 }

--- a/src/main/java/com/cupid/jikting/recommend/dto/ImageResponse.java
+++ b/src/main/java/com/cupid/jikting/recommend/dto/ImageResponse.java
@@ -17,7 +17,7 @@ public class ImageResponse {
 
     public static ImageResponse from(ProfileImage profileImage) {
         return new ImageResponse(
-                profileImage.getSequenceName(),
+                profileImage.getSequence().name(),
                 profileImage.getMemberProfileId(),
                 profileImage.getUrl());
     }

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -44,7 +44,7 @@ public class MemberControllerTest extends ApiDocument {
     private static final String NAME = "홍길동";
     private static final String PHONE = "01011112222";
     private static final String NICKNAME = "닉네임";
-    private static final LocalDate BIRTH = LocalDate.of(1996, 05, 10);
+    private static final LocalDate BIRTH = LocalDate.of(1996, 5, 10);
     private static final String COMPANY = "직장";
     private static final String IMAGE_URL = "사진 URL";
     private static final int AGE = 21;

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -3,8 +3,11 @@ package com.cupid.jikting.member.controller;
 import com.cupid.jikting.ApiDocument;
 import com.cupid.jikting.TestSecurityConfig;
 import com.cupid.jikting.common.dto.ErrorResponse;
+import com.cupid.jikting.common.entity.Hobby;
+import com.cupid.jikting.common.entity.Personality;
 import com.cupid.jikting.common.error.*;
 import com.cupid.jikting.member.dto.*;
+import com.cupid.jikting.member.entity.*;
 import com.cupid.jikting.member.service.MemberService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -18,6 +21,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -40,20 +44,22 @@ public class MemberControllerTest extends ApiDocument {
     private static final String NAME = "홍길동";
     private static final String PHONE = "01011112222";
     private static final String NICKNAME = "닉네임";
+    private static final LocalDate BIRTH = LocalDate.of(1996, 05, 10);
     private static final String COMPANY = "직장";
     private static final String IMAGE_URL = "사진 URL";
     private static final int AGE = 21;
     private static final int HEIGHT = 168;
-    private static final String GENDER = "성별";
+    private static final Gender GENDER = Gender.FEMALE;
     private static final String ADDRESS = "거주지";
-    private static final String MBTI = "MBTI";
-    private static final String DRINK_STATUS = "음주여부";
+    private static final Mbti MBTI = Mbti.ESTJ;
+    private static final SmokeStatus SMOKE_STATUS = SmokeStatus.SMOKING;
+    private static final DrinkStatus DRINK_STATUS = DrinkStatus.OFTEN;
     private static final boolean IS_SMOKE = false;
     private static final String COLLEGE = "출신학교(선택사항 - 없을 시 빈 문자열)";
     private static final String PERSONALITY = "성격";
     private static final String HOBBY = "취미";
     private static final String DESCRIPTION = "한줄 소개(선택사항 - 없을 시 빈 문자열)";
-    private static final String SEQUENCE = "순서";
+    private static final Sequence SEQUENCE = Sequence.MAIN;
     private static final String NEW_PASSWORD = "새 비밀번호";
     private static final String IMAGE_PARAMETER_NAME = "file";
     private static final String IMAGE_FILENAME = "image.png";
@@ -100,11 +106,37 @@ public class MemberControllerTest extends ApiDocument {
 
     @BeforeEach
     void setUp() {
+        ProfileImage profileImage = ProfileImage.builder()
+                .url(IMAGE_URL)
+                .sequence(SEQUENCE)
+                .build();
+        MemberProfile memberProfile = MemberProfile.builder()
+                .birth(BIRTH)
+                .height(HEIGHT)
+                .gender(GENDER)
+                .address(ADDRESS)
+                .mbti(MBTI)
+                .drinkStatus(DRINK_STATUS)
+                .smokeStatus(SMOKE_STATUS)
+                .college(COLLEGE)
+                .description(DESCRIPTION)
+                .build();
+        Hobby hobby = Hobby.builder()
+                .keyword(HOBBY)
+                .build();
+        MemberHobby memberHobby = MemberHobby.builder()
+                .hobby(hobby)
+                .build();
+        memberProfile.getMemberHobbies().add(memberHobby);
+        Personality personality = Personality.builder()
+                .keyword(PERSONALITY)
+                .build();
+        MemberPersonality memberPersonality = MemberPersonality.builder()
+                .personality(personality)
+                .build();
+        memberProfile.getMemberPersonalities().add(memberPersonality);
         List<ImageResponse> images = IntStream.rangeClosed(1, 3)
-                .mapToObj(n -> ImageResponse.builder()
-                        .url(IMAGE_URL)
-                        .sequence(SEQUENCE)
-                        .build())
+                .mapToObj(n -> ImageResponse.of(profileImage))
                 .collect(Collectors.toList());
         List<String> personalities = IntStream.rangeClosed(1, 3)
                 .mapToObj(n -> PERSONALITY + n)
@@ -120,7 +152,7 @@ public class MemberControllerTest extends ApiDocument {
                 .password(PASSWORD)
                 .name(NAME)
                 .phone(PHONE)
-                .gender(GENDER)
+                .gender(GENDER.getKey())
                 .build();
         nicknameUpdateRequest = NicknameUpdateRequest.builder()
                 .nickname(NICKNAME)
@@ -129,10 +161,10 @@ public class MemberControllerTest extends ApiDocument {
                 .images(images)
                 .age(AGE)
                 .height(HEIGHT)
-                .gender(GENDER)
+                .gender(GENDER.getKey())
                 .address(ADDRESS)
-                .mbti(MBTI)
-                .drinkStatus(DRINK_STATUS)
+                .mbti(MBTI.name())
+                .drinkStatus(DRINK_STATUS.getValue())
                 .isSmoke(IS_SMOKE)
                 .college(COLLEGE)
                 .personalities(personalities)
@@ -184,20 +216,7 @@ public class MemberControllerTest extends ApiDocument {
                 .company(COMPANY)
                 .imageUrl(IMAGE_URL)
                 .build();
-        memberProfileResponse = MemberProfileResponse.builder()
-                .images(images)
-                .age(AGE)
-                .height(HEIGHT)
-                .gender(GENDER)
-                .address(ADDRESS)
-                .mbti(MBTI)
-                .drinkStatus(DRINK_STATUS)
-                .isSmoke(IS_SMOKE)
-                .college(COLLEGE)
-                .personalities(personalities)
-                .hobbies(hobbies)
-                .description(DESCRIPTION)
-                .build();
+        memberProfileResponse = MemberProfileResponse.of(memberProfile);
         usernameResponse = UsernameResponse.builder()
                 .username(USERNAME)
                 .build();

--- a/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
+++ b/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
@@ -186,6 +186,16 @@ public class MemberServiceTest {
     }
 
     @Test
+    void 회원_프로필_조회_실패_회원_없음() {
+        // given
+        willThrow(new NotFoundException(ApplicationError.MEMBER_NOT_FOUND)).given(memberProfileRepository).findById(anyLong());
+        // when & then
+        assertThatThrownBy(() -> memberService.getProfile(ID))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage(ApplicationError.MEMBER_NOT_FOUND.getMessage());
+    }
+
+    @Test
     void 아이디_중복_확인_성공() {
         // given
         willReturn(false).given(memberRepository).existsByUsername(anyString());

--- a/src/test/java/com/cupid/jikting/recommend/controller/RecommendControllerTest.java
+++ b/src/test/java/com/cupid/jikting/recommend/controller/RecommendControllerTest.java
@@ -103,7 +103,7 @@ public class RecommendControllerTest extends ApiDocument {
                 .member(member)
                 .nickname(NICKNAME)
                 .birth(BIRTH)
-                .mbti(MBTI.ENFJ)
+                .mbti(Mbti.ENFJ)
                 .address(ADDRESS)
                 .smokeStatus(SmokeStatus.SMOKING)
                 .drinkStatus(DrinkStatus.NEVER)

--- a/src/test/java/com/cupid/jikting/recommend/service/RecommendServiceTest.java
+++ b/src/test/java/com/cupid/jikting/recommend/service/RecommendServiceTest.java
@@ -34,8 +34,8 @@ import static org.mockito.BDDMockito.willThrow;
 public class RecommendServiceTest {
 
     private static final Long ID = 1L;
-    private static final String TEAM_NAME = "팀 이름";
     private static final LocalDate BIRTH = LocalDate.now();
+    private static final Mbti MBTI = Mbti.ENFJ;
     private static final String ADDRESS = "지역";
     private static final String COMPANY = "회사";
     private static final int HEIGHT = 180;
@@ -72,7 +72,7 @@ public class RecommendServiceTest {
                 .build());
         MemberProfile memberProfile = MemberProfile.builder()
                 .birth(BIRTH)
-                .mbti(MBTI.ENFJ)
+                .mbti(MBTI)
                 .address(ADDRESS)
                 .member(member)
                 .smokeStatus(SmokeStatus.SMOKING)


### PR DESCRIPTION
## Issue

closed #119
[SP-178](https://soma-cupid.atlassian.net/browse/SP-178?atlOrigin=eyJpIjoiNmQ0NmE4OGE5OTQxNGZhNWEwYzVhZTgzY2I5ZmVhZDciLCJwIjoiaiJ9)

## 요구사항

- [x] 회원 프로필 조회 기능 구현

## 변경사항

- `MemberProfileResponse` 필더 패턴 삭제 및 정적 팩토리 메소드 적용
- `ProfileImage` sequence 이름 반환 메소드 삭제

## 리뷰 우선순위

🙂보통

## 코멘트

- `ProfileImage`에서 순서를 문자열로 바꾸는 과정을 아래 Before에서 After로 바꿨습니다.

    Before)
    ```java
    profileImage.getSequenceName();
    ```

    | ProfileImage.java
    ```java
    public String getSequenceName() {
        return sequence.name();
    }
    ```

    After)
    ```java
    profileImage.getSequence().name();
    ```

    열거 상수를 그대로 쓰는데, 여기까지 메소드로 빼야되나 고민하다가 바꿨는데 용태님은 어떤 방식이 더 좋다고 생각하시는지 궁금합니다.

[SP-178]: https://soma-cupid.atlassian.net/browse/SP-178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ