### PR TITLE
[SP-222] 받은 호감 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/cupid/jikting/jwt/service/JwtService.java
+++ b/src/main/java/com/cupid/jikting/jwt/service/JwtService.java
@@ -94,7 +94,7 @@ public class JwtService {
     public Long extractValidMemberProfileId(String accessToken) {
         return Optional.ofNullable(JWT.require(Algorithm.HMAC512(secretKey))
                         .build()
-                        .verify(accessToken)
+                        .verify(accessToken.replace(BEARER, ""))
                         .getClaim(MEMBER_PROFILE_ID_CLAIM)
                         .asLong())
                 .orElseThrow(() -> new JwtException(ApplicationError.INVALID_TOKEN));

--- a/src/main/java/com/cupid/jikting/jwt/service/JwtService.java
+++ b/src/main/java/com/cupid/jikting/jwt/service/JwtService.java
@@ -26,6 +26,7 @@ public class JwtService {
     private static final String REFRESH_TOKEN_SUBJECT = "RefreshToken";
     private static final String MEMBER_PROFILE_ID_CLAIM = "MemberProfileId";
     private static final String BEARER = "Bearer ";
+    private static final String REMOVE = "";
 
     private final MemberRepository memberRepository;
 
@@ -69,13 +70,13 @@ public class JwtService {
     public Optional<String> extractRefreshToken(HttpServletRequest request) {
         return Optional.ofNullable(request.getHeader(refreshHeader))
                 .filter(refreshToken -> refreshToken.startsWith(BEARER))
-                .map(refreshToken -> refreshToken.replace(BEARER, ""));
+                .map(refreshToken -> refreshToken.replace(BEARER, REMOVE));
     }
 
     public Optional<String> extractAccessToken(HttpServletRequest request) {
         return Optional.ofNullable(request.getHeader(accessHeader))
                 .filter(refreshToken -> refreshToken.startsWith(BEARER))
-                .map(refreshToken -> refreshToken.replace(BEARER, ""));
+                .map(refreshToken -> refreshToken.replace(BEARER, REMOVE));
     }
 
     public Optional<Long> extractMemberProfileId(String accessToken) {
@@ -94,7 +95,7 @@ public class JwtService {
     public Long extractValidMemberProfileId(String accessToken) {
         return Optional.ofNullable(JWT.require(Algorithm.HMAC512(secretKey))
                         .build()
-                        .verify(accessToken.replace(BEARER, ""))
+                        .verify(accessToken.replace(BEARER, REMOVE))
                         .getClaim(MEMBER_PROFILE_ID_CLAIM)
                         .asLong())
                 .orElseThrow(() -> new JwtException(ApplicationError.INVALID_TOKEN));

--- a/src/main/java/com/cupid/jikting/like/controller/LikeController.java
+++ b/src/main/java/com/cupid/jikting/like/controller/LikeController.java
@@ -1,5 +1,6 @@
 package com.cupid.jikting.like.controller;
 
+import com.cupid.jikting.jwt.service.JwtService;
 import com.cupid.jikting.like.dto.LikeResponse;
 import com.cupid.jikting.like.dto.TeamDetailResponse;
 import com.cupid.jikting.like.service.LikeService;
@@ -15,10 +16,11 @@ import java.util.List;
 public class LikeController {
 
     private final LikeService likeService;
+    private final JwtService jwtService;
 
     @GetMapping("/received")
-    public ResponseEntity<List<LikeResponse>> getAllReceivedLike() {
-        return ResponseEntity.ok().body(likeService.getAllReceivedLike());
+    public ResponseEntity<List<LikeResponse>> getAllReceivedLike(@RequestHeader("Authorization") String token) {
+        return ResponseEntity.ok().body(likeService.getAllReceivedLike(jwtService.extractValidMemberProfileId(token)));
     }
 
     @GetMapping("/sent")

--- a/src/main/java/com/cupid/jikting/like/dto/LikeResponse.java
+++ b/src/main/java/com/cupid/jikting/like/dto/LikeResponse.java
@@ -1,11 +1,12 @@
 package com.cupid.jikting.like.dto;
 
+import com.cupid.jikting.team.entity.Team;
+import com.cupid.jikting.team.entity.TeamLike;
 import lombok.*;
 
 import java.util.List;
 
 @Getter
-@Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class LikeResponse {
@@ -14,4 +15,14 @@ public class LikeResponse {
     private String name;
     private List<String> keywords;
     private List<String> imageUrls;
+
+    public static LikeResponse of(TeamLike teamLike) {
+        Team team = teamLike.getSentTeam();
+        return new LikeResponse(
+                teamLike.getId(),
+                team.getName(),
+                team.getPersonalities(),
+                team.getMainImageUrls()
+        );
+    }
 }

--- a/src/main/java/com/cupid/jikting/like/dto/LikeResponse.java
+++ b/src/main/java/com/cupid/jikting/like/dto/LikeResponse.java
@@ -16,13 +16,12 @@ public class LikeResponse {
     private List<String> keywords;
     private List<String> imageUrls;
 
-    public static LikeResponse of(TeamLike teamLike) {
+    public static LikeResponse from(TeamLike teamLike) {
         Team team = teamLike.getSentTeam();
         return new LikeResponse(
                 teamLike.getId(),
                 team.getName(),
                 team.getPersonalities(),
-                team.getMainImageUrls()
-        );
+                team.getMainImageUrls());
     }
 }

--- a/src/main/java/com/cupid/jikting/like/service/LikeService.java
+++ b/src/main/java/com/cupid/jikting/like/service/LikeService.java
@@ -4,6 +4,9 @@ import com.cupid.jikting.common.error.ApplicationError;
 import com.cupid.jikting.common.error.BadRequestException;
 import com.cupid.jikting.like.dto.LikeResponse;
 import com.cupid.jikting.like.dto.TeamDetailResponse;
+import com.cupid.jikting.team.entity.TeamLike;
+import com.cupid.jikting.team.entity.TeamMember;
+import com.cupid.jikting.team.repository.TeamLikeRepository;
 import com.cupid.jikting.team.repository.TeamMemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,11 +20,13 @@ import java.util.List;
 public class LikeService {
 
     private final TeamMemberRepository teamMemberRepository;
+    private final TeamLikeRepository teamLikeRepository;
 
     public List<LikeResponse> getAllReceivedLike(Long memberProfileId) {
-        Long teamId = teamMemberRepository.getTeamIdByMemberProfileId(memberProfileId)
+        TeamMember teamMember = teamMemberRepository.getTeamMemberByMemberProfileId(memberProfileId)
                 .orElseThrow(() -> new BadRequestException(ApplicationError.NOT_EXIST_REGISTERED_TEAM));
-        log.info("-----------teamID: " + teamId);
+        TeamLike teamLike = teamLikeRepository.getTeamLikesByReceivedTeamId(teamMember.getTeam().getId()).orElse(null);
+
         return null;
     }
 

--- a/src/main/java/com/cupid/jikting/like/service/LikeService.java
+++ b/src/main/java/com/cupid/jikting/like/service/LikeService.java
@@ -13,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -20,14 +21,13 @@ import java.util.List;
 public class LikeService {
 
     private final TeamMemberRepository teamMemberRepository;
-    private final TeamLikeRepository teamLikeRepository;
 
     public List<LikeResponse> getAllReceivedLike(Long memberProfileId) {
         TeamMember teamMember = teamMemberRepository.getTeamMemberByMemberProfileId(memberProfileId)
                 .orElseThrow(() -> new BadRequestException(ApplicationError.NOT_EXIST_REGISTERED_TEAM));
-        TeamLike teamLike = teamLikeRepository.getTeamLikesByReceivedTeamId(teamMember.getTeam().getId()).orElse(null);
-
-        return null;
+        return teamMember.getReceivedTeamLikes().stream()
+                .map(LikeResponse::of)
+                .collect(Collectors.toList());
     }
 
     public List<LikeResponse> getAllSentLike() {

--- a/src/main/java/com/cupid/jikting/like/service/LikeService.java
+++ b/src/main/java/com/cupid/jikting/like/service/LikeService.java
@@ -1,15 +1,27 @@
 package com.cupid.jikting.like.service;
 
+import com.cupid.jikting.common.error.ApplicationError;
+import com.cupid.jikting.common.error.BadRequestException;
 import com.cupid.jikting.like.dto.LikeResponse;
 import com.cupid.jikting.like.dto.TeamDetailResponse;
+import com.cupid.jikting.team.repository.TeamMemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+@Slf4j
+@RequiredArgsConstructor
 @Service
 public class LikeService {
 
-    public List<LikeResponse> getAllReceivedLike() {
+    private final TeamMemberRepository teamMemberRepository;
+
+    public List<LikeResponse> getAllReceivedLike(Long memberProfileId) {
+        Long teamId = teamMemberRepository.getTeamIdByMemberProfileId(memberProfileId)
+                .orElseThrow(() -> new BadRequestException(ApplicationError.NOT_EXIST_REGISTERED_TEAM));
+        log.info("-----------teamID: " + teamId);
         return null;
     }
 

--- a/src/main/java/com/cupid/jikting/like/service/LikeService.java
+++ b/src/main/java/com/cupid/jikting/like/service/LikeService.java
@@ -4,29 +4,27 @@ import com.cupid.jikting.common.error.ApplicationError;
 import com.cupid.jikting.common.error.BadRequestException;
 import com.cupid.jikting.like.dto.LikeResponse;
 import com.cupid.jikting.like.dto.TeamDetailResponse;
-import com.cupid.jikting.team.entity.TeamLike;
 import com.cupid.jikting.team.entity.TeamMember;
-import com.cupid.jikting.team.repository.TeamLikeRepository;
 import com.cupid.jikting.team.repository.TeamMemberRepository;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
-@Slf4j
 @RequiredArgsConstructor
 @Service
 public class LikeService {
 
     private final TeamMemberRepository teamMemberRepository;
 
+    @Transactional(readOnly=true)
     public List<LikeResponse> getAllReceivedLike(Long memberProfileId) {
-        TeamMember teamMember = teamMemberRepository.getTeamMemberByMemberProfileId(memberProfileId)
-                .orElseThrow(() -> new BadRequestException(ApplicationError.NOT_EXIST_REGISTERED_TEAM));
-        return teamMember.getReceivedTeamLikes().stream()
-                .map(LikeResponse::of)
+        return getTeamMemberById(memberProfileId)
+                .getReceivedTeamLikes()
+                .stream()
+                .map(LikeResponse::from)
                 .collect(Collectors.toList());
     }
 
@@ -42,5 +40,10 @@ public class LikeService {
 
     public TeamDetailResponse getTeamDetail(Long likeId) {
         return null;
+    }
+
+    private TeamMember getTeamMemberById(Long memberProfileId) {
+        return teamMemberRepository.getTeamMemberByMemberProfileId(memberProfileId)
+                .orElseThrow(() -> new BadRequestException(ApplicationError.NOT_EXIST_REGISTERED_TEAM));
     }
 }

--- a/src/main/java/com/cupid/jikting/member/entity/Member.java
+++ b/src/main/java/com/cupid/jikting/member/entity/Member.java
@@ -49,4 +49,10 @@ public class Member extends BaseEntity {
     public Long getMemberProfileId() {
         return memberProfile.getId();
     }
+
+    public void addMemberProfile() {
+        memberProfile = MemberProfile.builder()
+                .member(this)
+                .build();
+    }
 }

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -33,6 +33,7 @@ public class MemberService {
                 .name(signupRequest.getName())
                 .role(Role.UNCERTIFIED)
                 .build();
+        member.addMemberProfile();
         memberRepository.save(member);
     }
 

--- a/src/main/java/com/cupid/jikting/team/entity/Team.java
+++ b/src/main/java/com/cupid/jikting/team/entity/Team.java
@@ -66,4 +66,10 @@ public class Team extends BaseEntity {
                 .map(TeamMember::getMemberProfile)
                 .collect(Collectors.toList());
     }
+
+    public List<String> getMainImageUrls() {
+        return getMemberProfiles().stream()
+                .map(MemberProfile::getMainImageUrl)
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/cupid/jikting/team/entity/TeamMember.java
+++ b/src/main/java/com/cupid/jikting/team/entity/TeamMember.java
@@ -10,6 +10,7 @@ import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.SQLDelete;
 
 import javax.persistence.*;
+import java.util.List;
 
 @Getter
 @SuperBuilder
@@ -29,4 +30,8 @@ public class TeamMember extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_profile_id")
     private MemberProfile memberProfile;
+
+    public List<TeamLike> getReceivedTeamLikes() {
+        return team.getReceivedTeamLikes();
+    }
 }

--- a/src/main/java/com/cupid/jikting/team/repository/TeamLikeRepository.java
+++ b/src/main/java/com/cupid/jikting/team/repository/TeamLikeRepository.java
@@ -1,0 +1,11 @@
+package com.cupid.jikting.team.repository;
+
+import com.cupid.jikting.team.entity.TeamLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TeamLikeRepository extends JpaRepository<TeamLike, Long> {
+
+    Optional<TeamLike> getTeamLikesByReceivedTeamId(Long teamId);
+}

--- a/src/main/java/com/cupid/jikting/team/repository/TeamLikeRepository.java
+++ b/src/main/java/com/cupid/jikting/team/repository/TeamLikeRepository.java
@@ -3,9 +3,5 @@ package com.cupid.jikting.team.repository;
 import com.cupid.jikting.team.entity.TeamLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
 public interface TeamLikeRepository extends JpaRepository<TeamLike, Long> {
-
-    Optional<TeamLike> getTeamLikesByReceivedTeamId(Long teamId);
 }

--- a/src/main/java/com/cupid/jikting/team/repository/TeamLikeRepository.java
+++ b/src/main/java/com/cupid/jikting/team/repository/TeamLikeRepository.java
@@ -4,4 +4,5 @@ import com.cupid.jikting.team.entity.TeamLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TeamLikeRepository extends JpaRepository<TeamLike, Long> {
+
 }

--- a/src/main/java/com/cupid/jikting/team/repository/TeamMemberRepository.java
+++ b/src/main/java/com/cupid/jikting/team/repository/TeamMemberRepository.java
@@ -1,0 +1,11 @@
+package com.cupid.jikting.team.repository;
+
+import com.cupid.jikting.team.entity.TeamMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
+
+    Optional<Long> getTeamIdByMemberProfileId(Long memberProfileId);
+}

--- a/src/main/java/com/cupid/jikting/team/repository/TeamMemberRepository.java
+++ b/src/main/java/com/cupid/jikting/team/repository/TeamMemberRepository.java
@@ -7,5 +7,5 @@ import java.util.Optional;
 
 public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
 
-    Optional<Long> getTeamIdByMemberProfileId(Long memberProfileId);
+    Optional<TeamMember> getTeamMemberByMemberProfileId(Long memberProfileId);
 }

--- a/src/test/java/com/cupid/jikting/like/controller/LikeControllerTest.java
+++ b/src/test/java/com/cupid/jikting/like/controller/LikeControllerTest.java
@@ -126,7 +126,7 @@ public class LikeControllerTest extends ApiDocument {
                 .id(ID)
                 .sentTeam(team)
                 .build();
-        LikeResponse likeResponse = LikeResponse.of(teamLike);
+        LikeResponse likeResponse = LikeResponse.from(teamLike);
         likeResponses = List.of(likeResponse,likeResponse);
         teamDetailResponse = TeamDetailResponse.builder()
                 .likeId(ID)

--- a/src/test/java/com/cupid/jikting/like/controller/LikeControllerTest.java
+++ b/src/test/java/com/cupid/jikting/like/controller/LikeControllerTest.java
@@ -3,6 +3,7 @@ package com.cupid.jikting.like.controller;
 import com.cupid.jikting.ApiDocument;
 import com.cupid.jikting.TestSecurityConfig;
 import com.cupid.jikting.common.dto.ErrorResponse;
+import com.cupid.jikting.common.entity.Personality;
 import com.cupid.jikting.common.error.ApplicationError;
 import com.cupid.jikting.common.error.ApplicationException;
 import com.cupid.jikting.common.error.NotFoundException;
@@ -11,6 +12,13 @@ import com.cupid.jikting.like.dto.LikeResponse;
 import com.cupid.jikting.like.dto.MemberProfileResponse;
 import com.cupid.jikting.like.dto.TeamDetailResponse;
 import com.cupid.jikting.like.service.LikeService;
+import com.cupid.jikting.member.entity.MemberProfile;
+import com.cupid.jikting.member.entity.ProfileImage;
+import com.cupid.jikting.member.entity.Sequence;
+import com.cupid.jikting.team.entity.Team;
+import com.cupid.jikting.team.entity.TeamLike;
+import com.cupid.jikting.team.entity.TeamMember;
+import com.cupid.jikting.team.entity.TeamPersonality;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -87,20 +95,44 @@ public class LikeControllerTest extends ApiDocument {
                         .college(COLLEGE)
                         .build())
                 .collect(Collectors.toList());
-        LikeResponse likeResponse = LikeResponse.builder()
-                .likeId(ID)
-                .name(NAME)
-                .keywords(keywords)
-                .imageUrls(imageUrls)
+        Personality personality = Personality.builder()
+                .keyword(KEYWORD)
                 .build();
-        likeResponses = IntStream.rangeClosed(0, 2)
-                .mapToObj(n -> likeResponse)
+        List<TeamPersonality> teamPersonalities = IntStream.rangeClosed(0, 2)
+                .mapToObj(n -> TeamPersonality.builder()
+                        .personality(personality)
+                        .build())
                 .collect(Collectors.toList());
+        List<ProfileImage> profileImages = IntStream.rangeClosed(0, 2)
+                .mapToObj(n -> ProfileImage.builder()
+                        .url(URL)
+                        .sequence(Sequence.MAIN)
+                        .build())
+                .collect(Collectors.toList());
+        MemberProfile memberProfile = MemberProfile.builder()
+                .profileImages(profileImages)
+                .build();
+        List<TeamMember> teamMembers = IntStream.rangeClosed(0, 2)
+                .mapToObj(n -> TeamMember.builder()
+                        .memberProfile(memberProfile)
+                        .build())
+                .collect(Collectors.toList());
+        Team team = Team.builder()
+                .name(NAME)
+                .teamPersonalities(teamPersonalities)
+                .teamMembers(teamMembers)
+                .build();
+        TeamLike teamLike = TeamLike.builder()
+                .id(ID)
+                .sentTeam(team)
+                .build();
+        LikeResponse likeResponse = LikeResponse.of(teamLike);
+        likeResponses = List.of(likeResponse,likeResponse);
         teamDetailResponse = TeamDetailResponse.builder()
                 .likeId(ID)
                 .teamName(NAME)
                 .keywords(keywords)
-                .members(memberProfileRespons)
+                .members(memberProfileResponses)
                 .build();
         teamNotFoundException = new NotFoundException(ApplicationError.TEAM_NOT_FOUND);
     }

--- a/src/test/java/com/cupid/jikting/like/controller/LikeControllerTest.java
+++ b/src/test/java/com/cupid/jikting/like/controller/LikeControllerTest.java
@@ -71,10 +71,7 @@ public class LikeControllerTest extends ApiDocument {
         List<String> keywords = IntStream.rangeClosed(1, 3)
                 .mapToObj(n -> KEYWORD + n)
                 .collect(Collectors.toList());
-        List<String> imageUrls = IntStream.rangeClosed(1, 3)
-                .mapToObj(n -> URL + n)
-                .collect(Collectors.toList());
-        List<MemberProfileResponse> memberProfileRespons = IntStream.rangeClosed(1, 2)
+        List<MemberProfileResponse> memberProfileResponses = IntStream.rangeClosed(1, 2)
                 .mapToObj(n -> MemberProfileResponse.builder()
                         .nickname(NICKNAME)
                         .image(URL)

--- a/src/test/java/com/cupid/jikting/like/controller/LikeControllerTest.java
+++ b/src/test/java/com/cupid/jikting/like/controller/LikeControllerTest.java
@@ -6,6 +6,7 @@ import com.cupid.jikting.common.dto.ErrorResponse;
 import com.cupid.jikting.common.error.ApplicationError;
 import com.cupid.jikting.common.error.ApplicationException;
 import com.cupid.jikting.common.error.NotFoundException;
+import com.cupid.jikting.jwt.service.JwtService;
 import com.cupid.jikting.like.dto.LikeResponse;
 import com.cupid.jikting.like.dto.MemberProfileResponse;
 import com.cupid.jikting.like.dto.TeamDetailResponse;
@@ -50,7 +51,10 @@ public class LikeControllerTest extends ApiDocument {
     private static final String DESCRIPTION = "소개";
     private static final String KEYWORD = "키워드";
     private static final String COLLEGE = "대학";
+    private static final String AUTHORIZATION = "Authorization";
+    private static final String BEARER = "Bearer ";
 
+    private String accessToken;
     private List<LikeResponse> likeResponses;
     private TeamDetailResponse teamDetailResponse;
     private ApplicationException teamNotFoundException;
@@ -58,8 +62,12 @@ public class LikeControllerTest extends ApiDocument {
     @MockBean
     private LikeService likeService;
 
+    @MockBean
+    private JwtService jwtService;
+
     @BeforeEach
     void setUp() {
+        accessToken = jwtService.createAccessToken(ID);
         List<String> keywords = IntStream.rangeClosed(1, 3)
                 .mapToObj(n -> KEYWORD + n)
                 .collect(Collectors.toList());
@@ -104,7 +112,7 @@ public class LikeControllerTest extends ApiDocument {
     @Test
     void 받은_호감_목록_조회_성공() throws Exception {
         //given
-        willReturn(likeResponses).given(likeService).getAllReceivedLike();
+        willReturn(likeResponses).given(likeService).getAllReceivedLike(anyLong());
         //when
         ResultActions resultActions = 받은_호감_목록_조회_요청();
         //then
@@ -115,7 +123,7 @@ public class LikeControllerTest extends ApiDocument {
     @Test
     void 받은_호감_목록_조회_실패() throws Exception {
         //given
-        willThrow(teamNotFoundException).given(likeService).getAllReceivedLike();
+        willThrow(teamNotFoundException).given(likeService).getAllReceivedLike(anyLong());
         //when
         ResultActions resultActions = 받은_호감_목록_조회_요청();
         //then
@@ -212,7 +220,8 @@ public class LikeControllerTest extends ApiDocument {
 
     private ResultActions 받은_호감_목록_조회_요청() throws Exception {
         return mockMvc.perform(get(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/received")
-                .contextPath(CONTEXT_PATH));
+                .contextPath(CONTEXT_PATH)
+                .header(AUTHORIZATION, BEARER + accessToken));
     }
 
     private void 받은_호감_목록_조회_요청_성공(ResultActions resultActions) throws Exception {

--- a/src/test/java/com/cupid/jikting/like/service/LikeServiceTest.java
+++ b/src/test/java/com/cupid/jikting/like/service/LikeServiceTest.java
@@ -1,0 +1,124 @@
+package com.cupid.jikting.like.service;
+
+import com.cupid.jikting.common.entity.Personality;
+import com.cupid.jikting.common.error.ApplicationError;
+import com.cupid.jikting.common.error.BadRequestException;
+import com.cupid.jikting.like.dto.LikeResponse;
+import com.cupid.jikting.like.service.LikeService;
+import com.cupid.jikting.member.entity.MemberProfile;
+import com.cupid.jikting.member.entity.ProfileImage;
+import com.cupid.jikting.member.entity.Sequence;
+import com.cupid.jikting.team.entity.Team;
+import com.cupid.jikting.team.entity.TeamLike;
+import com.cupid.jikting.team.entity.TeamMember;
+import com.cupid.jikting.team.entity.TeamPersonality;
+import com.cupid.jikting.team.repository.TeamLikeRepository;
+import com.cupid.jikting.team.repository.TeamMemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.willReturn;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class LikeServiceTest {
+
+    private static final Long ID = 1L;
+    private static final String NAME = "팀이름";
+    private static final String KEYWORD = "키워드";
+    private static final String URL = "url";
+
+    private TeamMember teamMember;
+    private List<TeamLike> teamLikes;
+
+    @InjectMocks
+    private LikeService likeService;
+
+    @Mock
+    private  TeamMemberRepository teamMemberRepository;
+
+    @Mock
+    private  TeamLikeRepository teamLikeRepository;
+
+    @BeforeEach
+    void setUp() {
+        Personality personality = Personality.builder()
+                .keyword(KEYWORD)
+                .build();
+        TeamPersonality teamPersonality = TeamPersonality.builder()
+                .personality(personality)
+                .build();
+        List<ProfileImage> profileImages = IntStream.rangeClosed(0, 2)
+                .mapToObj(n -> ProfileImage.builder()
+                        .url(URL)
+                        .sequence(Sequence.MAIN)
+                        .build())
+                .collect(Collectors.toList());
+        MemberProfile memberProfile = MemberProfile.builder()
+                .profileImages(profileImages)
+                .build();
+        List<TeamMember> teamMembers = IntStream.rangeClosed(0, 2)
+                .mapToObj(n -> TeamMember.builder()
+                        .memberProfile(memberProfile)
+                        .build())
+                .collect(Collectors.toList());
+        Team sentTeam = Team
+                .builder()
+                .name(NAME)
+                .teamPersonalities(List.of(teamPersonality))
+                .teamMembers(teamMembers)
+                .build();
+        TeamLike teamLike = TeamLike.builder()
+            .id(ID)
+            .sentTeam(sentTeam)
+            .build();
+        Team team = Team.builder()
+                .id(ID)
+                .receivedTeamLikes(List.of(teamLike))
+                .build();
+        teamMember = TeamMember.builder()
+                .team(team)
+                .build();
+        teamLikes = List.of(TeamLike.builder()
+                .sentTeam(team)
+                .build());
+
+    }
+
+    @Test
+    void 받은_호감_조회_성공() {
+        // given
+        willReturn(Optional.of(teamMember)).given(teamMemberRepository).getTeamMemberByMemberProfileId(anyLong());
+        // when
+        List<LikeResponse> likeResponses = likeService.getAllReceivedLike(ID);
+        // then
+        assertAll(
+                () -> verify(teamMemberRepository).getTeamMemberByMemberProfileId(anyLong()),
+                () -> assertThat(likeResponses.size()).isEqualTo(teamLikes.size())
+        );
+    }
+
+    @Test
+    void 받은_호감_조회_실패_팀없음(){
+        // given
+        willThrow(new BadRequestException(ApplicationError.NOT_EXIST_REGISTERED_TEAM)).given(teamMemberRepository).getTeamMemberByMemberProfileId(anyLong());
+        // when & then
+        assertThatThrownBy(() -> likeService.getAllReceivedLike(ID))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(ApplicationError.NOT_EXIST_REGISTERED_TEAM.getMessage());
+    }
+}

--- a/src/test/java/com/cupid/jikting/like/service/LikeServiceTest.java
+++ b/src/test/java/com/cupid/jikting/like/service/LikeServiceTest.java
@@ -51,9 +51,6 @@ class LikeServiceTest {
     @Mock
     private  TeamMemberRepository teamMemberRepository;
 
-    @Mock
-    private  TeamLikeRepository teamLikeRepository;
-
     @BeforeEach
     void setUp() {
         Personality personality = Personality.builder()
@@ -96,7 +93,6 @@ class LikeServiceTest {
         teamLikes = List.of(TeamLike.builder()
                 .sentTeam(team)
                 .build());
-
     }
 
     @Test
@@ -113,7 +109,7 @@ class LikeServiceTest {
     }
 
     @Test
-    void 받은_호감_조회_실패_팀없음(){
+    void 받은_호감_조회_실패_팀_없음(){
         // given
         willThrow(new BadRequestException(ApplicationError.NOT_EXIST_REGISTERED_TEAM)).given(teamMemberRepository).getTeamMemberByMemberProfileId(anyLong());
         // when & then

--- a/src/test/java/com/cupid/jikting/like/service/LikeServiceTest.java
+++ b/src/test/java/com/cupid/jikting/like/service/LikeServiceTest.java
@@ -49,7 +49,7 @@ class LikeServiceTest {
     private LikeService likeService;
 
     @Mock
-    private  TeamMemberRepository teamMemberRepository;
+    private TeamMemberRepository teamMemberRepository;
 
     @BeforeEach
     void setUp() {


### PR DESCRIPTION
## Issue

closed #110 
[SP-222](https://soma-cupid.atlassian.net/browse/SP-222?atlOrigin=eyJpIjoiZDdlODg5YThkNTVhNDgyZWI5NGJhYTA1NGRmZDM5YjYiLCJwIjoiaiJ9)

## 요구사항

- [x] 받은 호감 목록 조회 기능 구현

## 변경사항

- header에서 토큰 추출하는 로직에서 `Bearer`를 삭제하는 로직 추가
- `LikeService` 받은 호감 조회 로직 추가
- `LikeResponse` 빌더 패턴 삭제 및 정적 팩토리 적용, `LikeControllerTest`에 적용
- `LikeServiceTest`  추가

## 리뷰 우선순위

🙂보통

[SP-222]: https://soma-cupid.atlassian.net/browse/SP-222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ