### PR TITLE
[SP-226] 보낸 호감 목록 조회 구현

### DIFF
--- a/src/main/java/com/cupid/jikting/like/controller/LikeController.java
+++ b/src/main/java/com/cupid/jikting/like/controller/LikeController.java
@@ -24,8 +24,8 @@ public class LikeController {
     }
 
     @GetMapping("/sent")
-    public ResponseEntity<List<LikeResponse>> getAllSentLike() {
-        return ResponseEntity.ok().body(likeService.getAllSentLike());
+    public ResponseEntity<List<LikeResponse>> getAllSentLike(@RequestHeader("Authorization") String token) {
+        return ResponseEntity.ok().body(likeService.getAllSentLike(jwtService.extractValidMemberProfileId(token)));
     }
 
     @PostMapping("/{likeId}/accept")

--- a/src/main/java/com/cupid/jikting/like/dto/LikeResponse.java
+++ b/src/main/java/com/cupid/jikting/like/dto/LikeResponse.java
@@ -24,4 +24,13 @@ public class LikeResponse {
                 team.getPersonalities(),
                 team.getMainImageUrls());
     }
+
+    public static LikeResponse fromSentTeamLike(TeamLike teamLike) {
+        Team team = teamLike.getReceivedTeam();
+        return new LikeResponse(
+                teamLike.getId(),
+                team.getName(),
+                team.getPersonalities(),
+                team.getMainImageUrls());
+    }
 }

--- a/src/main/java/com/cupid/jikting/like/dto/LikeResponse.java
+++ b/src/main/java/com/cupid/jikting/like/dto/LikeResponse.java
@@ -16,7 +16,7 @@ public class LikeResponse {
     private List<String> keywords;
     private List<String> imageUrls;
 
-    public static LikeResponse from(TeamLike teamLike) {
+    public static LikeResponse fromReceivedTeamLike(TeamLike teamLike) {
         Team team = teamLike.getSentTeam();
         return new LikeResponse(
                 teamLike.getId(),

--- a/src/main/java/com/cupid/jikting/like/dto/LikeResponse.java
+++ b/src/main/java/com/cupid/jikting/like/dto/LikeResponse.java
@@ -17,16 +17,14 @@ public class LikeResponse {
     private List<String> imageUrls;
 
     public static LikeResponse fromReceivedTeamLike(TeamLike teamLike) {
-        Team team = teamLike.getSentTeam();
-        return new LikeResponse(
-                teamLike.getId(),
-                team.getName(),
-                team.getPersonalities(),
-                team.getMainImageUrls());
+        return from(teamLike, teamLike.getSentTeam());
     }
 
     public static LikeResponse fromSentTeamLike(TeamLike teamLike) {
-        Team team = teamLike.getReceivedTeam();
+        return from(teamLike, teamLike.getReceivedTeam());
+    }
+
+    private static LikeResponse from(TeamLike teamLike, Team team) {
         return new LikeResponse(
                 teamLike.getId(),
                 team.getName(),

--- a/src/main/java/com/cupid/jikting/like/service/LikeService.java
+++ b/src/main/java/com/cupid/jikting/like/service/LikeService.java
@@ -19,7 +19,7 @@ public class LikeService {
 
     private final TeamMemberRepository teamMemberRepository;
 
-    @Transactional(readOnly=true)
+    @Transactional(readOnly = true)
     public List<LikeResponse> getAllReceivedLike(Long memberProfileId) {
         return getTeamMemberById(memberProfileId)
                 .getReceivedTeamLikes()
@@ -28,7 +28,7 @@ public class LikeService {
                 .collect(Collectors.toList());
     }
 
-    @Transactional(readOnly=true)
+    @Transactional(readOnly = true)
     public List<LikeResponse> getAllSentLike(Long memberProfileId) {
         return getTeamMemberById(memberProfileId)
                 .getSentTeamLikes()

--- a/src/main/java/com/cupid/jikting/like/service/LikeService.java
+++ b/src/main/java/com/cupid/jikting/like/service/LikeService.java
@@ -24,12 +24,16 @@ public class LikeService {
         return getTeamMemberById(memberProfileId)
                 .getReceivedTeamLikes()
                 .stream()
-                .map(LikeResponse::from)
+                .map(LikeResponse::fromReceivedTeamLike)
                 .collect(Collectors.toList());
     }
 
-    public List<LikeResponse> getAllSentLike() {
-        return null;
+    public List<LikeResponse> getAllSentLike(Long memberProfileId) {
+        return getTeamMemberById(memberProfileId)
+                .getSentTeamLikes()
+                .stream()
+                .map(LikeResponse::fromSentTeamLike)
+                .collect(Collectors.toList());
     }
 
     public void acceptLike(Long likeId) {

--- a/src/main/java/com/cupid/jikting/like/service/LikeService.java
+++ b/src/main/java/com/cupid/jikting/like/service/LikeService.java
@@ -28,6 +28,7 @@ public class LikeService {
                 .collect(Collectors.toList());
     }
 
+    @Transactional(readOnly=true)
     public List<LikeResponse> getAllSentLike(Long memberProfileId) {
         return getTeamMemberById(memberProfileId)
                 .getSentTeamLikes()

--- a/src/main/java/com/cupid/jikting/team/entity/TeamMember.java
+++ b/src/main/java/com/cupid/jikting/team/entity/TeamMember.java
@@ -41,4 +41,8 @@ public class TeamMember extends BaseEntity {
     public List<TeamLike> getReceivedTeamLikes() {
         return team.getReceivedTeamLikes();
     }
+
+    public List<TeamLike> getSentTeamLikes() {
+        return team.getSentTeamLikes();
+    }
 }

--- a/src/test/java/com/cupid/jikting/like/controller/LikeControllerTest.java
+++ b/src/test/java/com/cupid/jikting/like/controller/LikeControllerTest.java
@@ -125,8 +125,9 @@ public class LikeControllerTest extends ApiDocument {
         TeamLike teamLike = TeamLike.builder()
                 .id(ID)
                 .sentTeam(team)
+                .receivedTeam(team)
                 .build();
-        LikeResponse likeResponse = LikeResponse.from(teamLike);
+        LikeResponse likeResponse = LikeResponse.fromSentTeamLike(teamLike);
         likeResponses = List.of(likeResponse,likeResponse);
         teamDetailResponse = TeamDetailResponse.builder()
                 .likeId(ID)
@@ -163,7 +164,7 @@ public class LikeControllerTest extends ApiDocument {
     @Test
     void 보낸_호감_목록_조회_성공() throws Exception {
         //given
-        willReturn(likeResponses).given(likeService).getAllSentLike();
+        willReturn(likeResponses).given(likeService).getAllSentLike(anyLong());
         //when
         ResultActions resultActions = 보낸_호감_목록_조회_요청();
         //then
@@ -174,7 +175,7 @@ public class LikeControllerTest extends ApiDocument {
     @Test
     void 보낸_호감_목록_조회_실패() throws Exception {
         //given
-        willThrow(teamNotFoundException).given(likeService).getAllSentLike();
+        willThrow(teamNotFoundException).given(likeService).getAllSentLike(anyLong());
         //when
         ResultActions resultActions = 보낸_호감_목록_조회_요청();
         //then
@@ -269,7 +270,8 @@ public class LikeControllerTest extends ApiDocument {
 
     private ResultActions 보낸_호감_목록_조회_요청() throws Exception {
         return mockMvc.perform(get(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/sent")
-                .contextPath(CONTEXT_PATH));
+                .contextPath(CONTEXT_PATH)
+                .header(AUTHORIZATION, BEARER + accessToken));
     }
 
     private void 보낸_호감_목록_조회_요청_성공(ResultActions resultActions) throws Exception {


### PR DESCRIPTION
## Issue

closed #123 
[SP-226](https://soma-cupid.atlassian.net/browse/SP-226?atlOrigin=eyJpIjoiOGRmZGU2OTdkNWJjNDdmMWFkNGJlMGExMWIyMmRjNTEiLCJwIjoiaiJ9)

## 요구사항

- [x] 보낸 호감 목록 조회 구현

## 변경사항

- `LikeService` 보낸 호감 목록 조회 메서드 추가
- `LikeResponse` 기존 `from` -> `fromReceivedTeamLike` 변경 및 `fromSentTeamLike` 추가
- `LikeServicetest` 보낸 호감 목록 조회 테스트 추가

## 리뷰 우선순위

🙂보통

[SP-226]: https://soma-cupid.atlassian.net/browse/SP-226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ