### PR TITLE
[SP-224] 받은 호감 거절 구현

### DIFF
--- a/src/main/java/com/cupid/jikting/common/error/ApplicationError.java
+++ b/src/main/java/com/cupid/jikting/common/error/ApplicationError.java
@@ -36,6 +36,8 @@ public enum ApplicationError {
     ALREADY_IN_TEAM(HttpStatus.BAD_REQUEST, "T003", "이미 팀에 가입되었습니다."),
     TEAM_ALREADY_FULL(HttpStatus.BAD_REQUEST, "T004", "이미 팀 모집이 완료되었습니다."),
 
+    LIKE_NOT_FOUND(HttpStatus.BAD_REQUEST, "L001", "호감을 찾을 수 없습니다."),
+
     MEETING_NOT_FOUND(HttpStatus.BAD_REQUEST, "M001", "미팅을 찾을 수 없습니다."),
 
     INSTANT_MEETING_NOT_FOUND(HttpStatus.BAD_REQUEST, "I001", "번개팅을 찾을 수 없습니다."),

--- a/src/main/java/com/cupid/jikting/like/service/LikeService.java
+++ b/src/main/java/com/cupid/jikting/like/service/LikeService.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
+@Transactional
 @Service
 public class LikeService {
 
@@ -44,10 +45,11 @@ public class LikeService {
     public void acceptLike(Long likeId) {
     }
 
-    @Transactional
     public void rejectLike(Long likeId) {
-        TeamLike teamLike = teamLikeRepository.findById(likeId).orElseThrow(() -> new NotFoundException(ApplicationError.LIKE_NOT_FOUND));
+        TeamLike teamLike = teamLikeRepository.findById(likeId)
+                .orElseThrow(() -> new NotFoundException(ApplicationError.LIKE_NOT_FOUND));
         teamLike.reject();
+        teamLikeRepository.save(teamLike);
     }
 
     public TeamDetailResponse getTeamDetail(Long likeId) {

--- a/src/main/java/com/cupid/jikting/like/service/LikeService.java
+++ b/src/main/java/com/cupid/jikting/like/service/LikeService.java
@@ -2,9 +2,12 @@ package com.cupid.jikting.like.service;
 
 import com.cupid.jikting.common.error.ApplicationError;
 import com.cupid.jikting.common.error.BadRequestException;
+import com.cupid.jikting.common.error.NotFoundException;
 import com.cupid.jikting.like.dto.LikeResponse;
 import com.cupid.jikting.like.dto.TeamDetailResponse;
+import com.cupid.jikting.team.entity.TeamLike;
 import com.cupid.jikting.team.entity.TeamMember;
+import com.cupid.jikting.team.repository.TeamLikeRepository;
 import com.cupid.jikting.team.repository.TeamMemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,6 +21,7 @@ import java.util.stream.Collectors;
 public class LikeService {
 
     private final TeamMemberRepository teamMemberRepository;
+    private final TeamLikeRepository teamLikeRepository;
 
     @Transactional(readOnly = true)
     public List<LikeResponse> getAllReceivedLike(Long memberProfileId) {
@@ -40,7 +44,10 @@ public class LikeService {
     public void acceptLike(Long likeId) {
     }
 
+    @Transactional
     public void rejectLike(Long likeId) {
+        TeamLike teamLike = teamLikeRepository.findById(likeId).orElseThrow(() -> new NotFoundException(ApplicationError.LIKE_NOT_FOUND));
+        teamLike.reject();
     }
 
     public TeamDetailResponse getTeamDetail(Long likeId) {

--- a/src/main/java/com/cupid/jikting/team/entity/TeamLike.java
+++ b/src/main/java/com/cupid/jikting/team/entity/TeamLike.java
@@ -29,4 +29,8 @@ public class TeamLike extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "sent_team_id")
     private Team sentTeam;
+
+    public void reject() {
+        acceptStatus = AcceptStatus.REJECT;
+    }
 }

--- a/src/test/java/com/cupid/jikting/like/service/LikeServiceTest.java
+++ b/src/test/java/com/cupid/jikting/like/service/LikeServiceTest.java
@@ -3,14 +3,13 @@ package com.cupid.jikting.like.service;
 import com.cupid.jikting.common.entity.Personality;
 import com.cupid.jikting.common.error.ApplicationError;
 import com.cupid.jikting.common.error.BadRequestException;
+import com.cupid.jikting.common.error.NotFoundException;
 import com.cupid.jikting.like.dto.LikeResponse;
 import com.cupid.jikting.member.entity.MemberProfile;
 import com.cupid.jikting.member.entity.ProfileImage;
 import com.cupid.jikting.member.entity.Sequence;
-import com.cupid.jikting.team.entity.Team;
-import com.cupid.jikting.team.entity.TeamLike;
-import com.cupid.jikting.team.entity.TeamMember;
-import com.cupid.jikting.team.entity.TeamPersonality;
+import com.cupid.jikting.team.entity.*;
+import com.cupid.jikting.team.repository.TeamLikeRepository;
 import com.cupid.jikting.team.repository.TeamMemberRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -42,12 +41,16 @@ class LikeServiceTest {
 
     private TeamMember teamMember;
     private List<TeamLike> teamLikes;
+    private TeamLike teamLike;
 
     @InjectMocks
     private LikeService likeService;
 
     @Mock
     private TeamMemberRepository teamMemberRepository;
+
+    @Mock
+    private TeamLikeRepository teamLikeRepository;
 
     @BeforeEach
     void setUp() {
@@ -81,15 +84,15 @@ class LikeServiceTest {
                 .teamPersonalities(List.of(teamPersonality))
                 .teamMembers(teamMembers)
                 .build();
-        TeamLike teamLike = TeamLike.builder()
+        TeamLike tmpTeamLike = TeamLike.builder()
                 .id(ID)
                 .sentTeam(sentTeam)
                 .receivedTeam(receivedTeam)
                 .build();
         Team team = Team.builder()
                 .id(ID)
-                .receivedTeamLikes(List.of(teamLike))
-                .sentTeamLikes(List.of(teamLike))
+                .receivedTeamLikes(List.of(tmpTeamLike))
+                .sentTeamLikes(List.of(tmpTeamLike))
                 .build();
         teamMember = TeamMember.builder()
                 .team(team)
@@ -97,6 +100,10 @@ class LikeServiceTest {
         teamLikes = List.of(TeamLike.builder()
                 .sentTeam(team)
                 .build());
+        teamLike = TeamLike.builder()
+                .id(ID)
+                .acceptStatus(AcceptStatus.INITIAL)
+                .build();
     }
 
     @Test
@@ -143,5 +150,26 @@ class LikeServiceTest {
         assertThatThrownBy(() -> likeService.getAllSentLike(ID))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage(ApplicationError.NOT_EXIST_REGISTERED_TEAM.getMessage());
+    }
+
+    @Test
+    void 받은_호감_거절_성공() {
+        //given
+        willReturn(Optional.of(teamLike)).given(teamLikeRepository).findById(anyLong());
+        //when
+        likeService.rejectLike(ID);
+        //then
+        verify(teamLikeRepository).findById(anyLong());
+    }
+
+    @Test
+    void 받은_호감_거절_실패_호감_없음() {
+        //given
+        willThrow(new NotFoundException(ApplicationError.LIKE_NOT_FOUND)).given(teamLikeRepository)
+                .findById(anyLong());
+        //when & then
+        assertThatThrownBy(() -> likeService.rejectLike(ID))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage(ApplicationError.LIKE_NOT_FOUND.getMessage());
     }
 }

--- a/src/test/java/com/cupid/jikting/like/service/LikeServiceTest.java
+++ b/src/test/java/com/cupid/jikting/like/service/LikeServiceTest.java
@@ -84,15 +84,16 @@ class LikeServiceTest {
                 .teamPersonalities(List.of(teamPersonality))
                 .teamMembers(teamMembers)
                 .build();
-        TeamLike tmpTeamLike = TeamLike.builder()
+        teamLike = TeamLike.builder()
                 .id(ID)
                 .sentTeam(sentTeam)
                 .receivedTeam(receivedTeam)
+                .acceptStatus(AcceptStatus.INITIAL)
                 .build();
         Team team = Team.builder()
                 .id(ID)
-                .receivedTeamLikes(List.of(tmpTeamLike))
-                .sentTeamLikes(List.of(tmpTeamLike))
+                .receivedTeamLikes(List.of(teamLike))
+                .sentTeamLikes(List.of(teamLike))
                 .build();
         teamMember = TeamMember.builder()
                 .team(team)
@@ -100,10 +101,6 @@ class LikeServiceTest {
         teamLikes = List.of(TeamLike.builder()
                 .sentTeam(team)
                 .build());
-        teamLike = TeamLike.builder()
-                .id(ID)
-                .acceptStatus(AcceptStatus.INITIAL)
-                .build();
     }
 
     @Test
@@ -165,8 +162,7 @@ class LikeServiceTest {
     @Test
     void 받은_호감_거절_실패_호감_없음() {
         //given
-        willThrow(new NotFoundException(ApplicationError.LIKE_NOT_FOUND)).given(teamLikeRepository)
-                .findById(anyLong());
+        willThrow(new NotFoundException(ApplicationError.LIKE_NOT_FOUND)).given(teamLikeRepository).findById(anyLong());
         //when & then
         assertThatThrownBy(() -> likeService.rejectLike(ID))
                 .isInstanceOf(NotFoundException.class)


### PR DESCRIPTION
## Issue

closed #131 
[SP-224](https://soma-cupid.atlassian.net/browse/SP-224?atlOrigin=eyJpIjoiZDA5MmE3ODVjNDZhNGNhODg2NmMyMGFkMTA4NjdkYzUiLCJwIjoiaiJ9)

## 요구사항

- [x] 받은 호감 거절 구현

## 변경사항

- `LikeService`,`TeamLike`, `LikeServiceTest` 받은 호감 거절 추가
- `ApplicationError` 호감 못찾음 추가

## 리뷰 우선순위

🙂보통

[SP-224]: https://soma-cupid.atlassian.net/browse/SP-224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ