### PR TITLE
[SP-203] 회원 탈퇴 기능 구현

### DIFF
--- a/src/main/java/com/cupid/jikting/member/entity/Member.java
+++ b/src/main/java/com/cupid/jikting/member/entity/Member.java
@@ -1,8 +1,11 @@
 package com.cupid.jikting.member.entity;
 
 import com.cupid.jikting.common.entity.BaseEntity;
+import com.cupid.jikting.common.error.ApplicationError;
+import com.cupid.jikting.common.error.UnAuthorizedException;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -54,5 +57,11 @@ public class Member extends BaseEntity {
         memberProfile = MemberProfile.builder()
                 .member(this)
                 .build();
+    }
+
+    public void validatePassword(PasswordEncoder passwordEncoder, String password) {
+        if (!passwordEncoder.matches(password, this.password)) {
+            throw new UnAuthorizedException(ApplicationError.NOT_EQUAL_ID_OR_PASSWORD);
+        }
     }
 }

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -60,6 +60,9 @@ public class MemberService {
     }
 
     public void withdraw(Long memberId, WithdrawRequest withdrawRequest) {
+        Member member = getMemberProfileById(memberId).getMember();
+        member.validatePassword(passwordEncoder, withdrawRequest.getPassword());
+        memberRepository.delete(member);
     }
 
     public void checkDuplicatedUsername(UsernameCheckRequest usernameCheckRequest) {

--- a/src/test/java/com/cupid/jikting/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/cupid/jikting/member/repository/MemberRepositoryTest.java
@@ -1,0 +1,38 @@
+package com.cupid.jikting.member.repository;
+
+import com.cupid.jikting.member.entity.Member;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class MemberRepositoryTest {
+
+    private static final String USERNAME = "username123";
+    private static final String PASSWORD = "Password123!";
+    private static final String NAME = "홍길동";
+    private static final String PHONE = "01000000000";
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    void 회원_삭제_성공() {
+        // given
+        Member member = Member.builder()
+                .username(USERNAME)
+                .password(PASSWORD)
+                .name(NAME)
+                .phone(PHONE)
+                .build();
+        Member savedMember = memberRepository.save(member);
+        // when
+        memberRepository.delete(member);
+        // then
+        assertThat(memberRepository.findById(savedMember.getId())).isEmpty();
+    }
+}

--- a/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
+++ b/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
@@ -5,6 +5,7 @@ import com.cupid.jikting.common.entity.Personality;
 import com.cupid.jikting.common.error.ApplicationError;
 import com.cupid.jikting.common.error.DuplicateException;
 import com.cupid.jikting.common.error.NotFoundException;
+import com.cupid.jikting.common.error.UnAuthorizedException;
 import com.cupid.jikting.member.dto.*;
 import com.cupid.jikting.member.entity.*;
 import com.cupid.jikting.member.repository.MemberProfileRepository;
@@ -289,5 +290,19 @@ public class MemberServiceTest {
         assertThatThrownBy(() -> memberService.withdraw(ID, withdrawRequest))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage(ApplicationError.MEMBER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    void 회원_탈퇴_실패_비밀번호_불일치() {
+        // given
+        willReturn(Optional.of(memberProfile)).given(memberProfileRepository).findById(anyLong());
+        willThrow(new UnAuthorizedException(ApplicationError.NOT_EQUAL_ID_OR_PASSWORD)).given(passwordEncoder).matches(anyString(), anyString());
+        WithdrawRequest withdrawRequest = WithdrawRequest.builder()
+                .password(PASSWORD)
+                .build();
+        // when & then
+        assertThatThrownBy(() -> memberService.withdraw(ID, withdrawRequest))
+                .isInstanceOf(UnAuthorizedException.class)
+                .hasMessage(ApplicationError.NOT_EQUAL_ID_OR_PASSWORD.getMessage());
     }
 }

--- a/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
+++ b/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
@@ -151,11 +151,15 @@ public class MemberServiceTest {
     @Test
     void 회원_가입_성공() {
         // given
+        willReturn(PASSWORD).given(passwordEncoder).encode(anyString());
         willReturn(member).given(memberRepository).save(any(Member.class));
         // when
         memberService.signup(signupRequest);
         // then
-        verify(memberRepository).save(any(Member.class));
+        assertAll(
+                () -> verify(passwordEncoder).encode(anyString()),
+                () -> verify(memberRepository).save(any(Member.class))
+        );
     }
 
     @Test

--- a/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
+++ b/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
@@ -277,4 +277,17 @@ public class MemberServiceTest {
                 () -> verify(memberRepository).delete(any(Member.class))
         );
     }
+
+    @Test
+    void 회원_탈퇴_실패_회원_없음() {
+        // given
+        willThrow(new NotFoundException(ApplicationError.MEMBER_NOT_FOUND)).given(memberProfileRepository).findById(anyLong());
+        WithdrawRequest withdrawRequest = WithdrawRequest.builder()
+                .password(PASSWORD)
+                .build();
+        // when & then
+        assertThatThrownBy(() -> memberService.withdraw(ID, withdrawRequest))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage(ApplicationError.MEMBER_NOT_FOUND.getMessage());
+    }
 }


### PR DESCRIPTION
## Issue

closed #133 
[SP-203](https://soma-cupid.atlassian.net/browse/SP-203?atlOrigin=eyJpIjoiZjY0MTY3YjI3OGIyNGQ3OTkzNDY1ZmRjY2M5ZDcxNTIiLCJwIjoiaiJ9)

## 요구사항

- [x] 회원 탈퇴 기능 구현

## 변경사항

- `MemberServiceTest` 회원가입 성공 테스트 비밀번호 인코딩 mocking 추가

## 리뷰 우선순위

🙂보통

[SP-203]: https://soma-cupid.atlassian.net/browse/SP-203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ