### PR TITLE
[SP-184] 채팅 메시지 전송 기능 실패 테스트 추가

### DIFF
--- a/src/test/java/com/cupid/jikting/chatting/repository/ChattingRoomRepositoryTest.java
+++ b/src/test/java/com/cupid/jikting/chatting/repository/ChattingRoomRepositoryTest.java
@@ -1,0 +1,38 @@
+package com.cupid.jikting.chatting.repository;
+
+import com.cupid.jikting.chatting.entity.Chatting;
+import com.cupid.jikting.chatting.entity.ChattingRoom;
+import com.cupid.jikting.member.entity.MemberProfile;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class ChattingRoomRepositoryTest {
+
+    private static final String CONTENT = "내용";
+
+    @Autowired
+    private ChattingRoomRepository chattingRoomRepository;
+
+    @Test
+    void 채팅방에_채팅_저장_성공() {
+        // given
+        MemberProfile memberProfile = MemberProfile.builder()
+                .build();
+        ChattingRoom chattingRoom = ChattingRoom.builder().build();
+        Chatting chatting = Chatting.builder()
+                .content(CONTENT)
+                .memberProfile(memberProfile)
+                .build();
+        chattingRoom.createChatting(chatting);
+        // when
+        ChattingRoom savedChattingRoom = chattingRoomRepository.save(chattingRoom);
+        // then
+        assertThat(savedChattingRoom.getChattings().size()).isEqualTo(chattingRoom.getChattings().size());
+    }
+}

--- a/src/test/java/com/cupid/jikting/chatting/service/StompChattingServiceTest.java
+++ b/src/test/java/com/cupid/jikting/chatting/service/StompChattingServiceTest.java
@@ -3,7 +3,8 @@ package com.cupid.jikting.chatting.service;
 import com.cupid.jikting.chatting.dto.ChattingRequest;
 import com.cupid.jikting.chatting.entity.ChattingRoom;
 import com.cupid.jikting.chatting.repository.ChattingRoomRepository;
-import com.cupid.jikting.member.entity.Member;
+import com.cupid.jikting.common.error.ApplicationError;
+import com.cupid.jikting.common.error.NotFoundException;
 import com.cupid.jikting.member.entity.MemberProfile;
 import com.cupid.jikting.member.repository.MemberProfileRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -15,10 +16,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.willReturn;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -68,5 +71,15 @@ public class StompChattingServiceTest {
                 () -> verify(chattingRoomRepository).findById(anyLong()),
                 () -> verify(chattingRoomRepository).save(any(ChattingRoom.class))
         );
+    }
+
+    @Test
+    void 채팅_메시지_전송_실패_회원_없음() {
+        // given
+        willThrow(new NotFoundException(ApplicationError.MEMBER_NOT_FOUND)).given(memberProfileRepository).findById(anyLong());
+        // when & then
+        assertThatThrownBy(() -> chattingService.sendMessage(ID, chattingRequest))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage(ApplicationError.MEMBER_NOT_FOUND.getMessage());
     }
 }

--- a/src/test/java/com/cupid/jikting/chatting/service/StompChattingServiceTest.java
+++ b/src/test/java/com/cupid/jikting/chatting/service/StompChattingServiceTest.java
@@ -5,6 +5,7 @@ import com.cupid.jikting.chatting.entity.ChattingRoom;
 import com.cupid.jikting.chatting.repository.ChattingRoomRepository;
 import com.cupid.jikting.common.error.ApplicationError;
 import com.cupid.jikting.common.error.NotFoundException;
+import com.cupid.jikting.member.entity.Member;
 import com.cupid.jikting.member.entity.MemberProfile;
 import com.cupid.jikting.member.repository.MemberProfileRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -75,11 +76,22 @@ public class StompChattingServiceTest {
 
     @Test
     void 채팅_메시지_전송_실패_회원_없음() {
-        // given
+    	// given
         willThrow(new NotFoundException(ApplicationError.MEMBER_NOT_FOUND)).given(memberProfileRepository).findById(anyLong());
-        // when & then
+    	// when & then
         assertThatThrownBy(() -> chattingService.sendMessage(ID, chattingRequest))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage(ApplicationError.MEMBER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    void 채팅_메시지_전송_실패_채팅방_없음() {
+    	// given
+        willReturn(Optional.of(memberProfile)).given(memberProfileRepository).findById(anyLong());
+        willThrow(new NotFoundException(ApplicationError.CHATTING_ROOM_NOT_FOUND)).given(chattingRoomRepository).findById(anyLong());
+    	// when & then
+        assertThatThrownBy(() -> chattingService.sendMessage(ID, chattingRequest))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage(ApplicationError.CHATTING_ROOM_NOT_FOUND.getMessage());
     }
 }


### PR DESCRIPTION
## Issue

closed #135 
[SP-184](https://soma-cupid.atlassian.net/browse/SP-184?atlOrigin=eyJpIjoiY2Y1ZGJkMzFlYzUzNGFlOGI3NWZjMmQxNGQ4OWM3MmQiLCJwIjoiaiJ9)

## 요구사항

- [x] 채팅 메시지 전송 기능 실패 테스트 추가

## 변경사항

- `ChattingRoomRepositoryTest` 채팅방에 채팅 저장 성공 테스트 추가

## 리뷰 우선순위

🙂보통

[SP-184]: https://soma-cupid.atlassian.net/browse/SP-184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ