### PR TITLE
[SP-197] 번개팅 참여 기능 구현

### DIFF
--- a/src/main/java/com/cupid/jikting/meeting/controller/InstantMeetingController.java
+++ b/src/main/java/com/cupid/jikting/meeting/controller/InstantMeetingController.java
@@ -23,8 +23,8 @@ public class InstantMeetingController {
     }
 
     @PostMapping("/{instantMeetingId}")
-    public ResponseEntity<Void> attend(@PathVariable Long instantMeetingId) {
-        instantMeetingService.attend(instantMeetingId);
+    public ResponseEntity<Void> attend(@RequestHeader("Authorization") String token, @PathVariable Long instantMeetingId) {
+        instantMeetingService.attend(jwtService.extractValidMemberProfileId(token), instantMeetingId);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/cupid/jikting/meeting/entity/InstantMeeting.java
+++ b/src/main/java/com/cupid/jikting/meeting/entity/InstantMeeting.java
@@ -34,4 +34,8 @@ public class InstantMeeting extends BaseEntity {
         return instantMeetingMembers.stream()
                 .anyMatch(instantMeetingMember -> instantMeetingMember.isSameMemberProfileId(memberProfileId));
     }
+
+    public void addMemberProfile(InstantMeetingMember instantMeetingMember) {
+        instantMeetingMembers.add(instantMeetingMember);
+    }
 }

--- a/src/main/java/com/cupid/jikting/meeting/entity/InstantMeetingMember.java
+++ b/src/main/java/com/cupid/jikting/meeting/entity/InstantMeetingMember.java
@@ -6,13 +6,11 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.SQLDelete;
 
 import javax.persistence.*;
 
 @Getter
-@SuperBuilder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE instant_meeting_member SET is_deleted = true WHERE instant_meeting_member_id = ?")
@@ -30,5 +28,12 @@ public class InstantMeetingMember extends BaseEntity {
 
     public boolean isSameMemberProfileId(Long memberProfileId) {
         return memberProfile.isSameAs(memberProfileId);
+    }
+
+    public static InstantMeetingMember of(InstantMeeting instantMeeting, MemberProfile memberProfile) {
+        InstantMeetingMember instantMeetingMember = new InstantMeetingMember(memberProfile, instantMeeting);
+        instantMeeting.addMemberProfile(instantMeetingMember);
+        memberProfile.addInstantMeeting(instantMeetingMember);
+        return instantMeetingMember;
     }
 }

--- a/src/main/java/com/cupid/jikting/meeting/service/InstantMeetingService.java
+++ b/src/main/java/com/cupid/jikting/meeting/service/InstantMeetingService.java
@@ -31,11 +31,19 @@ public class InstantMeetingService {
 
     @Transactional
     public void attend(Long memberProfileId, Long instantMeetingId) {
-        MemberProfile memberProfile = memberProfileRepository.findById(memberProfileId)
-                .orElseThrow(() -> new NotFoundException(ApplicationError.MEMBER_NOT_FOUND));
-        InstantMeeting instantMeeting = instantMeetingRepository.findById(instantMeetingId)
-                .orElseThrow(() -> new NotFoundException(ApplicationError.INSTANT_MEETING_NOT_FOUND));
+        MemberProfile memberProfile = getMemberProfileById(memberProfileId);
+        InstantMeeting instantMeeting = getInstantMeetingById(instantMeetingId);
         InstantMeetingMember.of(instantMeeting, memberProfile);
         memberProfileRepository.save(memberProfile);
+    }
+
+    private MemberProfile getMemberProfileById(Long memberProfileId) {
+        return memberProfileRepository.findById(memberProfileId)
+                .orElseThrow(() -> new NotFoundException(ApplicationError.MEMBER_NOT_FOUND));
+    }
+
+    private InstantMeeting getInstantMeetingById(Long instantMeetingId) {
+        return instantMeetingRepository.findById(instantMeetingId)
+                .orElseThrow(() -> new NotFoundException(ApplicationError.INSTANT_MEETING_NOT_FOUND));
     }
 }

--- a/src/main/java/com/cupid/jikting/meeting/service/InstantMeetingService.java
+++ b/src/main/java/com/cupid/jikting/meeting/service/InstantMeetingService.java
@@ -1,9 +1,16 @@
 package com.cupid.jikting.meeting.service;
 
+import com.cupid.jikting.common.error.ApplicationError;
+import com.cupid.jikting.common.error.NotFoundException;
 import com.cupid.jikting.meeting.dto.InstantMeetingResponse;
+import com.cupid.jikting.meeting.entity.InstantMeeting;
+import com.cupid.jikting.meeting.entity.InstantMeetingMember;
 import com.cupid.jikting.meeting.repository.InstantMeetingRepository;
+import com.cupid.jikting.member.entity.MemberProfile;
+import com.cupid.jikting.member.repository.MemberProfileRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -13,6 +20,7 @@ import java.util.stream.Collectors;
 public class InstantMeetingService {
 
     private final InstantMeetingRepository instantMeetingRepository;
+    private final MemberProfileRepository memberProfileRepository;
 
     public List<InstantMeetingResponse> getAll(Long memberProfileId) {
         return instantMeetingRepository.findAll()
@@ -21,6 +29,13 @@ public class InstantMeetingService {
                 .collect(Collectors.toList());
     }
 
-    public void attend(Long instantMeetingId) {
+    @Transactional
+    public void attend(Long memberProfileId, Long instantMeetingId) {
+        MemberProfile memberProfile = memberProfileRepository.findById(memberProfileId)
+                .orElseThrow(() -> new NotFoundException(ApplicationError.MEMBER_NOT_FOUND));
+        InstantMeeting instantMeeting = instantMeetingRepository.findById(instantMeetingId)
+                .orElseThrow(() -> new NotFoundException(ApplicationError.INSTANT_MEETING_NOT_FOUND));
+        InstantMeetingMember.of(instantMeeting, memberProfile);
+        memberProfileRepository.save(memberProfile);
     }
 }

--- a/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
+++ b/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
@@ -71,7 +71,7 @@ public class MemberProfile extends BaseEntity {
     private List<MemberChattingRoom> memberChattingRooms = new ArrayList<>();
 
     @Builder.Default
-    @OneToMany(mappedBy = "memberProfile")
+    @OneToMany(mappedBy = "memberProfile", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
     private List<InstantMeetingMember> instantMeetingMembers = new ArrayList<>();
 
     public Team getTeam() {
@@ -141,5 +141,9 @@ public class MemberProfile extends BaseEntity {
 
     public boolean isSameAs(Long memberProfileId) {
         return id.equals(memberProfileId);
+    }
+
+    public void addInstantMeeting(InstantMeetingMember instantMeetingMember) {
+        instantMeetingMembers.add(instantMeetingMember);
     }
 }

--- a/src/test/java/com/cupid/jikting/meeting/controller/InstantMeetingControllerTest.java
+++ b/src/test/java/com/cupid/jikting/meeting/controller/InstantMeetingControllerTest.java
@@ -83,7 +83,7 @@ public class InstantMeetingControllerTest extends ApiDocument {
     @Test
     void 번개팅_참여_성공() throws Exception {
         //given
-        willDoNothing().given(instantMeetingService).attend(anyLong());
+        willDoNothing().given(instantMeetingService).attend(anyLong(), anyLong());
         //when
         ResultActions resultActions = 번개팅_참여_요청();
         //then
@@ -94,7 +94,7 @@ public class InstantMeetingControllerTest extends ApiDocument {
     @Test
     void 번개팅_참여_실패() throws Exception {
         //given
-        willThrow(instantMeetingAlreadyFullException).given(instantMeetingService).attend(anyLong());
+        willThrow(instantMeetingAlreadyFullException).given(instantMeetingService).attend(anyLong(), anyLong());
         //when
         ResultActions resultActions = 번개팅_참여_요청();
         //then
@@ -116,7 +116,8 @@ public class InstantMeetingControllerTest extends ApiDocument {
 
     private ResultActions 번개팅_참여_요청() throws Exception {
         return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH + PATH_DELIMITER + ID)
-                .contextPath(CONTEXT_PATH));
+                .contextPath(CONTEXT_PATH)
+                .header(AUTHORIZATION, BEARER + accessToken));
     }
 
     private void 번개팅_참여_요청_성공(ResultActions resultActions) throws Exception {

--- a/src/test/java/com/cupid/jikting/meeting/service/InstantMeetingServiceTest.java
+++ b/src/test/java/com/cupid/jikting/meeting/service/InstantMeetingServiceTest.java
@@ -1,10 +1,13 @@
 package com.cupid.jikting.meeting.service;
 
+import com.cupid.jikting.common.error.ApplicationError;
+import com.cupid.jikting.common.error.NotFoundException;
 import com.cupid.jikting.meeting.dto.InstantMeetingResponse;
 import com.cupid.jikting.meeting.entity.InstantMeeting;
 import com.cupid.jikting.meeting.entity.InstantMeetingMember;
 import com.cupid.jikting.meeting.repository.InstantMeetingRepository;
 import com.cupid.jikting.member.entity.MemberProfile;
+import com.cupid.jikting.member.repository.MemberProfileRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,12 +18,17 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.LocalDateTime;
 import java.time.Month;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.willReturn;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -31,6 +39,8 @@ public class InstantMeetingServiceTest {
     private static final String PLACE = "장소";
 
     private List<InstantMeeting> instantMeetings;
+    private MemberProfile memberProfile;
+    private InstantMeeting instantMeeting;
 
     @InjectMocks
     InstantMeetingService instantMeetingService;
@@ -38,20 +48,20 @@ public class InstantMeetingServiceTest {
     @Mock
     InstantMeetingRepository instantMeetingRepository;
 
+    @Mock
+    MemberProfileRepository memberProfileRepository;
+
     @BeforeEach
     void setUp() {
-        MemberProfile memberProfile = MemberProfile.builder()
+        memberProfile = MemberProfile.builder()
                 .id(ID)
                 .build();
-        InstantMeetingMember instantMeetingMember = InstantMeetingMember.builder()
-                .memberProfile(memberProfile)
-                .build();
-        InstantMeeting instantMeeting = InstantMeeting.builder()
+        instantMeeting = InstantMeeting.builder()
                 .id(ID)
                 .schedule(SCHEDULE)
                 .place(PLACE)
-                .instantMeetingMembers(List.of(instantMeetingMember))
                 .build();
+        InstantMeetingMember.of(instantMeeting, memberProfile);
         instantMeetings = IntStream.rangeClosed(0, 2)
                 .mapToObj(n -> instantMeeting)
                 .collect(Collectors.toList());
@@ -68,5 +78,41 @@ public class InstantMeetingServiceTest {
                 () -> verify(instantMeetingRepository).findAll(),
                 () -> assertThat(instantMeetingResponses.size()).isEqualTo(instantMeetings.size())
         );
+    }
+
+    @Test
+    void 번개팅_참여_성공() {
+        //given
+        willReturn(Optional.of(memberProfile)).given(memberProfileRepository).findById(anyLong());
+        willReturn(Optional.of(instantMeeting)).given(instantMeetingRepository).findById(anyLong());
+        //when
+        instantMeetingService.attend(ID, ID);
+        //then
+        assertAll(
+                () -> verify(memberProfileRepository).findById(anyLong()),
+                () -> verify(instantMeetingRepository).findById(anyLong()),
+                () -> verify(memberProfileRepository).save(any(MemberProfile.class))
+        );
+    }
+
+    @Test
+    void 번개팅_참여_실패_회원_없음() {
+        // given
+        willThrow(new NotFoundException(ApplicationError.MEMBER_NOT_FOUND)).given(memberProfileRepository).findById(anyLong());
+        // when & then
+        assertThatThrownBy(() -> instantMeetingService.attend(ID, ID))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage(ApplicationError.MEMBER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    void 번개팅_참여_실패_번개팅_없음() {
+        // given
+        willReturn(Optional.of(memberProfile)).given(memberProfileRepository).findById(anyLong());
+        willThrow(new NotFoundException(ApplicationError.INSTANT_MEETING_NOT_FOUND)).given(instantMeetingRepository).findById(anyLong());
+        // when & then
+        assertThatThrownBy(() -> instantMeetingService.attend(ID, ID))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage(ApplicationError.INSTANT_MEETING_NOT_FOUND.getMessage());
     }
 }


### PR DESCRIPTION
## Issue

closed #143 
[SP-197](https://soma-cupid.atlassian.net/browse/SP-197?atlOrigin=eyJpIjoiMWI2ZDllMGZkNGQyNDM4MTlhMmZjNTQ1YTlmMjc5ZTAiLCJwIjoiaiJ9)

## 요구사항

- [x] 번개팅 참여 기능 구현


## 변경사항

- `InstantMeetingController` header에서 token 추출 추가
- `InstantMeetingMember` 정적 팩토리 메서드 적용
- `InstantMeetingServiceTest` 번개팅 참여 서비스 테스트 추가

## 리뷰 우선순위

🙂보통

[SP-197]: https://soma-cupid.atlassian.net/browse/SP-197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ