### PR TITLE
[SP-228] 호감 목록 조회 - 팀 상세 조회 구현

### DIFF
--- a/src/main/java/com/cupid/jikting/like/controller/LikeController.java
+++ b/src/main/java/com/cupid/jikting/like/controller/LikeController.java
@@ -40,8 +40,13 @@ public class LikeController {
         return ResponseEntity.ok().build();
     }
 
-    @GetMapping("/{likeId}")
-    public ResponseEntity<TeamDetailResponse> getTeamDetail(@PathVariable Long likeId) {
-        return ResponseEntity.ok().body(likeService.getTeamDetail(likeId));
+    @GetMapping("/{likeId}/sent")
+    public ResponseEntity<TeamDetailResponse> getSentTeamDetail(@PathVariable Long likeId) {
+        return ResponseEntity.ok().body(likeService.getSentTeamDetail(likeId));
+    }
+
+    @GetMapping("/{likeId}/received")
+    public ResponseEntity<TeamDetailResponse> getReceivedTeamDetail(@PathVariable Long likeId) {
+        return ResponseEntity.ok().body(likeService.getReceivedTeamDetail(likeId));
     }
 }

--- a/src/main/java/com/cupid/jikting/like/dto/MemberProfileResponse.java
+++ b/src/main/java/com/cupid/jikting/like/dto/MemberProfileResponse.java
@@ -1,11 +1,12 @@
 package com.cupid.jikting.like.dto;
 
+import com.cupid.jikting.member.entity.MemberProfile;
 import lombok.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
-@Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberProfileResponse {
@@ -16,10 +17,29 @@ public class MemberProfileResponse {
     private String mbti;
     private String address;
     private String company;
-    private boolean isSmoke;
+    private String smokeStatus;
     private String drinkStatus;
     private int height;
     private String description;
     private List<String> keywords;
     private String college;
+
+    public static MemberProfileResponse from(MemberProfile memberProfile) {
+        List<String> keywords = new ArrayList<>();
+        keywords.addAll(memberProfile.getPersonalityKeywords());
+        keywords.addAll(memberProfile.getHobbyKeywords());
+        return new MemberProfileResponse(
+                memberProfile.getNickname(),
+                memberProfile.getMainImageUrl(),
+                memberProfile.getAge(),
+                memberProfile.getMbti().toString(),
+                memberProfile.getAddress(),
+                memberProfile.getCompany(),
+                memberProfile.getSmokeStatus().toString(),
+                memberProfile.getDrinkStatus().toString(),
+                memberProfile.getHeight(),
+                memberProfile.getDescription(),
+                keywords,
+                memberProfile.getCollege());
+    }
 }

--- a/src/main/java/com/cupid/jikting/like/dto/TeamDetailResponse.java
+++ b/src/main/java/com/cupid/jikting/like/dto/TeamDetailResponse.java
@@ -1,11 +1,15 @@
 package com.cupid.jikting.like.dto;
 
-import lombok.*;
+import com.cupid.jikting.team.entity.Team;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
-@Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TeamDetailResponse {
@@ -14,4 +18,16 @@ public class TeamDetailResponse {
     private String teamName;
     private List<String> keywords;
     private List<MemberProfileResponse> members;
+
+    public static TeamDetailResponse of(Long likeId, Team team) {
+        List<MemberProfileResponse> memberProfileResponses = team.getMemberProfiles()
+                .stream()
+                .map(MemberProfileResponse::from)
+                .collect(Collectors.toList());
+        return new TeamDetailResponse(
+                likeId,
+                team.getName(),
+                team.getPersonalities(),
+                memberProfileResponses);
+    }
 }

--- a/src/main/java/com/cupid/jikting/like/service/LikeService.java
+++ b/src/main/java/com/cupid/jikting/like/service/LikeService.java
@@ -46,18 +46,26 @@ public class LikeService {
     }
 
     public void rejectLike(Long likeId) {
-        TeamLike teamLike = teamLikeRepository.findById(likeId)
-                .orElseThrow(() -> new NotFoundException(ApplicationError.LIKE_NOT_FOUND));
+        TeamLike teamLike = getTeamLikeById(likeId);
         teamLike.reject();
         teamLikeRepository.save(teamLike);
     }
 
-    public TeamDetailResponse getTeamDetail(Long likeId) {
-        return null;
+    public TeamDetailResponse getSentTeamDetail(Long likeId) {
+        return TeamDetailResponse.of(likeId, getTeamLikeById(likeId).getReceivedTeam());
+    }
+
+    public TeamDetailResponse getReceivedTeamDetail(Long likeId) {
+        return TeamDetailResponse.of(likeId, getTeamLikeById(likeId).getSentTeam());
     }
 
     private TeamMember getTeamMemberById(Long memberProfileId) {
         return teamMemberRepository.getTeamMemberByMemberProfileId(memberProfileId)
                 .orElseThrow(() -> new BadRequestException(ApplicationError.NOT_EXIST_REGISTERED_TEAM));
+    }
+
+    private TeamLike getTeamLikeById(Long likeId) {
+        return teamLikeRepository.findById(likeId)
+                .orElseThrow(() -> new NotFoundException(ApplicationError.LIKE_NOT_FOUND));
     }
 }


### PR DESCRIPTION
## Issue

closed #150 
[SP-228](https://soma-cupid.atlassian.net/browse/SP-228?atlOrigin=eyJpIjoiY2Y5ZDQ0NjEyMDE0NGE1MTllZmRiZjQ3YTlhOGFkZWUiLCJwIjoiaiJ9)

## 요구사항

- [x] 팀 상세 조회 구현

## 변경사항

- 팀 상세 조회 보낸팀과 받은 팀으로 분리
- `MemberProfileResponse` 및 `TeamDetailResponse` 정적 팩토리 메서드 적용

## 리뷰 우선순위

🙂보통

## 코멘트

- 팀 상세 조회 보낸팀과 받은 팀으로 분리하였습니다.


[SP-228]: https://soma-cupid.atlassian.net/browse/SP-228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ