### PR TITLE
[SP-185] 채팅 내 미팅 확정 기능 구현

### DIFF
--- a/src/main/java/com/cupid/jikting/chatting/controller/ChattingRoomController.java
+++ b/src/main/java/com/cupid/jikting/chatting/controller/ChattingRoomController.java
@@ -2,6 +2,7 @@ package com.cupid.jikting.chatting.controller;
 
 import com.cupid.jikting.chatting.dto.ChattingRoomDetailResponse;
 import com.cupid.jikting.chatting.dto.ChattingRoomResponse;
+import com.cupid.jikting.chatting.dto.MeetingConfirmRequest;
 import com.cupid.jikting.chatting.service.ChattingRoomService;
 import com.cupid.jikting.jwt.service.JwtService;
 import lombok.RequiredArgsConstructor;
@@ -29,8 +30,8 @@ public class ChattingRoomController {
     }
 
     @PostMapping("/{chattingRoomId}/confirm")
-    public ResponseEntity<Void> confirm(@PathVariable Long chattingRoomId) {
-        chattingRoomService.confirm(chattingRoomId);
+    public ResponseEntity<Void> confirm(@PathVariable Long chattingRoomId, MeetingConfirmRequest meetingConfirmRequest) {
+        chattingRoomService.confirm(chattingRoomId, meetingConfirmRequest);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/cupid/jikting/chatting/entity/ChattingRoom.java
+++ b/src/main/java/com/cupid/jikting/chatting/entity/ChattingRoom.java
@@ -10,6 +10,7 @@ import org.hibernate.annotations.SQLDelete;
 
 import javax.persistence.*;
 import java.io.Serializable;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -22,7 +23,7 @@ import java.util.List;
 @Entity
 public class ChattingRoom extends BaseEntity implements Serializable {
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.MERGE)
     @JoinColumn(name = "meeting_id")
     private Meeting meeting;
 
@@ -44,5 +45,9 @@ public class ChattingRoom extends BaseEntity implements Serializable {
 
     public String getOppositeTeamName(Team team) {
         return meeting.getOppositeTeamName(team);
+    }
+
+    public void confirmMeeting(Long meetingId, LocalDateTime schedule, String place) {
+        meeting.confirm(meetingId, schedule, place);
     }
 }

--- a/src/main/java/com/cupid/jikting/chatting/service/ChattingRoomService.java
+++ b/src/main/java/com/cupid/jikting/chatting/service/ChattingRoomService.java
@@ -32,8 +32,7 @@ public class ChattingRoomService {
     private ChattingRoomRepository chattingRoomRepository;
 
     public List<ChattingRoomResponse> getAll(Long memberProfileId) {
-        MemberProfile memberProfile = memberProfileRepository.findById(memberProfileId)
-                .orElseThrow(() -> new NotFoundException(ApplicationError.MEMBER_NOT_FOUND));
+        MemberProfile memberProfile = getMemberProfileById(memberProfileId);
         return chattingRoomRepository.findAll()
                 .stream()
                 .map(chattingRoom -> toChattingRoomResponse(chattingRoom, memberProfile.getTeam()))
@@ -48,6 +47,11 @@ public class ChattingRoomService {
         ChattingRoom chattingRoom = getChattingRoomById(chattingRoomId);
         chattingRoom.confirmMeeting(meetingConfirmRequest.getMeetingId(), meetingConfirmRequest.getSchedule(), meetingConfirmRequest.getPlace());
         chattingRoomRepository.save(chattingRoom);
+    }
+
+    private MemberProfile getMemberProfileById(Long memberProfileId) {
+        return memberProfileRepository.findById(memberProfileId)
+                .orElseThrow(() -> new NotFoundException(ApplicationError.MEMBER_NOT_FOUND));
     }
 
     private ChattingRoomResponse toChattingRoomResponse(ChattingRoom chattingRoom, Team team) {

--- a/src/main/java/com/cupid/jikting/chatting/service/ChattingRoomService.java
+++ b/src/main/java/com/cupid/jikting/chatting/service/ChattingRoomService.java
@@ -2,6 +2,7 @@ package com.cupid.jikting.chatting.service;
 
 import com.cupid.jikting.chatting.dto.ChattingRoomDetailResponse;
 import com.cupid.jikting.chatting.dto.ChattingRoomResponse;
+import com.cupid.jikting.chatting.dto.MeetingConfirmRequest;
 import com.cupid.jikting.chatting.entity.Chatting;
 import com.cupid.jikting.chatting.entity.ChattingRoom;
 import com.cupid.jikting.chatting.entity.MemberChattingRoom;
@@ -41,7 +42,10 @@ public class ChattingRoomService {
         return null;
     }
 
-    public void confirm(Long chattingRoomId) {
+    public void confirm(Long chattingRoomId, MeetingConfirmRequest meetingConfirmRequest) {
+        ChattingRoom chattingRoom = getChattingRoomById(chattingRoomId);
+        chattingRoom.confirmMeeting(meetingConfirmRequest.getMeetingId(), meetingConfirmRequest.getSchedule(), meetingConfirmRequest.getPlace());
+        chattingRoomRepository.save(chattingRoom);
     }
 
     private ChattingRoomResponse toChattingRoomResponse(ChattingRoom chattingRoom, Team team) {
@@ -68,5 +72,10 @@ public class ChattingRoomService {
                         .map(ProfileImage::getUrl)
                         .toArray(String[]::new)))
                 .collect(Collectors.toList());
+    }
+
+    private ChattingRoom getChattingRoomById(Long chattingRoomId) {
+        return chattingRoomRepository.findById(chattingRoomId)
+                .orElseThrow(() -> new NotFoundException(ApplicationError.CHATTING_ROOM_NOT_FOUND));
     }
 }

--- a/src/main/java/com/cupid/jikting/chatting/service/ChattingRoomService.java
+++ b/src/main/java/com/cupid/jikting/chatting/service/ChattingRoomService.java
@@ -16,11 +16,13 @@ import com.cupid.jikting.team.entity.Team;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import javax.transaction.Transactional;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
+@Transactional
 @Service
 public class ChattingRoomService {
 

--- a/src/main/java/com/cupid/jikting/common/error/ApplicationError.java
+++ b/src/main/java/com/cupid/jikting/common/error/ApplicationError.java
@@ -19,6 +19,7 @@ public enum ApplicationError {
     EXPIRED_TOKEN(HttpStatus.BAD_REQUEST, "C009", "token 유효기간이 만료되었습니다."),
     VERIFICATION_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "C010", "인증번호가 유효하지 않습니다."),
     PERSONALITY_NOT_FOUND(HttpStatus.BAD_REQUEST, "C011", "성격 키워드를 찾을 수 없습니다."),
+    WRONG_ACCESS(HttpStatus.BAD_REQUEST, "C012", "잘못된 접근입니다."),
 
     UNAUTHORIZED_MEMBER(HttpStatus.UNAUTHORIZED, "U001", "인증되지 않은 사용자입니다."),
     FORBIDDEN_MEMBER(HttpStatus.FORBIDDEN, "U002", "권한이 없는 사용자입니다."),

--- a/src/main/java/com/cupid/jikting/meeting/entity/Meeting.java
+++ b/src/main/java/com/cupid/jikting/meeting/entity/Meeting.java
@@ -25,7 +25,6 @@ public class Meeting extends BaseEntity {
 
     private LocalDateTime schedule;
     private String place;
-    private LocalDateTime confirmAt;
 
     @Enumerated(EnumType.STRING)
     private ConfirmStatus confirmStatus;

--- a/src/main/java/com/cupid/jikting/meeting/entity/Meeting.java
+++ b/src/main/java/com/cupid/jikting/meeting/entity/Meeting.java
@@ -1,6 +1,8 @@
 package com.cupid.jikting.meeting.entity;
 
 import com.cupid.jikting.common.entity.BaseEntity;
+import com.cupid.jikting.common.error.ApplicationError;
+import com.cupid.jikting.common.error.WrongAccessException;
 import com.cupid.jikting.team.entity.Team;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -41,5 +43,18 @@ public class Meeting extends BaseEntity {
             return acceptingTeam.getName();
         }
         return recommendedTeam.getName();
+    }
+
+    public void confirm(Long meetingId, LocalDateTime schedule, String place) {
+        validate(meetingId);
+        this.schedule = schedule;
+        this.place = place;
+        confirmStatus = ConfirmStatus.DECIDED;
+    }
+
+    private void validate(Long meetingId) {
+        if (!id.equals(meetingId)) {
+            throw new WrongAccessException(ApplicationError.WRONG_ACCESS);
+        }
     }
 }

--- a/src/test/java/com/cupid/jikting/chatting/controller/ChattingRoomControllerTest.java
+++ b/src/test/java/com/cupid/jikting/chatting/controller/ChattingRoomControllerTest.java
@@ -141,7 +141,7 @@ public class ChattingRoomControllerTest extends ApiDocument {
     @Test
     void 미팅_확정_성공() throws Exception {
         //given
-        willDoNothing().given(chattingRoomService).confirm(anyLong());
+        willDoNothing().given(chattingRoomService).confirm(anyLong(), any(MeetingConfirmRequest.class));
         //when
         ResultActions resultActions = 미팅_확정_요청();
         //then
@@ -152,7 +152,7 @@ public class ChattingRoomControllerTest extends ApiDocument {
     @Test
     void 미팅_확정_양식불일치_실패() throws Exception {
         //given
-        willThrow(wrongFormException).given(chattingRoomService).confirm(anyLong());
+        willThrow(wrongFormException).given(chattingRoomService).confirm(anyLong(), any(MeetingConfirmRequest.class));
         //when
         ResultActions resultActions = 미팅_확정_요청();
         //then
@@ -163,7 +163,7 @@ public class ChattingRoomControllerTest extends ApiDocument {
     @Test
     void 미팅_확정_채팅방정보없음_실패() throws Exception {
         //given
-        willThrow(chattingRoomNotFoundException).given(chattingRoomService).confirm(anyLong());
+        willThrow(chattingRoomNotFoundException).given(chattingRoomService).confirm(anyLong(), any(MeetingConfirmRequest.class));
         //when
         ResultActions resultActions = 미팅_확정_요청();
         //then

--- a/src/test/java/com/cupid/jikting/chatting/service/ChattingRoomServiceTest.java
+++ b/src/test/java/com/cupid/jikting/chatting/service/ChattingRoomServiceTest.java
@@ -1,6 +1,7 @@
 package com.cupid.jikting.chatting.service;
 
 import com.cupid.jikting.chatting.dto.ChattingRoomResponse;
+import com.cupid.jikting.chatting.dto.MeetingConfirmRequest;
 import com.cupid.jikting.chatting.entity.ChattingRoom;
 import com.cupid.jikting.chatting.repository.ChattingRoomRepository;
 import com.cupid.jikting.common.error.ApplicationError;
@@ -18,6 +19,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -25,9 +27,12 @@ import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.willReturn;
 import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.verify;
 
 @WebMvcTest(MockitoExtension.class)
 class ChattingRoomServiceTest {
@@ -35,8 +40,11 @@ class ChattingRoomServiceTest {
     private static final Long ID = 1L;
     private static final String TEAM_NAME = "팀 이름";
     private static final boolean LEADER = true;
+    private static final LocalDateTime SCHEDULE = LocalDateTime.of(2023, 9, 10, 18, 30);
+    private static final String PLACE = "장소";
 
     private MemberProfile memberProfile;
+    private ChattingRoom chattingRoom;
     private List<ChattingRoom> chattingRooms;
     private ApplicationException memberNotFoundException;
 
@@ -59,15 +67,16 @@ class ChattingRoomServiceTest {
                 .id(ID)
                 .build();
         TeamMember.of(LEADER, team, memberProfile);
-        chattingRooms = IntStream.range(0, 3)
-                .mapToObj(n -> ChattingRoom.builder()
-                        .id(n + ID)
-                        .meeting(Meeting.builder()
-                                .id(ID)
-                                .recommendedTeam(team)
-                                .acceptingTeam(team)
-                                .build())
+        chattingRoom = ChattingRoom.builder()
+                .id(ID)
+                .meeting(Meeting.builder()
+                        .id(ID)
+                        .recommendedTeam(team)
+                        .acceptingTeam(team)
                         .build())
+                .build();
+        chattingRooms = IntStream.range(0, 3)
+                .mapToObj(n -> chattingRoom)
                 .collect(Collectors.toList());
         memberNotFoundException = new NotFoundException(ApplicationError.MEMBER_NOT_FOUND);
     }
@@ -91,5 +100,24 @@ class ChattingRoomServiceTest {
         assertThatThrownBy(() -> chattingRoomService.getAll(ID))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage(ApplicationError.MEMBER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    void 채팅방_내_미팅_화정_성공() {
+        // given
+        willReturn(Optional.of(chattingRoom)).given(chattingRoomRepository).findById(anyLong());
+        willReturn(chattingRoom).given(chattingRoomRepository).save(any(ChattingRoom.class));
+        MeetingConfirmRequest meetingConfirmRequest = MeetingConfirmRequest.builder()
+                .meetingId(ID)
+                .schedule(SCHEDULE)
+                .place(PLACE)
+                .build();
+        // when
+        chattingRoomService.confirm(ID, meetingConfirmRequest);
+        // then
+        assertAll(
+                () -> verify(chattingRoomRepository).findById(anyLong()),
+                () -> verify(chattingRoomRepository).save(any(ChattingRoom.class))
+        );
     }
 }

--- a/src/test/java/com/cupid/jikting/chatting/service/ChattingRoomServiceTest.java
+++ b/src/test/java/com/cupid/jikting/chatting/service/ChattingRoomServiceTest.java
@@ -120,4 +120,20 @@ class ChattingRoomServiceTest {
                 () -> verify(chattingRoomRepository).save(any(ChattingRoom.class))
         );
     }
+
+    @Test
+    void 채팅방_내_미팅_화정_실패_채팅방_없음() {
+        // given
+        willReturn(Optional.of(chattingRoom)).given(chattingRoomRepository).findById(anyLong());
+        willThrow(new NotFoundException(ApplicationError.CHATTING_ROOM_NOT_FOUND)).given(chattingRoomRepository).findById(anyLong());
+        MeetingConfirmRequest meetingConfirmRequest = MeetingConfirmRequest.builder()
+                .meetingId(ID)
+                .schedule(SCHEDULE)
+                .place(PLACE)
+                .build();
+        // when & then
+        assertThatThrownBy(() -> chattingRoomService.confirm(ID, meetingConfirmRequest))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage(ApplicationError.CHATTING_ROOM_NOT_FOUND.getMessage());
+    }
 }

--- a/src/test/java/com/cupid/jikting/chatting/service/ChattingRoomServiceTest.java
+++ b/src/test/java/com/cupid/jikting/chatting/service/ChattingRoomServiceTest.java
@@ -7,6 +7,7 @@ import com.cupid.jikting.chatting.repository.ChattingRoomRepository;
 import com.cupid.jikting.common.error.ApplicationError;
 import com.cupid.jikting.common.error.ApplicationException;
 import com.cupid.jikting.common.error.NotFoundException;
+import com.cupid.jikting.common.error.WrongAccessException;
 import com.cupid.jikting.meeting.entity.Meeting;
 import com.cupid.jikting.member.entity.MemberProfile;
 import com.cupid.jikting.member.repository.MemberProfileRepository;
@@ -38,6 +39,7 @@ import static org.mockito.Mockito.verify;
 class ChattingRoomServiceTest {
 
     private static final Long ID = 1L;
+    private static final Long WRONG_ID = 2L;
     private static final String TEAM_NAME = "팀 이름";
     private static final boolean LEADER = true;
     private static final LocalDateTime SCHEDULE = LocalDateTime.of(2023, 9, 10, 18, 30);
@@ -135,5 +137,20 @@ class ChattingRoomServiceTest {
         assertThatThrownBy(() -> chattingRoomService.confirm(ID, meetingConfirmRequest))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage(ApplicationError.CHATTING_ROOM_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    void 채팅방_내_미팅_화정_실패_잘못된_미팅() {
+        // given
+        willReturn(Optional.of(chattingRoom)).given(chattingRoomRepository).findById(anyLong());
+        MeetingConfirmRequest meetingConfirmRequest = MeetingConfirmRequest.builder()
+                .meetingId(WRONG_ID)
+                .schedule(SCHEDULE)
+                .place(PLACE)
+                .build();
+        // when & then
+        assertThatThrownBy(() -> chattingRoomService.confirm(ID, meetingConfirmRequest))
+                .isInstanceOf(WrongAccessException.class)
+                .hasMessage(ApplicationError.WRONG_ACCESS.getMessage());
     }
 }


### PR DESCRIPTION
## Issue

closed #158 
[SP-185](https://soma-cupid.atlassian.net/browse/SP-185?atlOrigin=eyJpIjoiMzEyMjVmMzZmZTM5NDUxNmI3ZGMyOGRlM2Y1YzE0ZWUiLCJwIjoiaiJ9)

## 요구사항

- [x] 채팅 내 미팅 확정 기능 구현

## 변경사항

- `Meeting` 확정 시간 삭제 (lastModifiedAt으로 대체 가능)
- `ChattingRoomService` 채팅 목록 조회 메소드 멤버프로필 조회 메소드 추출

## 리뷰 우선순위

🙂보통

[SP-185]: https://soma-cupid.atlassian.net/browse/SP-185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ