### PR TITLE
[SP-175] 전화번호 인증번호 발급 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ ext {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'com.auth0:java-jwt:4.2.1'

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.apache.httpcomponents:httpclient:4.5.14'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/cupid/jikting/common/config/RedisConfig.java
+++ b/src/main/java/com/cupid/jikting/common/config/RedisConfig.java
@@ -4,7 +4,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.StringRedisSerializer;

--- a/src/main/java/com/cupid/jikting/common/config/RedisConfig.java
+++ b/src/main/java/com/cupid/jikting/common/config/RedisConfig.java
@@ -1,0 +1,34 @@
+package com.cupid.jikting.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+}

--- a/src/main/java/com/cupid/jikting/common/config/RestTemplateConfig.java
+++ b/src/main/java/com/cupid/jikting/common/config/RestTemplateConfig.java
@@ -1,0 +1,17 @@
+package com.cupid.jikting.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        RestTemplate restTemplate = new RestTemplate();
+        restTemplate.setRequestFactory(new HttpComponentsClientHttpRequestFactory());
+        return restTemplate;
+    }
+}

--- a/src/main/java/com/cupid/jikting/common/config/SecurityConfig.java
+++ b/src/main/java/com/cupid/jikting/common/config/SecurityConfig.java
@@ -59,6 +59,7 @@ public class SecurityConfig {
                 .mvcMatchers("/").permitAll()
                 .mvcMatchers(HttpMethod.POST, "/members").permitAll()
                 .mvcMatchers("/members/username/check").permitAll()
+                .mvcMatchers("/members/code").permitAll()
                 .anyRequest().authenticated()
                 .and()
                 .oauth2Login()

--- a/src/main/java/com/cupid/jikting/common/error/ApplicationError.java
+++ b/src/main/java/com/cupid/jikting/common/error/ApplicationError.java
@@ -19,6 +19,7 @@ public enum ApplicationError {
     EXPIRED_TOKEN(HttpStatus.BAD_REQUEST, "C009", "token 유효기간이 만료되었습니다."),
     VERIFICATION_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "C010", "인증번호가 유효하지 않습니다."),
     PERSONALITY_NOT_FOUND(HttpStatus.BAD_REQUEST, "C011", "성격 키워드를 찾을 수 없습니다."),
+    SMS_SEND_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "C012", "SMS 전송 요청에 실패했습니다."),
 
     UNAUTHORIZED_MEMBER(HttpStatus.UNAUTHORIZED, "U001", "인증되지 않은 사용자입니다."),
     FORBIDDEN_MEMBER(HttpStatus.FORBIDDEN, "U002", "권한이 없는 사용자입니다."),

--- a/src/main/java/com/cupid/jikting/common/error/SmsSendFailException.java
+++ b/src/main/java/com/cupid/jikting/common/error/SmsSendFailException.java
@@ -1,0 +1,8 @@
+package com.cupid.jikting.common.error;
+
+public class SmsSendFailException extends RuntimeException {
+
+    public SmsSendFailException(ApplicationError error) {
+        super(error.getMessage());
+    }
+}

--- a/src/main/java/com/cupid/jikting/common/service/RedisConnector.java
+++ b/src/main/java/com/cupid/jikting/common/service/RedisConnector.java
@@ -1,0 +1,20 @@
+package com.cupid.jikting.common.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@RequiredArgsConstructor
+@Component
+public class RedisConnector {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void set(String key, String value, int expireTime) {
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        valueOperations.set(key, value, Duration.ofMinutes(expireTime));
+    }
+}

--- a/src/main/java/com/cupid/jikting/common/util/PasswordGenerator.java
+++ b/src/main/java/com/cupid/jikting/common/util/PasswordGenerator.java
@@ -3,8 +3,8 @@ package com.cupid.jikting.common.util;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
+import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
-import java.util.Random;
 import java.util.stream.IntStream;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -19,11 +19,18 @@ public class PasswordGenerator {
     };
     private static final String DELIMITER = "";
     private static final int PASSWORD_LENGTH = 8;
-    private static final Random RANDOM = new SecureRandom();
 
     public static String generate() {
         return String.join(DELIMITER, IntStream.range(0, PASSWORD_LENGTH)
-                .mapToObj(i -> CHAT_SET[(int) (CHAT_SET.length * RANDOM.nextDouble())])
+                .mapToObj(i -> CHAT_SET[(int) (CHAT_SET.length * getSecureRandom().nextDouble())])
                 .toArray(CharSequence[]::new));
+    }
+
+    private static SecureRandom getSecureRandom() {
+        try {
+            return SecureRandom.getInstanceStrong();
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/main/java/com/cupid/jikting/common/util/PasswordGenerator.java
+++ b/src/main/java/com/cupid/jikting/common/util/PasswordGenerator.java
@@ -6,7 +6,7 @@ import lombok.NoArgsConstructor;
 import java.util.Random;
 import java.util.stream.IntStream;
 
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PasswordGenerator {
 
     private static final char[] CHAT_SET = new char[]{

--- a/src/main/java/com/cupid/jikting/common/util/PasswordGenerator.java
+++ b/src/main/java/com/cupid/jikting/common/util/PasswordGenerator.java
@@ -3,6 +3,7 @@ package com.cupid.jikting.common.util;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
+import java.security.SecureRandom;
 import java.util.Random;
 import java.util.stream.IntStream;
 
@@ -18,7 +19,7 @@ public class PasswordGenerator {
     };
     private static final String DELIMITER = "";
     private static final int PASSWORD_LENGTH = 8;
-    private static final Random RANDOM = new Random();
+    private static final Random RANDOM = new SecureRandom();
 
     public static String generate() {
         return String.join(DELIMITER, IntStream.range(0, PASSWORD_LENGTH)

--- a/src/main/java/com/cupid/jikting/common/util/PasswordGenerator.java
+++ b/src/main/java/com/cupid/jikting/common/util/PasswordGenerator.java
@@ -3,8 +3,7 @@ package com.cupid.jikting.common.util;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
-import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
+import java.util.Random;
 import java.util.stream.IntStream;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -17,20 +16,13 @@ public class PasswordGenerator {
             'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
             'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'
     };
+    private static final Random RANDOM = new Random();
     private static final String DELIMITER = "";
     private static final int PASSWORD_LENGTH = 8;
 
     public static String generate() {
         return String.join(DELIMITER, IntStream.range(0, PASSWORD_LENGTH)
-                .mapToObj(i -> CHAT_SET[(int) (CHAT_SET.length * getSecureRandom().nextDouble())])
+                .mapToObj(i -> CHAT_SET[(int) (CHAT_SET.length * RANDOM.nextDouble())])
                 .toArray(CharSequence[]::new));
-    }
-
-    private static SecureRandom getSecureRandom() {
-        try {
-            return SecureRandom.getInstanceStrong();
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);
-        }
     }
 }

--- a/src/main/java/com/cupid/jikting/common/util/PasswordGenerator.java
+++ b/src/main/java/com/cupid/jikting/common/util/PasswordGenerator.java
@@ -6,8 +6,8 @@ import lombok.NoArgsConstructor;
 import java.util.Random;
 import java.util.stream.IntStream;
 
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class PasswordUtil {
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PasswordGenerator {
 
     private static final char[] CHAT_SET = new char[]{
             '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
@@ -20,7 +20,7 @@ public class PasswordUtil {
     private static final int PASSWORD_LENGTH = 8;
     private static final Random RANDOM = new Random();
 
-    public static String generateRandomPassword() {
+    public static String generate() {
         return String.join(DELIMITER, IntStream.range(0, PASSWORD_LENGTH)
                 .mapToObj(i -> CHAT_SET[(int) (CHAT_SET.length * RANDOM.nextDouble())])
                 .toArray(CharSequence[]::new));

--- a/src/main/java/com/cupid/jikting/common/util/VerificationCodeGenerator.java
+++ b/src/main/java/com/cupid/jikting/common/util/VerificationCodeGenerator.java
@@ -1,0 +1,22 @@
+package com.cupid.jikting.common.util;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.util.Random;
+import java.util.stream.IntStream;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class VerificationCodeGenerator {
+
+    private static final Random RANDOM = new Random();
+    private static final String DELIMITER = "";
+    private static final int VERIFICATION_CODE_RANGE = 9;
+
+    public static String generate(int verificationCodeLength) {
+        return String.join(DELIMITER, IntStream.range(0, verificationCodeLength)
+                .mapToObj(n -> RANDOM.nextInt(VERIFICATION_CODE_RANGE))
+                .map(String::valueOf)
+                .toArray(CharSequence[]::new));
+    }
+}

--- a/src/main/java/com/cupid/jikting/common/util/VerificationCodeGenerator.java
+++ b/src/main/java/com/cupid/jikting/common/util/VerificationCodeGenerator.java
@@ -3,21 +3,28 @@ package com.cupid.jikting.common.util;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
+import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
-import java.util.Random;
 import java.util.stream.IntStream;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class VerificationCodeGenerator {
 
-    private static final Random RANDOM = new SecureRandom();
     private static final String DELIMITER = "";
     private static final int VERIFICATION_CODE_RANGE = 9;
 
     public static String generate(int verificationCodeLength) {
         return String.join(DELIMITER, IntStream.range(0, verificationCodeLength)
-                .mapToObj(n -> RANDOM.nextInt(VERIFICATION_CODE_RANGE))
+                .mapToObj(n -> getSecureRandom().nextInt(VERIFICATION_CODE_RANGE))
                 .map(String::valueOf)
                 .toArray(CharSequence[]::new));
+    }
+
+    private static SecureRandom getSecureRandom() {
+        try {
+            return SecureRandom.getInstanceStrong();
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/main/java/com/cupid/jikting/common/util/VerificationCodeGenerator.java
+++ b/src/main/java/com/cupid/jikting/common/util/VerificationCodeGenerator.java
@@ -3,13 +3,14 @@ package com.cupid.jikting.common.util;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
+import java.security.SecureRandom;
 import java.util.Random;
 import java.util.stream.IntStream;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class VerificationCodeGenerator {
 
-    private static final Random RANDOM = new Random();
+    private static final Random RANDOM = new SecureRandom();
     private static final String DELIMITER = "";
     private static final int VERIFICATION_CODE_RANGE = 9;
 

--- a/src/main/java/com/cupid/jikting/jwt/filter/JwtAuthenticationProcessingFilter.java
+++ b/src/main/java/com/cupid/jikting/jwt/filter/JwtAuthenticationProcessingFilter.java
@@ -3,7 +3,7 @@ package com.cupid.jikting.jwt.filter;
 import com.cupid.jikting.common.error.ApplicationError;
 import com.cupid.jikting.common.error.BadRequestException;
 import com.cupid.jikting.common.error.InvalidJwtException;
-import com.cupid.jikting.common.util.PasswordUtil;
+import com.cupid.jikting.common.util.PasswordGenerator;
 import com.cupid.jikting.jwt.service.JwtService;
 import com.cupid.jikting.member.entity.Member;
 import com.cupid.jikting.member.repository.MemberRepository;
@@ -68,7 +68,7 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
     public void saveAuthentication(Member member) {
         String password = member.getPassword();
         if (password == null && member.getSocialType() != null) {
-            password = PasswordUtil.generateRandomPassword();
+            password = PasswordGenerator.generate();
         }
         if (password == null) {
             throw new BadRequestException(ApplicationError.BAD_MEMBER);

--- a/src/main/java/com/cupid/jikting/like/dto/MemberProfileResponse.java
+++ b/src/main/java/com/cupid/jikting/like/dto/MemberProfileResponse.java
@@ -1,7 +1,10 @@
 package com.cupid.jikting.like.dto;
 
 import com.cupid.jikting.member.entity.MemberProfile;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/cupid/jikting/meeting/entity/InstantMeetingMember.java
+++ b/src/main/java/com/cupid/jikting/meeting/entity/InstantMeetingMember.java
@@ -26,14 +26,14 @@ public class InstantMeetingMember extends BaseEntity {
     @JoinColumn(name = "instant_meeting_id")
     private InstantMeeting instantMeeting;
 
-    public boolean isSameMemberProfileId(Long memberProfileId) {
-        return memberProfile.isSameAs(memberProfileId);
-    }
-
     public static InstantMeetingMember of(InstantMeeting instantMeeting, MemberProfile memberProfile) {
         InstantMeetingMember instantMeetingMember = new InstantMeetingMember(memberProfile, instantMeeting);
         instantMeeting.addMemberProfile(instantMeetingMember);
         memberProfile.addInstantMeeting(instantMeetingMember);
         return instantMeetingMember;
+    }
+
+    public boolean isSameMemberProfileId(Long memberProfileId) {
+        return memberProfile.isSameAs(memberProfileId);
     }
 }

--- a/src/main/java/com/cupid/jikting/member/controller/MemberController.java
+++ b/src/main/java/com/cupid/jikting/member/controller/MemberController.java
@@ -3,12 +3,17 @@ package com.cupid.jikting.member.controller;
 import com.cupid.jikting.jwt.service.JwtService;
 import com.cupid.jikting.member.dto.*;
 import com.cupid.jikting.member.service.MemberService;
+import com.cupid.jikting.member.service.SmsService;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
+import java.io.UnsupportedEncodingException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
 
 @RequiredArgsConstructor
 @RestController
@@ -16,6 +21,7 @@ import javax.validation.Valid;
 public class MemberController {
 
     private final JwtService jwtService;
+    private final SmsService smsService;
     private final MemberService memberService;
 
     @PostMapping
@@ -77,8 +83,8 @@ public class MemberController {
     }
 
     @PostMapping("/code")
-    public ResponseEntity<Void> createVerificationCodeForSignup(@RequestBody SignUpVerificationCodeRequest signUpVerificationCodeRequest) {
-        memberService.createVerificationCodeForSignup(signUpVerificationCodeRequest);
+    public ResponseEntity<Void> createVerificationCodeForSignup(@RequestBody SignUpVerificationCodeRequest signUpVerificationCodeRequest) throws UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException, JsonProcessingException {
+        smsService.createVerificationCodeForSignup(signUpVerificationCodeRequest);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/cupid/jikting/member/dto/SignUpVerificationCodeRequest.java
+++ b/src/main/java/com/cupid/jikting/member/dto/SignUpVerificationCodeRequest.java
@@ -8,5 +8,5 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SignUpVerificationCodeRequest {
 
-    private String phone;
+    private String to;
 }

--- a/src/main/java/com/cupid/jikting/member/dto/SmsRequest.java
+++ b/src/main/java/com/cupid/jikting/member/dto/SmsRequest.java
@@ -1,0 +1,17 @@
+package com.cupid.jikting.member.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SmsRequest {
+
+    private String type;
+    private String from;
+    private String content;
+    private List<SignUpVerificationCodeRequest> messages;
+}

--- a/src/main/java/com/cupid/jikting/member/dto/SmsResponse.java
+++ b/src/main/java/com/cupid/jikting/member/dto/SmsResponse.java
@@ -1,0 +1,17 @@
+package com.cupid.jikting.member.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SmsResponse {
+
+    private String requestId;
+    private LocalDateTime requestTime;
+    private String statusCode;
+    private String statusName;
+}

--- a/src/main/java/com/cupid/jikting/member/oauth2/CustomOAuth2User.java
+++ b/src/main/java/com/cupid/jikting/member/oauth2/CustomOAuth2User.java
@@ -15,7 +15,7 @@ public class CustomOAuth2User extends DefaultOAuth2User {
     private final Role role;
 
     private CustomOAuth2User(Collection<? extends GrantedAuthority> authorities, Map<String, Object> attributes,
-                            String nameAttributeKey, String username, Role role) {
+                             String nameAttributeKey, String username, Role role) {
         super(authorities, attributes, nameAttributeKey);
         this.username = username;
         this.role = role;

--- a/src/main/java/com/cupid/jikting/member/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/cupid/jikting/member/service/CustomOAuth2UserService.java
@@ -58,7 +58,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
     }
 
     private Member getMember(OAuthAttributes attributes, SocialType socialType) {
-       return memberRepository.findBySocialTypeAndSocialId(socialType, attributes.getOauth2UserInfoId())
+        return memberRepository.findBySocialTypeAndSocialId(socialType, attributes.getOauth2UserInfoId())
                 .orElseGet(() -> saveMember(attributes, socialType));
     }
 

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -103,9 +103,6 @@ public class MemberService {
         }
     }
 
-    public void createVerificationCodeForSignup(SignUpVerificationCodeRequest signUpVerificationCodeRequest) {
-    }
-
     public void verifyPhoneForSignup(VerificationRequest verificationRequest) {
     }
 

--- a/src/main/java/com/cupid/jikting/member/service/NCPSmsService.java
+++ b/src/main/java/com/cupid/jikting/member/service/NCPSmsService.java
@@ -16,7 +16,6 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
-import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
@@ -32,7 +31,6 @@ import java.util.List;
 @Service
 public class NCPSmsService implements SmsService {
 
-    private static final RestTemplate REST_TEMPLATE = new RestTemplate();
     private static final int VERIFICATION_CODE_LENGTH = 6;
     private static final int EXPIRE_TIME = 3;
     private static final String TYPE = "SMS";
@@ -44,6 +42,7 @@ public class NCPSmsService implements SmsService {
 
     private final RedisConnector redisConnector;
     private final ObjectMapper objectMapper;
+    private final RestTemplate restTemplate;
 
     @Value("${ncp.accessKey}")
     private String accessKey;
@@ -65,8 +64,7 @@ public class NCPSmsService implements SmsService {
     }
 
     private SmsResponse sendSms(SignUpVerificationCodeRequest signUpVerificationCodeRequest) throws JsonProcessingException, NoSuchAlgorithmException, UnsupportedEncodingException, InvalidKeyException {
-        REST_TEMPLATE.setRequestFactory(new HttpComponentsClientHttpRequestFactory());
-        return REST_TEMPLATE.postForObject(
+        return restTemplate.postForObject(
                 URI.create("https://sens.apigw.ntruss.com/sms/v2/services/" + serviceId + "/messages"),
                 new HttpEntity<>(objectMapper.writeValueAsString(getSmsRequest(signUpVerificationCodeRequest, generateVerificationCode(signUpVerificationCodeRequest))), getHttpHeaders()),
                 SmsResponse.class);

--- a/src/main/java/com/cupid/jikting/member/service/NCPSmsService.java
+++ b/src/main/java/com/cupid/jikting/member/service/NCPSmsService.java
@@ -1,0 +1,106 @@
+package com.cupid.jikting.member.service;
+
+import com.cupid.jikting.common.error.ApplicationError;
+import com.cupid.jikting.common.error.SmsSendFailException;
+import com.cupid.jikting.common.util.VerificationCodeGenerator;
+import com.cupid.jikting.member.dto.SignUpVerificationCodeRequest;
+import com.cupid.jikting.member.dto.SmsRequest;
+import com.cupid.jikting.member.dto.SmsResponse;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.apache.tomcat.util.codec.binary.Base64;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class NCPSmsService implements SmsService {
+
+    private static final RestTemplate REST_TEMPLATE = new RestTemplate();
+    private static final int VERIFICATION_CODE_LENGTH = 6;
+    private static final String TYPE = "SMS";
+    private static final String SMS_SEND_SUCCESS = "202";
+    private static final String CHARSET_NAME = "UTF-8";
+    private static final String SECRET_KEY_ALGORITHM = "HmacSHA256";
+    private static final String BLANK = " ";
+    private static final String NEW_LINE = "\n";
+
+    private final ObjectMapper objectMapper;
+
+    @Value("${ncp.accessKey}")
+    private String accessKey;
+
+    @Value("${ncp.secretKey}")
+    private String secretKey;
+
+    @Value("${ncp.sms.serviceId}")
+    private String serviceId;
+
+    @Value("${ncp.sms.sender}")
+    private String phone;
+
+    @Override
+    public void createVerificationCodeForSignup(SignUpVerificationCodeRequest signUpVerificationCodeRequest) throws JsonProcessingException, UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException {
+        if (!sendSms(signUpVerificationCodeRequest).getStatusCode().equals(SMS_SEND_SUCCESS)) {
+            throw new SmsSendFailException(ApplicationError.SMS_SEND_FAIL);
+        }
+    }
+
+    private SmsResponse sendSms(SignUpVerificationCodeRequest signUpVerificationCodeRequest) throws JsonProcessingException, NoSuchAlgorithmException, UnsupportedEncodingException, InvalidKeyException {
+        REST_TEMPLATE.setRequestFactory(new HttpComponentsClientHttpRequestFactory());
+        return REST_TEMPLATE.postForObject(
+                URI.create("https://sens.apigw.ntruss.com/sms/v2/services/" + serviceId + "/messages"),
+                new HttpEntity<>(objectMapper.writeValueAsString(getSmsRequest(signUpVerificationCodeRequest)), getHttpHeaders()),
+                SmsResponse.class);
+    }
+
+    private SmsRequest getSmsRequest(SignUpVerificationCodeRequest signUpVerificationCodeRequest) {
+        return SmsRequest.builder()
+                .type(TYPE)
+                .from(phone)
+                .content(getVerificationCodeMessage())
+                .messages(List.of(signUpVerificationCodeRequest))
+                .build();
+    }
+
+    private static String getVerificationCodeMessage() {
+        return String.format("[직팅]\n인증번호: %s", VerificationCodeGenerator.generate(VERIFICATION_CODE_LENGTH));
+    }
+
+    private HttpHeaders getHttpHeaders() throws NoSuchAlgorithmException, UnsupportedEncodingException, InvalidKeyException {
+        String time = String.valueOf(System.currentTimeMillis());
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("x-ncp-apigw-timestamp", time);
+        headers.set("x-ncp-iam-access-key", accessKey);
+        headers.set("x-ncp-apigw-signature-v2", getSignature(time));
+        return headers;
+    }
+
+    private String getSignature(String time) throws NoSuchAlgorithmException, UnsupportedEncodingException, InvalidKeyException {
+        Mac mac = Mac.getInstance(SECRET_KEY_ALGORITHM);
+        mac.init(new SecretKeySpec(secretKey.getBytes(CHARSET_NAME), SECRET_KEY_ALGORITHM));
+        return Base64.encodeBase64String(mac.doFinal(getMessage(time).getBytes(CHARSET_NAME)));
+    }
+
+    private String getMessage(String time) {
+        return HttpMethod.POST.name() + BLANK + String.format("/sms/v2/services/%s/messages", serviceId)
+                + NEW_LINE + time
+                + NEW_LINE + accessKey;
+    }
+}

--- a/src/main/java/com/cupid/jikting/member/service/SmsService.java
+++ b/src/main/java/com/cupid/jikting/member/service/SmsService.java
@@ -1,0 +1,13 @@
+package com.cupid.jikting.member.service;
+
+import com.cupid.jikting.member.dto.SignUpVerificationCodeRequest;
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import java.io.UnsupportedEncodingException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+
+public interface SmsService {
+
+    void createVerificationCodeForSignup(SignUpVerificationCodeRequest signUpVerificationCodeRequest) throws JsonProcessingException, UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException;
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,6 +12,9 @@ spring.jpa.show-sql=true
 spring.jpa.hibernate.ddl-auto=none
 spring.jpa.properties.hibernate.fomat_sql=true
 
+spring.redis.host=${REDIS_HOST}
+spring.redis.port=${REDIS_PORT}
+
 ncp.accessKey=${NCP_ACCESS_KEY}
 ncp.secretKey=${NCP_SECRET_KEY}
 ncp.sms.serviceId=${NCP_SMS_SERVICE_ID}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,3 +11,8 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.show-sql=true
 spring.jpa.hibernate.ddl-auto=none
 spring.jpa.properties.hibernate.fomat_sql=true
+
+ncp.accessKey=${NCP_ACCESS_KEY}
+ncp.secretKey=${NCP_SECRET_KEY}
+ncp.sms.serviceId=${NCP_SMS_SERVICE_ID}
+ncp.sms.sender=${NCP_SMS_SERVICE_SENDER}

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -10,6 +10,7 @@ import com.cupid.jikting.jwt.service.JwtService;
 import com.cupid.jikting.member.dto.*;
 import com.cupid.jikting.member.entity.*;
 import com.cupid.jikting.member.service.MemberService;
+import com.cupid.jikting.member.service.SmsService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -101,6 +102,9 @@ public class MemberControllerTest extends ApiDocument {
 
     @MockBean
     private JwtService jwtService;
+
+    @MockBean
+    private SmsService smsService;
 
     @MockBean
     private MemberService memberService;
@@ -209,7 +213,7 @@ public class MemberControllerTest extends ApiDocument {
                 .nickname(NICKNAME)
                 .build();
         signUpVerificationCodeRequest = SignUpVerificationCodeRequest.builder()
-                .phone(PHONE)
+                .to(PHONE)
                 .build();
         usernameSearchVerificationCodeRequest = UsernameSearchVerificationCodeRequest.builder()
                 .username(USERNAME)
@@ -526,7 +530,7 @@ public class MemberControllerTest extends ApiDocument {
     @Test
     void 전화번호_인증번호_발급_성공() throws Exception {
         // given
-        willDoNothing().given(memberService).createVerificationCodeForSignup(any(SignUpVerificationCodeRequest.class));
+        willDoNothing().given(smsService).createVerificationCodeForSignup(any(SignUpVerificationCodeRequest.class));
         // when
         ResultActions resultActions = 전화번호_인증번호_발급_요청();
         // then
@@ -536,7 +540,7 @@ public class MemberControllerTest extends ApiDocument {
     @Test
     void 전화번호_인증번호_발급_실패() throws Exception {
         // given
-        willThrow(wrongFormException).given(memberService).createVerificationCodeForSignup(any(SignUpVerificationCodeRequest.class));
+        willThrow(wrongFormException).given(smsService).createVerificationCodeForSignup(any(SignUpVerificationCodeRequest.class));
         // when
         ResultActions resultActions = 전화번호_인증번호_발급_요청();
         // then


### PR DESCRIPTION
## Issue

closed #161 
[SP-175](https://soma-cupid.atlassian.net/browse/SP-175?atlOrigin=eyJpIjoiZjkzZGMyOTkwN2Y2NGVjNmE0M2NiMTU4MDQzYWY1YWUiLCJwIjoiaiJ9)

## 요구사항

- [x] 전화번호 인증번호 발급 기능 구현

## 변경사항

- `PasswordUtil` -> `PasswordGenerator` 네이밍 수정
- `InstantMeetingMember` 메소드 선언 순서 수정
- `CustomOAuth2User`, `CustomOAuth2UserService` 코드 포매팅

## 리뷰 우선순위

🙂보통

## 코멘트

- 구현 내용

    https://github.com/SWM-Cupid/jikting-backend/issues/161#issuecomment-1663920379

- 인증번호 만료시간은 3분으로 설정했습니다.

[SP-175]: https://soma-cupid.atlassian.net/browse/SP-175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ