### PR TITLE
[SP-275] 이미지 등록 로직 리팩토링

### DIFF
--- a/src/main/java/com/cupid/jikting/chatting/controller/ChattingRoomController.java
+++ b/src/main/java/com/cupid/jikting/chatting/controller/ChattingRoomController.java
@@ -5,7 +5,6 @@ import com.cupid.jikting.chatting.dto.ChattingRoomResponse;
 import com.cupid.jikting.chatting.dto.MeetingConfirmRequest;
 import com.cupid.jikting.chatting.service.ChattingRoomService;
 import com.cupid.jikting.common.support.AuthorizedVariable;
-import com.cupid.jikting.jwt.service.JwtService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -18,7 +17,6 @@ import java.util.List;
 public class ChattingRoomController {
 
     private final ChattingRoomService chattingRoomService;
-    private final JwtService jwtService;
 
     @GetMapping
     public ResponseEntity<List<ChattingRoomResponse>> getAll(@AuthorizedVariable Long memberProfileId) {

--- a/src/main/java/com/cupid/jikting/like/controller/LikeController.java
+++ b/src/main/java/com/cupid/jikting/like/controller/LikeController.java
@@ -1,7 +1,6 @@
 package com.cupid.jikting.like.controller;
 
 import com.cupid.jikting.common.support.AuthorizedVariable;
-import com.cupid.jikting.jwt.service.JwtService;
 import com.cupid.jikting.like.dto.LikeResponse;
 import com.cupid.jikting.like.dto.TeamDetailResponse;
 import com.cupid.jikting.like.service.LikeService;
@@ -17,7 +16,6 @@ import java.util.List;
 public class LikeController {
 
     private final LikeService likeService;
-    private final JwtService jwtService;
 
     @GetMapping("/received")
     public ResponseEntity<List<LikeResponse>> getAllReceivedLike(@AuthorizedVariable Long memberProfileId) {

--- a/src/main/java/com/cupid/jikting/meeting/controller/InstantMeetingController.java
+++ b/src/main/java/com/cupid/jikting/meeting/controller/InstantMeetingController.java
@@ -1,7 +1,6 @@
 package com.cupid.jikting.meeting.controller;
 
 import com.cupid.jikting.common.support.AuthorizedVariable;
-import com.cupid.jikting.jwt.service.JwtService;
 import com.cupid.jikting.meeting.dto.InstantMeetingResponse;
 import com.cupid.jikting.meeting.service.InstantMeetingService;
 import lombok.RequiredArgsConstructor;
@@ -16,7 +15,6 @@ import java.util.List;
 public class InstantMeetingController {
 
     private final InstantMeetingService instantMeetingService;
-    private final JwtService jwtService;
 
     @GetMapping
     public ResponseEntity<List<InstantMeetingResponse>> getAll(@AuthorizedVariable Long memberProfileId) {

--- a/src/main/java/com/cupid/jikting/member/controller/MemberController.java
+++ b/src/main/java/com/cupid/jikting/member/controller/MemberController.java
@@ -1,7 +1,6 @@
 package com.cupid.jikting.member.controller;
 
 import com.cupid.jikting.common.support.AuthorizedVariable;
-import com.cupid.jikting.jwt.service.JwtService;
 import com.cupid.jikting.member.dto.*;
 import com.cupid.jikting.member.service.MemberService;
 import com.cupid.jikting.member.service.SmsService;
@@ -55,12 +54,6 @@ public class MemberController {
     @PatchMapping("/password")
     public ResponseEntity<Void> updatePassword(@AuthorizedVariable Long memberProfileId, @RequestBody PasswordUpdateRequest passwordUpdateRequest) {
         memberService.updatePassword(memberProfileId, passwordUpdateRequest);
-        return ResponseEntity.ok().build();
-    }
-
-    @PostMapping("/image")
-    public ResponseEntity<Void> updateImage(@RequestPart("file") MultipartFile multipartFile) {
-        memberService.updateImage(multipartFile);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/cupid/jikting/member/controller/MemberController.java
+++ b/src/main/java/com/cupid/jikting/member/controller/MemberController.java
@@ -21,7 +21,6 @@ import java.security.NoSuchAlgorithmException;
 @RequestMapping("/members")
 public class MemberController {
 
-    private final JwtService jwtService;
     private final SmsService smsService;
     private final MemberService memberService;
 

--- a/src/main/java/com/cupid/jikting/member/handler/LoginFailureHandler.java
+++ b/src/main/java/com/cupid/jikting/member/handler/LoginFailureHandler.java
@@ -22,6 +22,6 @@ public class LoginFailureHandler extends SimpleUrlAuthenticationFailureHandler {
         response.setCharacterEncoding(CHARACTER_ENCODING);
         response.setContentType(CONTENT_TYPE);
         response.getWriter().write(ApplicationError.NOT_EQUAL_ID_OR_PASSWORD.getMessage());
-        log.info("로그인에 실패했습니다. 메시지 : {}", exception.getMessage());
+        log.info("로그인에 실패했습니다. 메시지 : {}\n{}", exception.getMessage(), exception.getStackTrace());
     }
 }

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -84,10 +84,6 @@ public class MemberService {
         memberProfile.updatePassword(passwordEncoder.encode(passwordUpdateRequest.getNewPassword()));
     }
 
-    public void updateImage(MultipartFile multipartFile) {
-
-    }
-
     public void withdraw(Long memberId, WithdrawRequest withdrawRequest) {
         Member member = getMemberProfileById(memberId).getMember();
         member.validatePassword(passwordEncoder, withdrawRequest.getPassword());

--- a/src/main/java/com/cupid/jikting/recommend/controller/RecommendController.java
+++ b/src/main/java/com/cupid/jikting/recommend/controller/RecommendController.java
@@ -1,7 +1,6 @@
 package com.cupid.jikting.recommend.controller;
 
 import com.cupid.jikting.common.support.AuthorizedVariable;
-import com.cupid.jikting.jwt.service.JwtService;
 import com.cupid.jikting.recommend.dto.RecommendResponse;
 import com.cupid.jikting.recommend.service.RecommendService;
 import lombok.RequiredArgsConstructor;
@@ -16,7 +15,6 @@ import java.util.List;
 public class RecommendController {
 
     private final RecommendService recommendService;
-    private final JwtService jwtService;
 
     @GetMapping
     public ResponseEntity<List<RecommendResponse>> get(@AuthorizedVariable Long memberProfileId) {

--- a/src/main/java/com/cupid/jikting/team/controller/TeamController.java
+++ b/src/main/java/com/cupid/jikting/team/controller/TeamController.java
@@ -1,7 +1,6 @@
 package com.cupid.jikting.team.controller;
 
 import com.cupid.jikting.common.support.AuthorizedVariable;
-import com.cupid.jikting.jwt.service.JwtService;
 import com.cupid.jikting.team.dto.TeamRegisterRequest;
 import com.cupid.jikting.team.dto.TeamRegisterResponse;
 import com.cupid.jikting.team.dto.TeamResponse;
@@ -17,7 +16,6 @@ import org.springframework.web.bind.annotation.*;
 public class TeamController {
 
     private final TeamService teamService;
-    private final JwtService jwtService;
 
     @PostMapping
     public ResponseEntity<TeamRegisterResponse> register(@AuthorizedVariable Long memberProfileId,

--- a/src/test/java/com/cupid/jikting/member/controller/FileUploadControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/FileUploadControllerTest.java
@@ -1,0 +1,144 @@
+package com.cupid.jikting.member.controller;
+
+import com.cupid.jikting.ApiDocument;
+import com.cupid.jikting.TestSecurityConfig;
+import com.cupid.jikting.common.dto.ErrorResponse;
+import com.cupid.jikting.common.error.ApplicationError;
+import com.cupid.jikting.common.error.ApplicationException;
+import com.cupid.jikting.common.error.NotFoundException;
+import com.cupid.jikting.common.error.WrongFormException;
+import com.cupid.jikting.jwt.service.JwtService;
+import com.cupid.jikting.member.service.FileUploadService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.web.multipart.MultipartFile;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.willReturn;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Import(TestSecurityConfig.class)
+@WebMvcTest(FileUploadController.class)
+public class FileUploadControllerTest extends ApiDocument {
+
+    private static final String CONTEXT_PATH = "/v1";
+    private static final String DOMAIN_ROOT_PATH = "/files";
+    private static final String AUTHORIZATION = "Authorization";
+    private static final String BEARER = "Bearer ";
+    private static final Long ID = 1L;
+    private static final String IMAGE_PARAMETER_NAME = "file";
+    private static final String IMAGE_FILENAME = "image.png";
+    private static final String IMAGE_CONTENT_TYPE = "image/png";
+    private static final String IMAGE_FILE = "이미지 파일";
+
+    private String accessToken;
+    private MockMultipartFile image;
+    private ApplicationException memberNotFoundException;
+    private ApplicationException wrongFileExtensionException;
+    private ApplicationException wrongFileSizeException;
+
+    @MockBean
+    private FileUploadService fileUploadService;
+
+    @MockBean
+    private JwtService jwtService;
+
+    @BeforeEach
+    void setUp() {
+        accessToken = jwtService.createAccessToken(ID);
+        image = new MockMultipartFile(IMAGE_PARAMETER_NAME, IMAGE_FILENAME, IMAGE_CONTENT_TYPE, IMAGE_FILE.getBytes());
+        memberNotFoundException = new NotFoundException(ApplicationError.MEMBER_NOT_FOUND);
+        wrongFileExtensionException = new WrongFormException(ApplicationError.INVALID_FILE_EXTENSION);
+        wrongFileSizeException = new WrongFormException(ApplicationError.INVALID_FILE_SIZE);
+    }
+
+    @WithMockUser
+    @Test
+    void 회원_이미지_수정_성공(@Value("${cloud.aws.s3.bucket}") String bucket) throws Exception {
+        // given
+        willReturn("https://" + bucket + ".s3.ap-northeast-2.amazonaws.com/" + IMAGE_FILENAME).given(fileUploadService).save(any(MultipartFile.class));
+        // when
+        ResultActions resultActions = 회원_이미지_수정_요청();
+        // then
+        회원_이미지_수정_요청_성공(resultActions);
+    }
+
+    @WithMockUser
+    @Test
+    void 회원_이미지_수정_회원정보없음_실패() throws Exception {
+        // given
+        willThrow(memberNotFoundException).given(fileUploadService).save(any(MultipartFile.class));
+        // when
+        ResultActions resultActions = 회원_이미지_수정_요청();
+        // then
+        회원_이미지_수정_요청_회원정보없음_실패(resultActions);
+    }
+
+    @WithMockUser
+    @Test
+    void 회원_이미지_수정_파일형식미지원_실패() throws Exception {
+        // given
+        willThrow(wrongFileExtensionException).given(fileUploadService).save(any(MultipartFile.class));
+        // when
+        ResultActions resultActions = 회원_이미지_수정_요청();
+        // then
+        회원_이미지_수정_요청_파일형식미지원_실패(resultActions);
+    }
+
+    @WithMockUser
+    @Test
+    void 회원_이미지_수정_파일크기미지원_실패() throws Exception {
+        // given
+        willThrow(wrongFileSizeException).given(fileUploadService).save(any(MultipartFile.class));
+        // when
+        ResultActions resultActions = 회원_이미지_수정_요청();
+        // then
+        회원_이미지_수정_요청_파일크기미지원_실패(resultActions);
+    }
+
+    private ResultActions 회원_이미지_수정_요청() throws Exception {
+        return mockMvc.perform(multipart(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/upload")
+                .file(image)
+                .header(AUTHORIZATION, BEARER + accessToken)
+                .contextPath(CONTEXT_PATH)
+                .contentType(MediaType.MULTIPART_FORM_DATA));
+    }
+
+    private void 회원_이미지_수정_요청_성공(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isOk()),
+                "update-member-image-success");
+    }
+
+    private void 회원_이미지_수정_요청_회원정보없음_실패(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isBadRequest())
+                        .andExpect(content().json(toJson(ErrorResponse.from(memberNotFoundException)))),
+                "update-member-image-not-found-member-fail");
+    }
+
+    private void 회원_이미지_수정_요청_파일형식미지원_실패(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isBadRequest())
+                        .andExpect(content().json(toJson(ErrorResponse.from(wrongFileExtensionException)))),
+                "update-member-image-invalid-file-extension-fail");
+    }
+
+    private void 회원_이미지_수정_요청_파일크기미지원_실패(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isBadRequest())
+                        .andExpect(content().json(toJson(ErrorResponse.from(wrongFileSizeException)))),
+                "update-member-image-invalid-file-size-fail");
+    }
+}

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -417,50 +417,6 @@ public class MemberControllerTest extends ApiDocument {
 
     @WithMockUser
     @Test
-    void 회원_이미지_수정_성공() throws Exception {
-        // given
-        willDoNothing().given(memberService).updateImage(any(MultipartFile.class));
-        // when
-        ResultActions resultActions = 회원_이미지_수정_요청();
-        // then
-        회원_이미지_수정_요청_성공(resultActions);
-    }
-
-    @WithMockUser
-    @Test
-    void 회원_이미지_수정_회원정보없음_실패() throws Exception {
-        // given
-        willThrow(memberNotFoundException).given(memberService).updateImage(any(MultipartFile.class));
-        // when
-        ResultActions resultActions = 회원_이미지_수정_요청();
-        // then
-        회원_이미지_수정_요청_회원정보없음_실패(resultActions);
-    }
-
-    @WithMockUser
-    @Test
-    void 회원_이미지_수정_파일형식미지원_실패() throws Exception {
-        // given
-        willThrow(wrongFileExtensionException).given(memberService).updateImage(any(MultipartFile.class));
-        // when
-        ResultActions resultActions = 회원_이미지_수정_요청();
-        // then
-        회원_이미지_수정_요청_파일형식미지원_실패(resultActions);
-    }
-
-    @WithMockUser
-    @Test
-    void 회원_이미지_수정_파일크기미지원_실패() throws Exception {
-        // given
-        willThrow(wrongFileSizeException).given(memberService).updateImage(any(MultipartFile.class));
-        // when
-        ResultActions resultActions = 회원_이미지_수정_요청();
-        // then
-        회원_이미지_수정_요청_파일크기미지원_실패(resultActions);
-    }
-
-    @WithMockUser
-    @Test
     void 회원_탈퇴_성공() throws Exception {
         // given
         willDoNothing().given(memberService).withdraw(anyLong(), any(WithdrawRequest.class));
@@ -812,6 +768,7 @@ public class MemberControllerTest extends ApiDocument {
 
     private ResultActions 회원_조회_요청() throws Exception {
         return mockMvc.perform(get(CONTEXT_PATH + DOMAIN_ROOT_PATH)
+                .header(AUTHORIZATION, BEARER + accessToken)
                 .contextPath(CONTEXT_PATH));
     }
 
@@ -831,6 +788,7 @@ public class MemberControllerTest extends ApiDocument {
 
     private ResultActions 회원_프로필_조회_요청() throws Exception {
         return mockMvc.perform(get(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/profile")
+                .header(AUTHORIZATION, BEARER + accessToken)
                 .contextPath(CONTEXT_PATH));
     }
 
@@ -925,42 +883,9 @@ public class MemberControllerTest extends ApiDocument {
                 "update-member-password-wrong-form-fail");
     }
 
-    private ResultActions 회원_이미지_수정_요청() throws Exception {
-        return mockMvc.perform(multipart(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/image")
-                .file(image)
-                .contextPath(CONTEXT_PATH)
-                .contentType(MediaType.MULTIPART_FORM_DATA));
-    }
-
-    private void 회원_이미지_수정_요청_성공(ResultActions resultActions) throws Exception {
-        printAndMakeSnippet(resultActions
-                        .andExpect(status().isOk()),
-                "update-member-image-success");
-    }
-
-    private void 회원_이미지_수정_요청_회원정보없음_실패(ResultActions resultActions) throws Exception {
-        printAndMakeSnippet(resultActions
-                        .andExpect(status().isBadRequest())
-                        .andExpect(content().json(toJson(ErrorResponse.from(memberNotFoundException)))),
-                "update-member-image-not-found-member-fail");
-    }
-
-    private void 회원_이미지_수정_요청_파일형식미지원_실패(ResultActions resultActions) throws Exception {
-        printAndMakeSnippet(resultActions
-                        .andExpect(status().isBadRequest())
-                        .andExpect(content().json(toJson(ErrorResponse.from(wrongFileExtensionException)))),
-                "update-member-image-invalid-file-extension-fail");
-    }
-
-    private void 회원_이미지_수정_요청_파일크기미지원_실패(ResultActions resultActions) throws Exception {
-        printAndMakeSnippet(resultActions
-                        .andExpect(status().isBadRequest())
-                        .andExpect(content().json(toJson(ErrorResponse.from(wrongFileSizeException)))),
-                "update-member-image-invalid-file-size-fail");
-    }
-
     private ResultActions 회원_탈퇴_요청() throws Exception {
         return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/withdraw")
+                .header(AUTHORIZATION, BEARER + accessToken)
                 .contextPath(CONTEXT_PATH)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(toJson(withdrawRequest)));
@@ -1176,6 +1101,7 @@ public class MemberControllerTest extends ApiDocument {
 
     private ResultActions 회사_이메일_인증번호_발급_요청() throws Exception {
         return mockMvc.perform(patch(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/company/code")
+                .header(AUTHORIZATION, BEARER + accessToken)
                 .contextPath(CONTEXT_PATH)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(toJson(companyVerificationCodeRequest)));
@@ -1196,6 +1122,7 @@ public class MemberControllerTest extends ApiDocument {
 
     private ResultActions 회사_이메일_인증_요청() throws Exception {
         return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/company/verification")
+                .header(AUTHORIZATION, BEARER + accessToken)
                 .contextPath(CONTEXT_PATH)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(toJson(verificationRequest)));
@@ -1225,6 +1152,7 @@ public class MemberControllerTest extends ApiDocument {
         return mockMvc.perform(multipart(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/company/card")
                 .file(companyVerificationRequestPart)
                 .file(image)
+                .header(AUTHORIZATION, BEARER + accessToken)
                 .contextPath(CONTEXT_PATH)
                 .contentType(MediaType.MULTIPART_FORM_DATA));
     }


### PR DESCRIPTION
## Issue

closed #184 
[SP-275](https://soma-cupid.atlassian.net/browse/SP-275?atlOrigin=eyJpIjoiOGI1MWY1MDUxMmU3NDE1NDk3YWIzOWFiYjBhZDQ3MDQiLCJwIjoiaiJ9)

## 요구사항

- [x] 이미지 등록 로직 리팩토링

## 변경사항

- Controller에서 JwtService 일괄 삭제
- `MemberControllerTest` 로그인 필요 요청에 header 추가

## 리뷰 우선순위

🙂보통

[SP-275]: https://soma-cupid.atlassian.net/browse/SP-275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ