### PR TITLE
[SP-303] Oauth2 에러 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'
     implementation 'org.apache.httpcomponents:httpclient:4.5.14'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.session:spring-session-data-redis'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/cupid/jikting/common/config/RedisConfig.java
+++ b/src/main/java/com/cupid/jikting/common/config/RedisConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisClusterConfiguration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.StringRedisTemplate;
 
@@ -13,8 +14,14 @@ import java.util.List;
 @Configuration
 public class RedisConfig {
 
-    @Value("${spring.redis.cluster.nodes}")
-    private List<String> clusterNodes;
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+    @Value("${spring.redis.password}")
+    private String password;
 
     @Bean
     public StringRedisTemplate redisTemplate() {
@@ -23,6 +30,10 @@ public class RedisConfig {
 
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
-        return new LettuceConnectionFactory(new RedisClusterConfiguration(clusterNodes));
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+        redisStandaloneConfiguration.setHostName(host);
+        redisStandaloneConfiguration.setPort(port);
+        redisStandaloneConfiguration.setPassword(password);
+        return new LettuceConnectionFactory(redisStandaloneConfiguration);
     }
 }

--- a/src/main/java/com/cupid/jikting/jwt/filter/JwtAuthenticationProcessingFilter.java
+++ b/src/main/java/com/cupid/jikting/jwt/filter/JwtAuthenticationProcessingFilter.java
@@ -32,6 +32,7 @@ import java.util.List;
 @Slf4j
 public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
 
+    private static final String SIGNUP_URL = "/members";
 
     private final JwtService jwtService;
     private final MemberRepository memberRepository;
@@ -39,9 +40,6 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
 
     @Value("${jwt.tokenAuthorizationWhiteList}")
     private List<String> tokenAUthorizationWhiteList;
-
-    @Value("${jwt.signupUri}")
-    private String signUpUri;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)

--- a/src/main/java/com/cupid/jikting/jwt/filter/JwtAuthenticationProcessingFilter.java
+++ b/src/main/java/com/cupid/jikting/jwt/filter/JwtAuthenticationProcessingFilter.java
@@ -59,9 +59,8 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
     }
 
     private boolean isNotRequiredJwtAuthentication(HttpServletRequest request) {
-        return tokenAUthorizationWhiteList.stream()
-                .anyMatch(uri -> request.getRequestURI().contains(uri))
-                || (request.getRequestURI().contains(signUpUri) && request.getMethod().equals(HttpMethod.POST.name()));
+        return tokenAUthorizationWhiteList.stream().anyMatch(uri -> request.getRequestURI().contains(uri))
+                || (request.getRequestURI().contains(SIGNUP_URL) && request.getMethod().equals(HttpMethod.POST.name()));
     }
 
     public void reissueAccessToken(HttpServletResponse response, String refreshToken) {

--- a/src/main/java/com/cupid/jikting/jwt/service/JwtService.java
+++ b/src/main/java/com/cupid/jikting/jwt/service/JwtService.java
@@ -87,12 +87,17 @@ public class JwtService {
     }
 
     public Long extractMemberProfileId(HttpServletRequest request) {
-        return Optional.ofNullable(JWT.require(Algorithm.HMAC512(secretKey))
-                        .build()
-                        .verify(extractAccessToken(request))
-                        .getClaim(MEMBER_PROFILE_ID_CLAIM)
-                        .asLong())
-                .orElseThrow(() -> new JwtException(ApplicationError.UNAUTHORIZED_MEMBER));
+        try {
+            return Optional.ofNullable(JWT.require(Algorithm.HMAC512(secretKey))
+                            .build()
+                            .verify(extractAccessToken(request))
+                            .getClaim(MEMBER_PROFILE_ID_CLAIM)
+                            .asLong())
+                    .orElseThrow(() -> new JwtException(ApplicationError.UNAUTHORIZED_MEMBER));
+        } catch (Exception e) {
+            log.error("유효하지 않은 토큰입니다. {}", e.getMessage());
+            throw new JwtException(ApplicationError.INVALID_TOKEN);
+        }
     }
 
     public Long extractValidMemberProfileId(String accessToken) {

--- a/src/main/java/com/cupid/jikting/jwt/service/JwtService.java
+++ b/src/main/java/com/cupid/jikting/jwt/service/JwtService.java
@@ -95,7 +95,7 @@ public class JwtService {
                             .asLong())
                     .orElseThrow(() -> new JwtException(ApplicationError.UNAUTHORIZED_MEMBER));
         } catch (Exception e) {
-            log.error("유효하지 않은 토큰입니다. {}", e.getMessage());
+            log.info("유효하지 않은 토큰입니다. {}", e.getMessage());
             throw new JwtException(ApplicationError.INVALID_TOKEN);
         }
     }
@@ -122,7 +122,7 @@ public class JwtService {
             JWT.require(Algorithm.HMAC512(secretKey)).build().verify(token);
             return true;
         } catch (Exception e) {
-            log.error("유효하지 않은 토큰입니다. {}", e.getMessage());
+            log.info("유효하지 않은 토큰입니다. {}", e.getMessage());
             throw new JwtException(ApplicationError.INVALID_TOKEN);
         }
     }

--- a/src/main/java/com/cupid/jikting/member/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/cupid/jikting/member/handler/OAuth2LoginSuccessHandler.java
@@ -35,7 +35,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         if (oAuth2User.getRole() == Role.GUEST) {
             String accessToken = jwtService.createAccessToken(getMemberProfileIdByUsername(oAuth2User.getUsername()));
             response.addHeader(jwtService.getAccessHeader(), TOKEN_TYPE + accessToken);
-            response.sendRedirect("/oauth2/sign-up");
+            response.sendRedirect("https://jikting.com/kakao/signup");
             jwtService.sendAccessAndRefreshToken(response, accessToken, null);
         } else {
             loginSuccess(response, oAuth2User);

--- a/src/main/java/com/cupid/jikting/member/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/cupid/jikting/member/handler/OAuth2LoginSuccessHandler.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
     private static final String TOKEN_TYPE = "Bearer ";
+    private static final String LOGIN_REDIRECT_URL = "https://jikting.com/kakao/signup";
 
     private final JwtService jwtService;
     private final MemberRepository memberRepository;
@@ -35,7 +36,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         if (oAuth2User.getRole() == Role.GUEST) {
             String accessToken = jwtService.createAccessToken(getMemberProfileIdByUsername(oAuth2User.getUsername()));
             response.addHeader(jwtService.getAccessHeader(), TOKEN_TYPE + accessToken);
-            response.sendRedirect("https://jikting.com/kakao/signup");
+            response.sendRedirect(LOGIN_REDIRECT_URL);
             jwtService.sendAccessAndRefreshToken(response, accessToken, null);
         } else {
             loginSuccess(response, oAuth2User);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,6 +24,8 @@ jwt.accessToken.expiration=${JWT_ACCESS_TOKEN_EXPIRATION}
 jwt.accessToken.header=Authorization
 jwt.refreshToken.expiration=${JWT_REFRESH_TOKEN_EXPIRATION}
 jwt.refreshToken.header=Authorization-refresh
+jwt.tokenAuthorizationWhiteList=${TOKEN_AUTHORIZATION_WHITE_LIST}
+jwt.signupUri=${SIGNUP_URI}
 
 cloud.aws.credentials.accessKey=${AWS_ACCESS_KEY}
 cloud.aws.credentials.secretKey=${AWS_SECRET_KEY}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -25,7 +25,6 @@ jwt.accessToken.header=Authorization
 jwt.refreshToken.expiration=${JWT_REFRESH_TOKEN_EXPIRATION}
 jwt.refreshToken.header=Authorization-refresh
 jwt.tokenAuthorizationWhiteList=${TOKEN_AUTHORIZATION_WHITE_LIST}
-jwt.signupUri=${SIGNUP_URI}
 
 cloud.aws.credentials.accessKey=${AWS_ACCESS_KEY}
 cloud.aws.credentials.secretKey=${AWS_SECRET_KEY}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,6 +16,7 @@ spring.jpa.properties.hibernate.fomat_sql=true
 
 spring.redis.host=${REDIS_HOST}
 spring.redis.port=${REDIS_PORT}
+spring.redis.password=${REDIS_PASSWORD}
 spring.redis.cluster.nodes=${REDIS_CLUSTER_NODES}
 
 jwt.secretKey=${JWT_SECRET_KEY}
@@ -38,3 +39,5 @@ ncp.accessKey=${NCP_ACCESS_KEY}
 ncp.secretKey=${NCP_SECRET_KEY}
 ncp.sms.serviceId=${NCP_SMS_SERVICE_ID}
 ncp.sms.sender=${NCP_SMS_SERVICE_SENDER}
+
+spring.session.store-type=redis


### PR DESCRIPTION
## Issue

closed #190 
[SP-303](https://soma-cupid.atlassian.net/browse/SP-303?atlOrigin=eyJpIjoiNTIyMWJiOWRjOTdlNDM0ZjgwNDUyOTljMzU2NWJiZmUiLCJwIjoiaiJ9)

## 요구사항

- [x] Oauth2 에러 해결

## 변경사항

- session 저장소 redis로 변경
- redis test용으로 변경
- `JwtAuthentcationProcessFilter` 무시 uri들 추가
- Oauth2 로그인시 redirect uri 설정

## 리뷰 우선순위

🙂보통

## 코멘트

- Oauth2 로그인시 클라이언트에서 랜덤으로 생성하는 state가 session에 저장되고 oauth2 인증과정에서 session에서 state를 가져와 비교하는 과정이 존재하는데 ecs와 alb를 통해 배포를 하여 session이 공유되지 않는 이슈로 oauth2 로그인이 정상 작동하지 않았던 것 같습니다.
- 해당 이슈를 해결하기 위해 session storage를 redis로 변경하였습니다.
- 추후에 정리된 링크를 추가하겠습니다.

[SP-303]: https://soma-cupid.atlassian.net/browse/SP-303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ