### PR TITLE
[SP-339] 회원 프로필 이미지 및 정보 수정 통합

### DIFF
--- a/src/main/java/com/cupid/jikting/common/config/RedisConfig.java
+++ b/src/main/java/com/cupid/jikting/common/config/RedisConfig.java
@@ -4,7 +4,6 @@ import com.cupid.jikting.chatting.service.RedisSubscriber;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.connection.RedisClusterConfiguration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
@@ -14,8 +13,6 @@ import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
-
-import java.util.List;
 
 @Configuration
 public class RedisConfig {

--- a/src/main/java/com/cupid/jikting/common/entity/BaseEntity.java
+++ b/src/main/java/com/cupid/jikting/common/entity/BaseEntity.java
@@ -5,7 +5,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
-import org.hibernate.annotations.Where;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedBy;
@@ -19,7 +18,6 @@ import java.time.LocalDateTime;
 @SuperBuilder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Where(clause = "isDeleted = false")
 @EntityListeners(AuditingEntityListener.class)
 @MappedSuperclass
 public abstract class BaseEntity {

--- a/src/main/java/com/cupid/jikting/common/entity/Hobby.java
+++ b/src/main/java/com/cupid/jikting/common/entity/Hobby.java
@@ -4,6 +4,7 @@ import com.cupid.jikting.member.entity.MemberHobby;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import javax.persistence.AttributeOverride;
 import javax.persistence.Column;
@@ -17,6 +18,7 @@ import java.util.List;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE hobby SET is_deleted = true WHERE hobby_id = ?")
+@Where(clause = "is_deleted = false")
 @AttributeOverride(name = "id", column = @Column(name = "hobby_id"))
 @Entity
 public class Hobby extends BaseEntity {

--- a/src/main/java/com/cupid/jikting/common/entity/Personality.java
+++ b/src/main/java/com/cupid/jikting/common/entity/Personality.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import javax.persistence.AttributeOverride;
 import javax.persistence.Column;
@@ -16,6 +17,7 @@ import javax.persistence.Entity;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE personality SET is_deleted = true WHERE personality_id = ?")
+@Where(clause = "is_deleted = false")
 @AttributeOverride(name = "id", column = @Column(name = "personality_id"))
 @Entity
 public class Personality extends BaseEntity {

--- a/src/main/java/com/cupid/jikting/common/error/ApplicationError.java
+++ b/src/main/java/com/cupid/jikting/common/error/ApplicationError.java
@@ -56,6 +56,9 @@ public enum ApplicationError {
 
     FILE_NOT_EXIST(HttpStatus.BAD_REQUEST, "F001", "파일이 존재하지 않습니다."),
 
+    AWS_S3_SAVE_ERROR(HttpStatus.BAD_REQUEST, "S001", "S3 파일 업로드를 실패했습니다."),
+    AWS_S3_DELETE_ERROR(HttpStatus.BAD_REQUEST, "S002", "S3 파일 삭제를 실패했습니다."),
+
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S001", "서버 내부 에러가 발생했습니다.");
 
     private final HttpStatus status;

--- a/src/main/java/com/cupid/jikting/common/error/ApplicationError.java
+++ b/src/main/java/com/cupid/jikting/common/error/ApplicationError.java
@@ -56,8 +56,8 @@ public enum ApplicationError {
 
     FILE_NOT_EXIST(HttpStatus.BAD_REQUEST, "F001", "파일이 존재하지 않습니다."),
 
-    AWS_S3_SAVE_ERROR(HttpStatus.BAD_REQUEST, "S001", "S3 파일 업로드를 실패했습니다."),
-    AWS_S3_DELETE_ERROR(HttpStatus.BAD_REQUEST, "S002", "S3 파일 삭제를 실패했습니다."),
+    AWS_S3_SAVE_ERROR(HttpStatus.BAD_REQUEST, "A001", "S3 파일 업로드를 실패했습니다."),
+    AWS_S3_DELETE_ERROR(HttpStatus.BAD_REQUEST, "A002", "S3 파일 삭제를 실패했습니다."),
 
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S001", "서버 내부 에러가 발생했습니다.");
 

--- a/src/main/java/com/cupid/jikting/jwt/filter/JwtAuthenticationProcessingFilter.java
+++ b/src/main/java/com/cupid/jikting/jwt/filter/JwtAuthenticationProcessingFilter.java
@@ -60,7 +60,7 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
 
     private boolean isNotRequiredJwtAuthentication(HttpServletRequest request) {
         return tokenAUthorizationWhiteList.stream().anyMatch(uri -> request.getRequestURI().contains(uri))
-                || (request.getRequestURI().contains(SIGNUP_URL) && request.getMethod().equals(HttpMethod.POST.name()));
+                || (request.getRequestURI().equals(SIGNUP_URL) && request.getMethod().equals(HttpMethod.POST.name()));
     }
 
     public void reissueAccessToken(HttpServletResponse response, String refreshToken) {

--- a/src/main/java/com/cupid/jikting/jwt/service/JwtService.java
+++ b/src/main/java/com/cupid/jikting/jwt/service/JwtService.java
@@ -4,7 +4,6 @@ import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.cupid.jikting.common.error.ApplicationError;
 import com.cupid.jikting.common.error.JwtException;
-import com.cupid.jikting.common.error.NotFoundException;
 import com.cupid.jikting.common.service.RedisConnector;
 import com.cupid.jikting.member.repository.MemberRepository;
 import lombok.Getter;

--- a/src/main/java/com/cupid/jikting/meeting/entity/InstantMeeting.java
+++ b/src/main/java/com/cupid/jikting/meeting/entity/InstantMeeting.java
@@ -4,6 +4,7 @@ import com.cupid.jikting.common.entity.BaseEntity;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import javax.persistence.AttributeOverride;
 import javax.persistence.Column;
@@ -18,6 +19,7 @@ import java.util.List;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE instant_meeting SET is_deleted = true WHERE instant_meeting_id = ?")
+@Where(clause = "is_deleted = false")
 @AttributeOverride(name = "id", column = @Column(name = "instant_meeting_id"))
 @Entity
 public class InstantMeeting extends BaseEntity {

--- a/src/main/java/com/cupid/jikting/meeting/entity/InstantMeetingMember.java
+++ b/src/main/java/com/cupid/jikting/meeting/entity/InstantMeetingMember.java
@@ -7,6 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
 
@@ -14,6 +15,7 @@ import javax.persistence.*;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE instant_meeting_member SET is_deleted = true WHERE instant_meeting_member_id = ?")
+@Where(clause = "is_deleted = false")
 @AttributeOverride(name = "id", column = @Column(name = "instant_meeting_member_id"))
 @Entity
 public class InstantMeetingMember extends BaseEntity {

--- a/src/main/java/com/cupid/jikting/meeting/entity/Meeting.java
+++ b/src/main/java/com/cupid/jikting/meeting/entity/Meeting.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -19,6 +20,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE meeting SET is_deleted = true WHERE meeting_id = ?")
+@Where(clause = "is_deleted = false")
 @AttributeOverride(name = "id", column = @Column(name = "meeting_id"))
 @Entity
 public class Meeting extends BaseEntity {

--- a/src/main/java/com/cupid/jikting/member/controller/MemberController.java
+++ b/src/main/java/com/cupid/jikting/member/controller/MemberController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
@@ -45,9 +46,12 @@ public class MemberController {
         return ResponseEntity.ok().build();
     }
 
-    @PatchMapping("/profile")
-    public ResponseEntity<Void> updateProfile(@AuthorizedVariable Long memberProfileId, @RequestBody MemberProfileUpdateRequest memberProfileUpdateRequest) {
-        memberService.updateProfile(memberProfileId, memberProfileUpdateRequest);
+    @PostMapping("/profile")
+    public ResponseEntity<Void> updateProfile(@AuthorizedVariable Long memberProfileId,
+                                              @RequestPart MultipartFile file,
+                                              @RequestPart MemberProfileUpdateRequest memberProfileUpdateRequest)
+            throws IOException {
+        memberService.updateProfile(memberProfileId, file, memberProfileUpdateRequest);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/cupid/jikting/member/controller/MemberController.java
+++ b/src/main/java/com/cupid/jikting/member/controller/MemberController.java
@@ -49,8 +49,7 @@ public class MemberController {
     @PostMapping("/profile")
     public ResponseEntity<Void> updateProfile(@AuthorizedVariable Long memberProfileId,
                                               @RequestPart MultipartFile file,
-                                              @RequestPart MemberProfileUpdateRequest memberProfileUpdateRequest)
-            throws IOException {
+                                              @RequestPart MemberProfileUpdateRequest memberProfileUpdateRequest) throws IOException {
         memberService.updateProfile(memberProfileId, file, memberProfileUpdateRequest);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/cupid/jikting/member/dto/ImageRequest.java
+++ b/src/main/java/com/cupid/jikting/member/dto/ImageRequest.java
@@ -8,7 +8,6 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ImageRequest {
 
-    private Long profileImageId;
     private String url;
     private String sequence;
 }

--- a/src/main/java/com/cupid/jikting/member/dto/MemberProfileUpdateRequest.java
+++ b/src/main/java/com/cupid/jikting/member/dto/MemberProfileUpdateRequest.java
@@ -22,5 +22,4 @@ public class MemberProfileUpdateRequest {
     private String description;
     private List<String> personalities;
     private List<String> hobbies;
-    private List<ImageRequest> images;
 }

--- a/src/main/java/com/cupid/jikting/member/entity/Company.java
+++ b/src/main/java/com/cupid/jikting/member/entity/Company.java
@@ -4,6 +4,7 @@ import com.cupid.jikting.common.entity.BaseEntity;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import javax.persistence.AttributeOverride;
 import javax.persistence.Column;
@@ -17,6 +18,7 @@ import java.util.List;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE company SET is_deleted = true WHERE company_id = ?")
+@Where(clause = "is_deleted = false")
 @AttributeOverride(name = "id", column = @Column(name = "company_id"))
 @Entity
 public class Company extends BaseEntity {

--- a/src/main/java/com/cupid/jikting/member/entity/Member.java
+++ b/src/main/java/com/cupid/jikting/member/entity/Member.java
@@ -57,7 +57,7 @@ public class Member extends BaseEntity {
                 .nickname(nickname)
                 .member(this)
                 .build();
-        memberProfile.addDefaultProfileImages();
+        memberProfile.createDefaultProfileImages();
     }
 
     public void validatePassword(PasswordEncoder passwordEncoder, String password) {

--- a/src/main/java/com/cupid/jikting/member/entity/Member.java
+++ b/src/main/java/com/cupid/jikting/member/entity/Member.java
@@ -57,6 +57,7 @@ public class Member extends BaseEntity {
                 .nickname(nickname)
                 .member(this)
                 .build();
+        memberProfile.addDefaultProfileImages();
     }
 
     public void validatePassword(PasswordEncoder passwordEncoder, String password) {

--- a/src/main/java/com/cupid/jikting/member/entity/MemberCertification.java
+++ b/src/main/java/com/cupid/jikting/member/entity/MemberCertification.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
 
@@ -15,6 +16,7 @@ import javax.persistence.*;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE member_certification SET is_deleted = true WHERE member_certification_id = ?")
+@Where(clause = "is_deleted = false")
 @AttributeOverride(name = "id", column = @Column(name = "member_certification_id"))
 @Entity
 public class MemberCertification extends BaseEntity {

--- a/src/main/java/com/cupid/jikting/member/entity/MemberCompany.java
+++ b/src/main/java/com/cupid/jikting/member/entity/MemberCompany.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
 
@@ -15,6 +16,7 @@ import javax.persistence.*;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE member_company SET is_deleted = true WHERE member_company_id = ?")
+@Where(clause = "is_deleted = false")
 @AttributeOverride(name = "id", column = @Column(name = "member_company_id"))
 @Entity
 public class MemberCompany extends BaseEntity {

--- a/src/main/java/com/cupid/jikting/member/entity/MemberHobbies.java
+++ b/src/main/java/com/cupid/jikting/member/entity/MemberHobbies.java
@@ -3,6 +3,7 @@ package com.cupid.jikting.member.entity;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Embeddable;
 import javax.persistence.OneToMany;
 import java.util.ArrayList;
@@ -13,7 +14,7 @@ import java.util.stream.Collectors;
 @Embeddable
 public class MemberHobbies {
 
-    @OneToMany(mappedBy = "memberProfile")
+    @OneToMany(mappedBy = "memberProfile", cascade = {CascadeType.PERSIST, CascadeType.MERGE}, orphanRemoval = true)
     private List<MemberHobby> memberHobbies = new ArrayList<>();
 
     public void update(List<MemberHobby> memberHobbies) {

--- a/src/main/java/com/cupid/jikting/member/entity/MemberHobby.java
+++ b/src/main/java/com/cupid/jikting/member/entity/MemberHobby.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
 
@@ -16,6 +17,7 @@ import javax.persistence.*;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE member_hobby SET is_deleted = true WHERE member_hobby_id = ?")
+@Where(clause = "is_deleted = false")
 @AttributeOverride(name = "id", column = @Column(name = "member_hobby_id"))
 @Entity
 public class MemberHobby extends BaseEntity {

--- a/src/main/java/com/cupid/jikting/member/entity/MemberPersonalities.java
+++ b/src/main/java/com/cupid/jikting/member/entity/MemberPersonalities.java
@@ -14,7 +14,7 @@ import java.util.stream.Collectors;
 @Embeddable
 public class MemberPersonalities {
 
-    @OneToMany(mappedBy = "memberProfile", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
+    @OneToMany(mappedBy = "memberProfile", cascade = {CascadeType.PERSIST, CascadeType.MERGE}, orphanRemoval = true)
     private final List<MemberPersonality> memberPersonalities = new ArrayList<>();
 
     public void update(List<MemberPersonality> memberPersonalities) {

--- a/src/main/java/com/cupid/jikting/member/entity/MemberPersonality.java
+++ b/src/main/java/com/cupid/jikting/member/entity/MemberPersonality.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
 
@@ -16,6 +17,7 @@ import javax.persistence.*;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE member_personality SET is_deleted = true WHERE member_personality_id = ?")
+@Where(clause = "is_deleted = false")
 @AttributeOverride(name = "id", column = @Column(name = "member_personality_id"))
 @Entity
 public class MemberPersonality extends BaseEntity {

--- a/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
+++ b/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
@@ -6,6 +6,7 @@ import com.cupid.jikting.common.error.ApplicationError;
 import com.cupid.jikting.common.error.BadRequestException;
 import com.cupid.jikting.common.error.WrongAccessException;
 import com.cupid.jikting.meeting.entity.InstantMeetingMember;
+import com.cupid.jikting.member.dto.ImageRequest;
 import com.cupid.jikting.recommend.entity.Recommend;
 import com.cupid.jikting.team.entity.Team;
 import com.cupid.jikting.team.entity.TeamMember;
@@ -129,7 +130,7 @@ public class MemberProfile extends BaseEntity {
 
     public void updateProfile(LocalDate birth, int height, Mbti mbti, String address, Gender gender, String college,
                               SmokeStatus smokeStatus, DrinkStatus drinkStatus, String description,
-                              List<MemberPersonality> memberPersonalities, List<MemberHobby> memberHobbies, List<ProfileImage> profileImages) {
+                              List<MemberPersonality> memberPersonalities, List<MemberHobby> memberHobbies) {
         this.birth = birth;
         this.height = height;
         this.mbti = mbti;

--- a/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
+++ b/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
@@ -141,7 +141,10 @@ public class MemberProfile extends BaseEntity {
         this.description = description;
         this.memberPersonalities.update(memberPersonalities);
         this.memberHobbies.update(memberHobbies);
-        this.profileImages.update(profileImages);
+    }
+
+    public void updateProfileImage(List<ImageRequest> imageRequests) {
+        this.profileImages.update(imageRequests);
     }
 
     public void addMemberChattingRoom(MemberChattingRoom memberChattingRoom) {
@@ -154,6 +157,10 @@ public class MemberProfile extends BaseEntity {
 
     public void addInstantMeeting(InstantMeetingMember instantMeetingMember) {
         instantMeetingMembers.add(instantMeetingMember);
+    }
+
+    public void addDefaultProfileImages() {
+        profileImages.setDefaultImages(this);
     }
 
     public Long getTeamId() {

--- a/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
+++ b/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
@@ -124,7 +124,7 @@ public class MemberProfile extends BaseEntity {
         return profileImages.getMainImageUrl();
     }
 
-    public void addDefaultProfileImages() {
+    public void createDefaultProfileImages() {
         profileImages.createDefaultImages(this);
     }
 

--- a/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
+++ b/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
@@ -124,6 +124,10 @@ public class MemberProfile extends BaseEntity {
         return profileImages.getMainImageUrl();
     }
 
+    public void addDefaultProfileImages() {
+        profileImages.createDefaultImages(this);
+    }
+
     public void update(String nickname) {
         this.nickname = nickname;
     }
@@ -158,10 +162,6 @@ public class MemberProfile extends BaseEntity {
 
     public void addInstantMeeting(InstantMeetingMember instantMeetingMember) {
         instantMeetingMembers.add(instantMeetingMember);
-    }
-
-    public void addDefaultProfileImages() {
-        profileImages.setDefaultImages(this);
     }
 
     public Long getTeamId() {

--- a/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
+++ b/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
@@ -13,6 +13,7 @@ import com.cupid.jikting.team.entity.TeamMember;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import javax.persistence.*;
@@ -25,6 +26,7 @@ import java.util.List;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE member_profile SET is_deleted = true WHERE member_profile_id = ?")
+@Where(clause = "is_deleted = false")
 @AttributeOverride(name = "id", column = @Column(name = "member_profile_id"))
 @Entity
 public class MemberProfile extends BaseEntity {

--- a/src/main/java/com/cupid/jikting/member/entity/ProfileImage.java
+++ b/src/main/java/com/cupid/jikting/member/entity/ProfileImage.java
@@ -36,9 +36,8 @@ public class ProfileImage extends BaseEntity {
         return sequence.equals(Sequence.MAIN);
     }
 
-    public void update(String url, Sequence sequence) {
+    public void update(String url) {
         this.url = url;
-        this.sequence = sequence;
     }
 
     public boolean isSameSequence(String sequence) {

--- a/src/main/java/com/cupid/jikting/member/entity/ProfileImage.java
+++ b/src/main/java/com/cupid/jikting/member/entity/ProfileImage.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
 
@@ -15,6 +16,7 @@ import javax.persistence.*;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE profile_image SET is_deleted = true WHERE profile_image_id = ?")
+@Where(clause = "is_deleted = false")
 @AttributeOverride(name = "id", column = @Column(name = "profile_image_id"))
 @Entity
 public class ProfileImage extends BaseEntity {

--- a/src/main/java/com/cupid/jikting/member/entity/ProfileImage.java
+++ b/src/main/java/com/cupid/jikting/member/entity/ProfileImage.java
@@ -41,7 +41,7 @@ public class ProfileImage extends BaseEntity {
         this.sequence = sequence;
     }
 
-    public boolean isSameAs(Long id) {
-        return this.id.equals(id);
+    public boolean isSameSequence(String sequence) {
+        return this.sequence.name().equals(sequence);
     }
 }

--- a/src/main/java/com/cupid/jikting/member/entity/ProfileImages.java
+++ b/src/main/java/com/cupid/jikting/member/entity/ProfileImages.java
@@ -19,14 +19,16 @@ import java.util.stream.Stream;
 @Embeddable
 public class ProfileImages {
 
+    private static final String DEFAULT_IMAGE_URL = "https://cupid-images.s3.ap-northeast-2.amazonaws.com/default.png";
+
     @OneToMany(mappedBy = "memberProfile", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
     private List<ProfileImage> profileImages = new ArrayList<>();
 
-    public void setDefaultImages(MemberProfile memberProfile) {
+    public void createDefaultImages(MemberProfile memberProfile) {
         profileImages = Stream.of(Sequence.MAIN, Sequence.FIRST, Sequence.SECOND)
                 .map(sequence -> ProfileImage.builder()
                         .memberProfile(memberProfile)
-                        .url("https://cupid-images.s3.ap-northeast-2.amazonaws.com/default.png")
+                        .url(DEFAULT_IMAGE_URL)
                         .sequence(sequence)
                         .build())
                 .collect(Collectors.toList());
@@ -35,7 +37,7 @@ public class ProfileImages {
     public void update(List<ImageRequest> imageRequests) {
         imageRequests.forEach(updateProfileImage -> {
             ProfileImage profileImage = findBySequence(updateProfileImage.getSequence());
-            profileImage.update(updateProfileImage.getUrl(), Sequence.valueOf(updateProfileImage.getSequence()));
+            profileImage.update(updateProfileImage.getUrl());
         });
     }
 

--- a/src/main/java/com/cupid/jikting/member/entity/ProfileImages.java
+++ b/src/main/java/com/cupid/jikting/member/entity/ProfileImages.java
@@ -2,6 +2,7 @@ package com.cupid.jikting.member.entity;
 
 import com.cupid.jikting.common.error.ApplicationError;
 import com.cupid.jikting.common.error.NotFoundException;
+import com.cupid.jikting.member.dto.ImageRequest;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -11,6 +12,8 @@ import javax.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Embeddable

--- a/src/main/java/com/cupid/jikting/member/handler/OAuth2LoginFailureHandler.java
+++ b/src/main/java/com/cupid/jikting/member/handler/OAuth2LoginFailureHandler.java
@@ -19,6 +19,6 @@ public class OAuth2LoginFailureHandler implements AuthenticationFailureHandler {
                                         AuthenticationException exception) throws IOException {
         response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
         response.getWriter().write("소셜 로그인 실패! 서버 로그를 확인해주세요.");
-        log.info("소셜 로그인에 실패했습니다. 에러 메시지 : {} {}", exception.getMessage(),exception.getStackTrace());
+        log.info("소셜 로그인에 실패했습니다. 에러 메시지 : {} {}", exception.getMessage(), exception.getStackTrace());
     }
 }

--- a/src/main/java/com/cupid/jikting/member/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/cupid/jikting/member/handler/OAuth2LoginSuccessHandler.java
@@ -23,7 +23,8 @@ import java.io.IOException;
 public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
     private static final String TOKEN_TYPE = "Bearer ";
-    private static final String LOGIN_REDIRECT_URL = "https://jikting.com/kakao/signup";
+    private static final String OAUTH_SIGNUP_REDIRECT_URL = "https://jikting.com/signup/kakao";
+    private static final String LOGIN_REDIRECT_URL = "https://jikting.com/main";
 
     private final JwtService jwtService;
     private final MemberRepository memberRepository;
@@ -36,20 +37,21 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         if (oAuth2User.getRole() == Role.GUEST) {
             String accessToken = jwtService.createAccessToken(getMemberProfileIdByUsername(oAuth2User.getUsername()));
             response.addHeader(jwtService.getAccessHeader(), TOKEN_TYPE + accessToken);
-            response.sendRedirect(LOGIN_REDIRECT_URL);
+            response.sendRedirect(OAUTH_SIGNUP_REDIRECT_URL);
             jwtService.sendAccessAndRefreshToken(response, accessToken, null);
         } else {
             loginSuccess(response, oAuth2User);
         }
     }
 
-    private void loginSuccess(HttpServletResponse response, CustomOAuth2User oAuth2User) {
+    private void loginSuccess(HttpServletResponse response, CustomOAuth2User oAuth2User) throws IOException {
         String accessToken = jwtService.createAccessToken(getMemberProfileIdByUsername(oAuth2User.getUsername()));
         String refreshToken = jwtService.createRefreshToken();
         response.addHeader(jwtService.getAccessHeader(), "Bearer " + accessToken);
         response.addHeader(jwtService.getRefreshHeader(), "Bearer " + refreshToken);
         jwtService.sendAccessAndRefreshToken(response, accessToken, refreshToken);
         jwtService.updateRefreshToken(oAuth2User.getUsername(), refreshToken);
+        response.sendRedirect(LOGIN_REDIRECT_URL);
     }
 
     private Long getMemberProfileIdByUsername(String username) {

--- a/src/main/java/com/cupid/jikting/member/service/FileUploadService.java
+++ b/src/main/java/com/cupid/jikting/member/service/FileUploadService.java
@@ -33,13 +33,19 @@ public class FileUploadService {
         return "https://" + bucket + ".s3.ap-northeast-2.amazonaws.com/" + fileName;
     }
 
-    public void delete(String url) {
+    private void delete(String url) {
         String key = extractKeyFromImageUrl(url);
         try {
             amazonS3Client.deleteObject(bucket, key);
         } catch (AmazonServiceException e) {
             throw new FileUploadException(ApplicationError.AWS_S3_DELETE_ERROR);
         }
+    }
+
+    public String update(MultipartFile file, String url) throws IOException {
+        String savedUrl = save(file);
+        delete(url);
+        return savedUrl;
     }
 
     private void validateExist(MultipartFile file) {

--- a/src/main/java/com/cupid/jikting/member/service/FileUploadService.java
+++ b/src/main/java/com/cupid/jikting/member/service/FileUploadService.java
@@ -1,5 +1,6 @@
 package com.cupid.jikting.member.service;
 
+import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.cupid.jikting.common.error.ApplicationError;
@@ -8,6 +9,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
 
@@ -30,9 +33,23 @@ public class FileUploadService {
         return "https://" + bucket + ".s3.ap-northeast-2.amazonaws.com/" + fileName;
     }
 
+    public void delete(String url) {
+        String key = extractKeyFromImageUrl(url);
+        try {
+            amazonS3Client.deleteObject(bucket, key);
+        } catch (AmazonServiceException e) {
+            throw new FileUploadException(ApplicationError.AWS_S3_DELETE_ERROR);
+        }
+    }
+
     private void validateExist(MultipartFile file) {
         if (file.isEmpty()) {
             throw new FileUploadException(ApplicationError.FILE_NOT_EXIST);
         }
+    }
+
+    private String extractKeyFromImageUrl(String imageUrl) {
+        UriComponents components = UriComponentsBuilder.fromUriString(imageUrl).build();
+        return components.getPathSegments().get(components.getPathSegments().size() - 1);
     }
 }

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -2,10 +2,7 @@ package com.cupid.jikting.member.service;
 
 import com.cupid.jikting.common.entity.Hobby;
 import com.cupid.jikting.common.entity.Personality;
-import com.cupid.jikting.common.error.ApplicationError;
-import com.cupid.jikting.common.error.BadRequestException;
-import com.cupid.jikting.common.error.DuplicateException;
-import com.cupid.jikting.common.error.NotFoundException;
+import com.cupid.jikting.common.error.*;
 import com.cupid.jikting.common.repository.PersonalityRepository;
 import com.cupid.jikting.common.service.RedisConnector;
 import com.cupid.jikting.member.dto.*;
@@ -19,6 +16,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.transaction.Transactional;
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -27,6 +26,7 @@ import java.util.stream.Collectors;
 @Service
 public class MemberService {
 
+    private final FileUploadService fileUploadService;
     private final PasswordEncoder passwordEncoder;
     private final MemberRepository memberRepository;
     private final MemberProfileRepository memberProfileRepository;
@@ -61,7 +61,8 @@ public class MemberService {
         memberProfileRepository.save(memberProfile);
     }
 
-    public void updateProfile(Long memberProfileId, MemberProfileUpdateRequest memberProfileUpdateRequest) {
+    public void updateProfile(Long memberProfileId, MultipartFile file,
+                              MemberProfileUpdateRequest memberProfileUpdateRequest) throws IOException {
         MemberProfile memberProfile = getMemberProfileById(memberProfileId);
         memberProfile.updateProfile(memberProfileUpdateRequest.getBirth(),
                 memberProfileUpdateRequest.getHeight(),
@@ -73,8 +74,19 @@ public class MemberService {
                 DrinkStatus.find(memberProfileUpdateRequest.getDrinkStatus()),
                 memberProfileUpdateRequest.getDescription(),
                 getMemberPersonalities(memberProfile, memberProfileUpdateRequest.getPersonalities()),
-                getMemberHobbies(memberProfile, memberProfileUpdateRequest.getHobbies()),
-                getProfileImages(memberProfile, memberProfileUpdateRequest.getImages()));
+                getMemberHobbies(memberProfile, memberProfileUpdateRequest.getHobbies()));
+        if (!file.isEmpty()) {
+            fileUploadService.delete(memberProfile.getMainImageUrl());
+            String url = fileUploadService.save(file);
+            ImageRequest imageRequest = ImageRequest.builder()
+                    .url(url)
+                    .sequence(Sequence.MAIN.name())
+                    .build();
+            List<ImageRequest> imageRequests = new ArrayList<>();
+            imageRequests.add(imageRequest);
+            memberProfile.updateProfileImage(imageRequests);
+
+        }
         memberProfileRepository.save(memberProfile);
     }
 
@@ -169,16 +181,5 @@ public class MemberService {
     private Hobby getHobbyByKeyword(String keyword) {
         return hobbyRepository.findByKeyword(keyword)
                 .orElseThrow(() -> new NotFoundException(ApplicationError.HOBBY_NOT_FOUND));
-    }
-
-    private List<ProfileImage> getProfileImages(MemberProfile memberProfile, List<ImageRequest> images) {
-        return images.stream()
-                .map(imageRequest -> ProfileImage.builder()
-                        .memberProfile(memberProfile)
-                        .id(imageRequest.getProfileImageId())
-                        .url(imageRequest.getUrl())
-                        .sequence(Sequence.valueOf(imageRequest.getSequence()))
-                        .build())
-                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -2,7 +2,10 @@ package com.cupid.jikting.member.service;
 
 import com.cupid.jikting.common.entity.Hobby;
 import com.cupid.jikting.common.entity.Personality;
-import com.cupid.jikting.common.error.*;
+import com.cupid.jikting.common.error.ApplicationError;
+import com.cupid.jikting.common.error.BadRequestException;
+import com.cupid.jikting.common.error.DuplicateException;
+import com.cupid.jikting.common.error.NotFoundException;
 import com.cupid.jikting.common.repository.PersonalityRepository;
 import com.cupid.jikting.common.service.RedisConnector;
 import com.cupid.jikting.member.dto.*;
@@ -17,7 +20,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import javax.transaction.Transactional;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -76,16 +76,12 @@ public class MemberService {
                 getMemberPersonalities(memberProfile, memberProfileUpdateRequest.getPersonalities()),
                 getMemberHobbies(memberProfile, memberProfileUpdateRequest.getHobbies()));
         if (!file.isEmpty()) {
-            fileUploadService.delete(memberProfile.getMainImageUrl());
-            String url = fileUploadService.save(file);
+            String url = fileUploadService.update(file, memberProfile.getMainImageUrl());
             ImageRequest imageRequest = ImageRequest.builder()
                     .url(url)
                     .sequence(Sequence.MAIN.name())
                     .build();
-            List<ImageRequest> imageRequests = new ArrayList<>();
-            imageRequests.add(imageRequest);
-            memberProfile.updateProfileImage(imageRequests);
-
+            memberProfile.updateProfileImage(List.of(imageRequest));
         }
         memberProfileRepository.save(memberProfile);
     }

--- a/src/main/java/com/cupid/jikting/recommend/entity/Recommend.java
+++ b/src/main/java/com/cupid/jikting/recommend/entity/Recommend.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
 import java.util.List;
@@ -18,6 +19,7 @@ import java.util.List;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE recommend SET is_deleted = true WHERE recommend_id = ?")
+@Where(clause = "is_deleted = false")
 @AttributeOverride(name = "id", column = @Column(name = "recommend_id"))
 @Entity
 public class Recommend extends BaseEntity {

--- a/src/main/java/com/cupid/jikting/team/entity/Team.java
+++ b/src/main/java/com/cupid/jikting/team/entity/Team.java
@@ -7,6 +7,7 @@ import com.cupid.jikting.recommend.entity.Recommend;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -18,6 +19,7 @@ import java.util.stream.Collectors;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE team SET is_deleted = true WHERE team_id = ?")
+@Where(clause = "is_deleted = false")
 @AttributeOverride(name = "id", column = @Column(name = "team_id"))
 @Entity
 public class Team extends BaseEntity {

--- a/src/main/java/com/cupid/jikting/team/entity/TeamLike.java
+++ b/src/main/java/com/cupid/jikting/team/entity/TeamLike.java
@@ -11,6 +11,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
 import java.util.List;
@@ -20,6 +21,7 @@ import java.util.List;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE team_like SET is_deleted = true WHERE team_like_id = ?")
+@Where(clause = "is_deleted = false")
 @AttributeOverride(name = "id", column = @Column(name = "team_Like_id"))
 @Entity
 public class TeamLike extends BaseEntity {

--- a/src/main/java/com/cupid/jikting/team/entity/TeamMember.java
+++ b/src/main/java/com/cupid/jikting/team/entity/TeamMember.java
@@ -7,6 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
 import java.util.List;
@@ -15,6 +16,7 @@ import java.util.List;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE team_member SET is_deleted = true WHERE team_member_id = ?")
+@Where(clause = "is_deleted = false")
 @AttributeOverride(name = "id", column = @Column(name = "team_member_id"))
 @Entity
 public class TeamMember extends BaseEntity {

--- a/src/main/java/com/cupid/jikting/team/entity/TeamPersonality.java
+++ b/src/main/java/com/cupid/jikting/team/entity/TeamPersonality.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
 
@@ -16,6 +17,7 @@ import javax.persistence.*;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE team_personality SET is_deleted = true WHERE team_personality_id = ?")
+@Where(clause = "is_deleted = false")
 @AttributeOverride(name = "id", column = @Column(name = "team_personality_id"))
 @Entity
 public class TeamPersonality extends BaseEntity {

--- a/src/test/java/com/cupid/jikting/like/controller/LikeControllerTest.java
+++ b/src/test/java/com/cupid/jikting/like/controller/LikeControllerTest.java
@@ -109,17 +109,15 @@ public class LikeControllerTest extends ApiDocument {
                 .id(ID)
                 .memberCompanies(List.of(memberCompany))
                 .build();
-        MemberProfile memberProfile = MemberProfile.builder()
-                .id(ID)
-                .member(member)
-                .build();
+        member.addMemberProfile(NICKNAME);
+        MemberProfile memberProfile = member.getMemberProfile();
         ProfileImage profileImage = ProfileImage.builder()
                 .id(ID)
                 .sequence(Sequence.MAIN)
                 .url(URL)
                 .build();
         memberProfile.updateProfile(BIRTH, HEIGHT, Mbti.ENFJ, ADDRESS, Gender.MALE, COLLEGE, SmokeStatus.SMOKING, DrinkStatus.OFTEN, DESCRIPTION,
-                memberPersonalities, memberHobbies, List.of(profileImage));
+                memberPersonalities, memberHobbies);
         List<MemberProfileResponse> memberProfileResponses = IntStream.rangeClosed(1, 2)
                 .mapToObj(n -> MemberProfileResponse.from(memberProfile))
                 .collect(Collectors.toList());

--- a/src/test/java/com/cupid/jikting/like/service/LikeServiceTest.java
+++ b/src/test/java/com/cupid/jikting/like/service/LikeServiceTest.java
@@ -104,7 +104,7 @@ class LikeServiceTest {
                 .member(member)
                 .build();
         memberProfile.updateProfile(LocalDate.of(YEAR, MONTH, DATE), HEIGHT, Mbti.ENFJ, ADDRESS, Gender.MALE, COLLEGE, SmokeStatus.SMOKING, DrinkStatus.OFTEN, DESCRIPTION,
-                List.of(memberPersonality), List.of(memberHobby), profileImages);
+                List.of(memberPersonality), List.of(memberHobby));
         Team sentTeam = Team.builder()
                 .id(ID)
                 .name(NAME)

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -153,7 +153,6 @@ public class MemberControllerTest extends ApiDocument {
         memberProfile.getMember().getMemberCompanies().add(memberCompany);
         List<ImageRequest> images = IntStream.range(0, 1)
                 .mapToObj(n -> ImageRequest.builder()
-                        .profileImageId(profileImage.getId())
                         .url(profileImage.getUrl())
                         .sequence(profileImage.getSequence().name())
                         .build())

--- a/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
+++ b/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
@@ -21,6 +21,7 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -287,7 +288,7 @@ public class MemberServiceTest {
     }
 
     @Test
-    void 회원_프로필_수정_성공() {
+    void 회원_프로필_수정_성공() throws IOException {
         // given
         willReturn(Optional.of(memberProfile)).given(memberProfileRepository).findById(anyLong());
         willReturn(Optional.of(personality)).given(personalityRepository).findByKeyword(anyString());

--- a/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
+++ b/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
@@ -55,6 +55,7 @@ public class MemberServiceTest {
     private static final String DESCRIPTION = "한줄 소개(선택사항 - 없을 시 빈 문자열)";
     private static final String VERIFICATION_CODE = "인증번호";
     private static final String WRONG_VERIFICATION_CODE = "잘못된" + VERIFICATION_CODE;
+    private static final int PROFILE_IMAGE_SIZE = 3;
 
     private Member member;
     private MemberProfile memberProfile;
@@ -192,7 +193,7 @@ public class MemberServiceTest {
         // then
         assertAll(
                 () -> verify(memberProfileRepository).findById(anyLong()),
-                () -> assertThat(memberProfileResponse.getImages().size()).isEqualTo(3),
+                () -> assertThat(memberProfileResponse.getImages().size()).isEqualTo(PROFILE_IMAGE_SIZE),
                 () -> assertThat(memberProfileResponse.getAge()).isEqualTo(memberProfile.getAge()),
                 () -> assertThat(memberProfileResponse.getHeight()).isEqualTo(memberProfile.getHeight()),
                 () -> assertThat(memberProfileResponse.getAddress()).isEqualTo(memberProfile.getAddress()),

--- a/src/test/java/com/cupid/jikting/recommend/controller/RecommendControllerTest.java
+++ b/src/test/java/com/cupid/jikting/recommend/controller/RecommendControllerTest.java
@@ -110,7 +110,7 @@ public class RecommendControllerTest extends ApiDocument {
                 .member(member)
                 .build();
         memberProfile.updateProfile(BIRTH, HEIGHT, Mbti.ENFJ, ADDRESS, Gender.MALE, COLLEGE, SmokeStatus.SMOKING, DrinkStatus.OFTEN, DESCRIPTION,
-                List.of(memberPersonality), List.of(memberHobby), profileImages);
+                List.of(memberPersonality), List.of(memberHobby));
         List<MemberResponse> memberResponses = IntStream.rangeClosed(0, 2)
                 .mapToObj(n -> MemberResponse.from(memberProfile))
                 .collect(Collectors.toList());

--- a/src/test/java/com/cupid/jikting/team/controller/TeamControllerTest.java
+++ b/src/test/java/com/cupid/jikting/team/controller/TeamControllerTest.java
@@ -113,17 +113,12 @@ public class TeamControllerTest extends ApiDocument {
                 .type(TYPE)
                 .memberCompanies(List.of(memberCompany))
                 .build();
+        member.addMemberProfile(NICKNAME);
         IntStream.range(0, 3)
                 .mapToObj(n -> {
-                    MemberProfile memberProfile = MemberProfile.builder()
-                            .nickname(NICKNAME)
-                            .birth(BIRTH)
-                            .mbti(Mbti.ENFJ)
-                            .address(ADDRESS)
-                            .member(member)
-                            .build();
+                    MemberProfile memberProfile = member.getMemberProfile();
                     memberProfile.updateProfile(BIRTH, HEIGHT, Mbti.ENFJ, ADDRESS, Gender.MALE, COLLEGE, SmokeStatus.SMOKING, DrinkStatus.OFTEN, DESCRIPTION,
-                            List.of(MemberPersonality.builder().build()), List.of(MemberHobby.builder().build()), profileImages);
+                            List.of(MemberPersonality.builder().build()), List.of(MemberHobby.builder().build()));
                     return memberProfile;
                 })
                 .forEach(memberProfile -> TeamMember.of(LEADER, team, memberProfile));

--- a/src/test/java/com/cupid/jikting/team/service/TeamServiceTest.java
+++ b/src/test/java/com/cupid/jikting/team/service/TeamServiceTest.java
@@ -41,6 +41,7 @@ class TeamServiceTest {
     private static final String KEYWORD = "성격 키워드";
     private static final Long ID = 1L;
     private static final String NAME = "이름";
+    private static final String NICKNAME = "닉네임";
     private static final String DESCRIPTION = "한줄소개";
     private static final int MEMBER_COUNT = 3;
     private static final boolean LEADER = true;
@@ -88,20 +89,9 @@ class TeamServiceTest {
                 .memberCompanies(List.of(memberCompany))
                 .type(TYPE)
                 .build();
-        leader = MemberProfile.builder()
-                .id(ID)
-                .birth(BIRTH)
-                .mbti(Mbti.ENFJ)
-                .address(ADDRESS)
-                .member(member)
-                .build();
-        memberProfile = MemberProfile.builder()
-                .id(ID)
-                .birth(BIRTH)
-                .mbti(Mbti.ENFJ)
-                .address(ADDRESS)
-                .member(member)
-                .build();
+        member.addMemberProfile(NICKNAME);
+        leader = member.getMemberProfile();
+        memberProfile = member.getMemberProfile();
         personality = Personality.builder()
                 .keyword(KEYWORD)
                 .build();
@@ -112,9 +102,9 @@ class TeamServiceTest {
                         .build())
                 .collect(Collectors.toList());
         leader.updateProfile(BIRTH, HEIGHT, Mbti.ENFJ, ADDRESS, Gender.MALE, COLLEGE, SmokeStatus.NONSMOKING, DrinkStatus.OFTEN, DESCRIPTION,
-                List.of(MemberPersonality.builder().build()), List.of(MemberHobby.builder().build()), profileImages);
+                List.of(MemberPersonality.builder().build()), List.of(MemberHobby.builder().build()));
         memberProfile.updateProfile(BIRTH, HEIGHT, Mbti.ENFJ, ADDRESS, Gender.MALE, COLLEGE, SmokeStatus.NONSMOKING, DrinkStatus.OFTEN, DESCRIPTION,
-                List.of(MemberPersonality.builder().build()), List.of(MemberHobby.builder().build()), profileImages);
+                List.of(MemberPersonality.builder().build()), List.of(MemberHobby.builder().build()));
         team = Team.builder()
                 .id(ID)
                 .name(NAME)


### PR DESCRIPTION
## Issue

closed #198 
[SP-339](https://soma-cupid.atlassian.net/browse/SP-339?atlOrigin=eyJpIjoiNjA3ZjZlYzlmNGY4NGE3NWEzYWUyNDNmZTUwMjQxNTAiLCJwIjoiaiJ9)

## 요구사항

- [x] 회원 프로필 이미지 및 정보 수정 통합

## 변경사항

- 회원가입 시 기본 이미지 생성 추가

## 리뷰 우선순위

🙂보통

## 코멘트

- 회원 프로필 수정 시 수정 되는 이미지를 수정 완료 버튼을 눌렀을 때 한번에 반영하도록 수정하였습니다.
- 회원 가입 시에 기본 프로필 이미지 3장을 생성하도록 수정하였습니다.
- 일단 MVP에는 프로필 사진이 한장이라 프로필 사진 업데이트 시 Main만 수정하도록 바꿨습니다.


[SP-339]: https://soma-cupid.atlassian.net/browse/SP-339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ