### PR TITLE
[SP-311] 채팅방 입장 API 구현

### DIFF
--- a/src/main/java/com/cupid/jikting/chatting/config/WebSocketConfig.java
+++ b/src/main/java/com/cupid/jikting/chatting/config/WebSocketConfig.java
@@ -13,7 +13,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws/chattings")
-                .setAllowedOrigins("*");
+                .setAllowedOrigins("http://localhost:5173", "https://jikting.com", "https://www.jikting.com")
+                .withSockJS();
     }
 
     @Override

--- a/src/main/java/com/cupid/jikting/chatting/config/WebSocketConfig.java
+++ b/src/main/java/com/cupid/jikting/chatting/config/WebSocketConfig.java
@@ -12,7 +12,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/chattings")
+        registry.addEndpoint("/ws/chattings")
                 .setAllowedOrigins("*");
     }
 

--- a/src/main/java/com/cupid/jikting/chatting/controller/ChattingController.java
+++ b/src/main/java/com/cupid/jikting/chatting/controller/ChattingController.java
@@ -6,7 +6,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
 
 @Slf4j
@@ -14,12 +13,10 @@ import org.springframework.stereotype.Controller;
 @Controller
 public class ChattingController {
 
-    private final SimpMessagingTemplate simpMessagingTemplate;
     private final ChattingService chattingService;
 
-    @MessageMapping("/chattings/rooms/{chattingRoomId}/messages")
+    @MessageMapping("/chattings/rooms/{chattingRoomId}")
     public void send(@DestinationVariable Long chattingRoomId, ChattingRequest chattingRequest) {
-        simpMessagingTemplate.convertAndSend("/subscription/chattings/rooms/" + chattingRoomId, chattingRequest.getContent());
         chattingService.sendMessage(chattingRoomId, chattingRequest);
         log.info("Message [{}] send by member: {} to chatting room: {}", chattingRequest.getContent(), chattingRequest.getSenderId(), chattingRoomId);
     }

--- a/src/main/java/com/cupid/jikting/chatting/controller/ChattingRoomController.java
+++ b/src/main/java/com/cupid/jikting/chatting/controller/ChattingRoomController.java
@@ -24,8 +24,8 @@ public class ChattingRoomController {
     }
 
     @GetMapping("/{chattingRoomId}")
-    public ResponseEntity<ChattingRoomDetailResponse> get(@PathVariable Long chattingRoomId) {
-        return ResponseEntity.ok().body(chattingRoomService.get(chattingRoomId));
+    public ResponseEntity<ChattingRoomDetailResponse> get(@AuthorizedVariable Long memberProfileId, @PathVariable Long chattingRoomId) {
+        return ResponseEntity.ok().body(chattingRoomService.get(memberProfileId, chattingRoomId));
     }
 
     @PostMapping("/{chattingRoomId}/confirm")

--- a/src/main/java/com/cupid/jikting/chatting/dto/ChattingRequest.java
+++ b/src/main/java/com/cupid/jikting/chatting/dto/ChattingRequest.java
@@ -3,6 +3,8 @@ package com.cupid.jikting.chatting.dto;
 import com.cupid.jikting.chatting.entity.Chatting;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
@@ -17,6 +19,7 @@ public class ChattingRequest {
         return Chatting.builder()
                 .senderId(senderId)
                 .content(content)
+                .createdAt(LocalDateTime.now())
                 .build();
     }
 }

--- a/src/main/java/com/cupid/jikting/chatting/dto/ChattingResponse.java
+++ b/src/main/java/com/cupid/jikting/chatting/dto/ChattingResponse.java
@@ -1,0 +1,15 @@
+package com.cupid.jikting.chatting.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChattingResponse {
+
+    private Long senderId;
+    private String content;
+    private String createdDate;
+    private String createdTime;
+}

--- a/src/main/java/com/cupid/jikting/chatting/dto/ChattingRoomDetailResponse.java
+++ b/src/main/java/com/cupid/jikting/chatting/dto/ChattingRoomDetailResponse.java
@@ -10,7 +10,9 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChattingRoomDetailResponse {
 
+    private String name;
     private String description;
     private List<String> keywords;
     private List<MemberResponse> members;
+    private List<ChattingResponse> chattings;
 }

--- a/src/main/java/com/cupid/jikting/chatting/dto/MemberResponse.java
+++ b/src/main/java/com/cupid/jikting/chatting/dto/MemberResponse.java
@@ -1,14 +1,21 @@
 package com.cupid.jikting.chatting.dto;
 
-import lombok.*;
+import com.cupid.jikting.member.entity.MemberProfile;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberResponse {
 
-    private Long memberId;
-    private String image;
+    private Long memberProfileId;
     private String nickname;
+    private String image;
+
+    public static MemberResponse from(MemberProfile memberProfile) {
+        return new MemberResponse(memberProfile.getId(), memberProfile.getNickname(), memberProfile.getMainImageUrl());
+    }
 }

--- a/src/main/java/com/cupid/jikting/chatting/entity/Chatting.java
+++ b/src/main/java/com/cupid/jikting/chatting/entity/Chatting.java
@@ -3,8 +3,6 @@ package com.cupid.jikting.chatting.entity;
 import lombok.*;
 import org.springframework.data.annotation.Id;
 
-import javax.persistence.AttributeOverride;
-import javax.persistence.Column;
 import java.io.Serializable;
 import java.util.UUID;
 
@@ -12,7 +10,6 @@ import java.util.UUID;
 @Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AttributeOverride(name = "id", column = @Column(name = "chatting_id"))
 public class Chatting implements Serializable {
 
     @Id

--- a/src/main/java/com/cupid/jikting/chatting/entity/Chatting.java
+++ b/src/main/java/com/cupid/jikting/chatting/entity/Chatting.java
@@ -4,7 +4,7 @@ import lombok.*;
 import org.springframework.data.annotation.Id;
 
 import java.io.Serializable;
-import java.util.UUID;
+import java.time.LocalDateTime;
 
 @Getter
 @Builder
@@ -13,8 +13,9 @@ import java.util.UUID;
 public class Chatting implements Serializable {
 
     @Id
-    private String id = UUID.randomUUID().toString();
+    private Long id;
 
     private Long senderId;
     private String content;
+    private LocalDateTime createdAt;
 }

--- a/src/main/java/com/cupid/jikting/chatting/entity/ChattingRoom.java
+++ b/src/main/java/com/cupid/jikting/chatting/entity/ChattingRoom.java
@@ -37,6 +37,10 @@ public class ChattingRoom extends BaseEntity {
         return meeting.getOppositeTeamDescription(team);
     }
 
+    public List<String> getOppositeTeamKeywords(Team team) {
+        return meeting.getOppositeTeamKeywords(team);
+    }
+
     public void addMemberChattingRoom(MemberChattingRoom memberChattingRoom) {
         memberChattingRooms.add(memberChattingRoom);
     }

--- a/src/main/java/com/cupid/jikting/chatting/entity/ChattingRoom.java
+++ b/src/main/java/com/cupid/jikting/chatting/entity/ChattingRoom.java
@@ -2,6 +2,7 @@ package com.cupid.jikting.chatting.entity;
 
 import com.cupid.jikting.common.entity.BaseEntity;
 import com.cupid.jikting.meeting.entity.Meeting;
+import com.cupid.jikting.member.entity.MemberProfile;
 import com.cupid.jikting.team.entity.Team;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
@@ -47,5 +48,9 @@ public class ChattingRoom extends BaseEntity {
 
     public void confirmMeeting(Long meetingId, LocalDateTime schedule, String place) {
         meeting.confirm(meetingId, schedule, place);
+    }
+
+    public List<MemberProfile> getMemberProfiles() {
+        return meeting.getMemberProfiles();
     }
 }

--- a/src/main/java/com/cupid/jikting/chatting/entity/ChattingRoom.java
+++ b/src/main/java/com/cupid/jikting/chatting/entity/ChattingRoom.java
@@ -33,6 +33,10 @@ public class ChattingRoom extends BaseEntity {
         return meeting.getOppositeTeamName(team);
     }
 
+    public String getOppositeTeamDescription(Team team) {
+        return meeting.getOppositeTeamDescription(team);
+    }
+
     public void addMemberChattingRoom(MemberChattingRoom memberChattingRoom) {
         memberChattingRooms.add(memberChattingRoom);
     }

--- a/src/main/java/com/cupid/jikting/chatting/service/RedisSubscriber.java
+++ b/src/main/java/com/cupid/jikting/chatting/service/RedisSubscriber.java
@@ -22,7 +22,7 @@ public class RedisSubscriber implements MessageListener {
     @Override
     public void onMessage(Message message, byte[] pattern) {
         ChattingRequest chattingRequest = jsonParser.toChattingRequest((String) redisTemplate.getStringSerializer().deserialize(message.getBody()));
-        messagingTemplate.convertAndSend("/subscription/chattings/rooms/" + chattingRequest.getChattingRoomId(), chattingRequest.getContent());
+        messagingTemplate.convertAndSend("/subscription/chattings/rooms/" + chattingRequest.getChattingRoomId(), chattingRequest);
         log.info("Message [{}] send by member: {} to chatting room: {}", chattingRequest.getContent(), chattingRequest.getSenderId(), chattingRequest.getChattingRoomId());
     }
 }

--- a/src/main/java/com/cupid/jikting/common/config/RedisConfig.java
+++ b/src/main/java/com/cupid/jikting/common/config/RedisConfig.java
@@ -4,7 +4,6 @@ import com.cupid.jikting.chatting.service.RedisSubscriber;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.connection.RedisClusterConfiguration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
@@ -14,8 +13,6 @@ import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
-
-import java.util.List;
 
 @Configuration
 public class RedisConfig {

--- a/src/main/java/com/cupid/jikting/common/config/SecurityConfig.java
+++ b/src/main/java/com/cupid/jikting/common/config/SecurityConfig.java
@@ -65,7 +65,7 @@ public class SecurityConfig {
                 .mvcMatchers("/members/nickname/check").permitAll()
                 .mvcMatchers("/members/code").permitAll()
                 .mvcMatchers("/members/verification").permitAll()
-                .mvcMatchers("/chattings").permitAll()
+                .mvcMatchers("/ws").permitAll()
                 .anyRequest().authenticated()
                 .and()
                 .oauth2Login()

--- a/src/main/java/com/cupid/jikting/common/config/SecurityConfig.java
+++ b/src/main/java/com/cupid/jikting/common/config/SecurityConfig.java
@@ -65,6 +65,7 @@ public class SecurityConfig {
                 .mvcMatchers("/members/nickname/check").permitAll()
                 .mvcMatchers("/members/code").permitAll()
                 .mvcMatchers("/members/verification").permitAll()
+                .mvcMatchers("/chattings").permitAll()
                 .anyRequest().authenticated()
                 .and()
                 .oauth2Login()

--- a/src/main/java/com/cupid/jikting/common/service/RedisConnector.java
+++ b/src/main/java/com/cupid/jikting/common/service/RedisConnector.java
@@ -14,6 +14,7 @@ import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.Optional;
 
 @Slf4j
@@ -62,5 +63,10 @@ public class RedisConnector {
 
     public void delete(String key) {
         redisTemplate.delete(key);
+    }
+
+    public List<Chatting> getMessages(String chattingRoomKey) {
+        HashOperations<String, Long, Chatting> hashOperations = redisTemplate.opsForHash();
+        return hashOperations.values(chattingRoomKey);
     }
 }

--- a/src/main/java/com/cupid/jikting/common/service/RedisConnector.java
+++ b/src/main/java/com/cupid/jikting/common/service/RedisConnector.java
@@ -39,13 +39,13 @@ public class RedisConnector {
     }
 
     public void saveChatting(String chattingRoom, Chatting chatting) {
-        HashOperations<String, Object, Object> hashOperations = redisTemplate.opsForHash();
+        HashOperations<String, Long, Object> hashOperations = redisTemplate.opsForHash();
         hashOperations.put(chattingRoom, chatting.getId(), chatting);
         log.info("create new chatting [{}] int chatting room '{}'", chatting, chattingRoom);
     }
 
     public String getLastMessage(String chattingRoom) {
-        HashOperations<String, Object, Object> hashOperations = redisTemplate.opsForHash();
+        HashOperations<String, Long, ChattingRequest> hashOperations = redisTemplate.opsForHash();
         return hashOperations.values(chattingRoom)
                 .stream()
                 .map(String::valueOf)

--- a/src/main/java/com/cupid/jikting/meeting/entity/Meeting.java
+++ b/src/main/java/com/cupid/jikting/meeting/entity/Meeting.java
@@ -44,6 +44,13 @@ public class Meeting extends BaseEntity {
         return recommendedTeam.getName();
     }
 
+    public String getOppositeTeamDescription(Team team) {
+        if (recommendedTeam.equals(team)) {
+            return acceptingTeam.getDescription();
+        }
+        return recommendedTeam.getDescription();
+    }
+
     public void confirm(Long meetingId, LocalDateTime schedule, String place) {
         validate(meetingId);
         this.schedule = schedule;

--- a/src/main/java/com/cupid/jikting/meeting/entity/Meeting.java
+++ b/src/main/java/com/cupid/jikting/meeting/entity/Meeting.java
@@ -3,6 +3,7 @@ package com.cupid.jikting.meeting.entity;
 import com.cupid.jikting.common.entity.BaseEntity;
 import com.cupid.jikting.common.error.ApplicationError;
 import com.cupid.jikting.common.error.WrongAccessException;
+import com.cupid.jikting.member.entity.MemberProfile;
 import com.cupid.jikting.team.entity.Team;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -13,6 +14,7 @@ import org.hibernate.annotations.SQLDelete;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -59,6 +61,12 @@ public class Meeting extends BaseEntity {
             return acceptingTeam.getPersonalities();
         }
         return recommendedTeam.getPersonalities();
+    }
+
+    public List<MemberProfile> getMemberProfiles() {
+        List<MemberProfile> memberProfiles = new ArrayList<>(recommendedTeam.getMemberProfiles());
+        memberProfiles.addAll(acceptingTeam.getMemberProfiles());
+        return memberProfiles;
     }
 
     public void confirm(Long meetingId, LocalDateTime schedule, String place) {

--- a/src/main/java/com/cupid/jikting/meeting/entity/Meeting.java
+++ b/src/main/java/com/cupid/jikting/meeting/entity/Meeting.java
@@ -26,8 +26,6 @@ import java.util.List;
 @Entity
 public class Meeting extends BaseEntity {
 
-    private static final String CHATTING_ROOM_NAME_DELIMITER = " - ";
-
     private LocalDateTime schedule;
     private String place;
 

--- a/src/main/java/com/cupid/jikting/meeting/entity/Meeting.java
+++ b/src/main/java/com/cupid/jikting/meeting/entity/Meeting.java
@@ -13,6 +13,7 @@ import org.hibernate.annotations.SQLDelete;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @SuperBuilder
@@ -22,6 +23,8 @@ import java.time.LocalDateTime;
 @AttributeOverride(name = "id", column = @Column(name = "meeting_id"))
 @Entity
 public class Meeting extends BaseEntity {
+
+    private static final String CHATTING_ROOM_NAME_DELIMITER = " - ";
 
     private LocalDateTime schedule;
     private String place;
@@ -49,6 +52,13 @@ public class Meeting extends BaseEntity {
             return acceptingTeam.getDescription();
         }
         return recommendedTeam.getDescription();
+    }
+
+    public List<String> getOppositeTeamKeywords(Team team) {
+        if (recommendedTeam.equals(team)) {
+            return acceptingTeam.getPersonalities();
+        }
+        return recommendedTeam.getPersonalities();
     }
 
     public void confirm(Long meetingId, LocalDateTime schedule, String place) {

--- a/src/test/java/com/cupid/jikting/chatting/controller/ChattingRoomControllerTest.java
+++ b/src/test/java/com/cupid/jikting/chatting/controller/ChattingRoomControllerTest.java
@@ -150,7 +150,7 @@ public class ChattingRoomControllerTest extends ApiDocument {
     @Test
     void 채팅방_입장_성공() throws Exception {
         //given
-        willReturn(chattingRoomDetailResponse).given(chattingRoomService).get(anyLong());
+        willReturn(chattingRoomDetailResponse).given(chattingRoomService).get(anyLong(), anyLong());
         //when
         ResultActions resultActions = 채팅방_입장_요청();
         //then
@@ -161,7 +161,7 @@ public class ChattingRoomControllerTest extends ApiDocument {
     @Test
     void 채팅방_입장_실패() throws Exception {
         //given
-        willThrow(chattingRoomNotFoundException).given(chattingRoomService).get(anyLong());
+        willThrow(chattingRoomNotFoundException).given(chattingRoomService).get(anyLong(), anyLong());
         //when
         ResultActions resultActions = 채팅방_입장_요청();
         //then

--- a/src/test/java/com/cupid/jikting/chatting/controller/ChattingRoomControllerTest.java
+++ b/src/test/java/com/cupid/jikting/chatting/controller/ChattingRoomControllerTest.java
@@ -8,11 +8,14 @@ import com.cupid.jikting.chatting.dto.MeetingConfirmRequest;
 import com.cupid.jikting.chatting.dto.MemberResponse;
 import com.cupid.jikting.chatting.service.ChattingRoomService;
 import com.cupid.jikting.common.dto.ErrorResponse;
+import com.cupid.jikting.common.entity.Hobby;
+import com.cupid.jikting.common.entity.Personality;
 import com.cupid.jikting.common.error.ApplicationError;
 import com.cupid.jikting.common.error.ApplicationException;
 import com.cupid.jikting.common.error.NotFoundException;
 import com.cupid.jikting.common.error.WrongFormException;
 import com.cupid.jikting.jwt.service.JwtService;
+import com.cupid.jikting.member.entity.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -22,6 +25,7 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.ResultActions;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.Month;
 import java.util.List;
@@ -53,6 +57,12 @@ public class ChattingRoomControllerTest extends ApiDocument {
     private static final String DESCRIPTION = "팀소개";
     private static final String KEYWORD = "키워드";
     private static final String NICKNAME = "닉네임";
+    private static final String HOBBY = "취미";
+    private static final String PERSONALITY = "성격";
+    private static final String ADDRESS = "거주지";
+    private static final String COLLEGE = "대학";
+    private static final LocalDate BIRTH = LocalDate.of(1997, 9, 11);
+    private static final int HEIGHT = 180;
 
     private String accessToken;
     private MeetingConfirmRequest meetingConfirmRequest;
@@ -76,6 +86,31 @@ public class ChattingRoomControllerTest extends ApiDocument {
         List<String> keywords = IntStream.rangeClosed(1, 3)
                 .mapToObj(n -> KEYWORD + n)
                 .collect(Collectors.toList());
+        MemberProfile memberProfile = MemberProfile.builder()
+                .id(ID)
+                .nickname(NICKNAME)
+                .build();
+        List<ProfileImage> profileImages = IntStream.rangeClosed(0, 2)
+                .mapToObj(n -> ProfileImage.builder()
+                        .memberProfile(memberProfile)
+                        .sequence(Sequence.MAIN)
+                        .url(URL)
+                        .build())
+                .collect(Collectors.toList());
+        Hobby hobby = Hobby.builder()
+                .keyword(HOBBY)
+                .build();
+        Personality personality = Personality.builder()
+                .keyword(PERSONALITY)
+                .build();
+        MemberHobby memberHobby = MemberHobby.builder()
+                .hobby(hobby)
+                .build();
+        MemberPersonality memberPersonality = MemberPersonality.builder()
+                .personality(personality)
+                .build();
+        memberProfile.updateProfile(BIRTH, HEIGHT, Mbti.ENFJ, ADDRESS, Gender.MALE, COLLEGE, SmokeStatus.SMOKING, DrinkStatus.OFTEN, DESCRIPTION,
+                List.of(memberPersonality), List.of(memberHobby), profileImages);
         meetingConfirmRequest = MeetingConfirmRequest.builder()
                 .meetingId(ID)
                 .place(PLACE)
@@ -93,11 +128,7 @@ public class ChattingRoomControllerTest extends ApiDocument {
                 .description(DESCRIPTION)
                 .keywords(keywords)
                 .members(IntStream.rangeClosed(0, 2)
-                        .mapToObj(n -> MemberResponse.builder()
-                                .memberId(ID)
-                                .image(URL)
-                                .nickname(NICKNAME)
-                                .build())
+                        .mapToObj(n -> MemberResponse.from(memberProfile))
                         .collect(Collectors.toList()))
                 .build();
         wrongFormException = new WrongFormException(ApplicationError.INVALID_FORMAT);

--- a/src/test/java/com/cupid/jikting/chatting/service/ChattingRoomServiceTest.java
+++ b/src/test/java/com/cupid/jikting/chatting/service/ChattingRoomServiceTest.java
@@ -139,7 +139,7 @@ class ChattingRoomServiceTest {
     }
 
     @Test
-    void 채팅_목록_조회_성공() {
+    void 채팅방_목록_조회_성공() {
         // given
         willReturn(Optional.of(memberProfile)).given(memberProfileRepository).findById(anyLong());
         willReturn(chattingRooms).given(chattingRoomRepository).findAll();
@@ -151,7 +151,7 @@ class ChattingRoomServiceTest {
     }
 
     @Test
-    void 채팅_목록_조회_실패_회원_프로필_없음() {
+    void 채팅방_목록_조회_실패_회원_프로필_없음() {
         // given
         willThrow(memberNotFoundException).given(memberProfileRepository).findById(anyLong());
         // when & then

--- a/src/test/java/com/cupid/jikting/chatting/service/ChattingRoomServiceTest.java
+++ b/src/test/java/com/cupid/jikting/chatting/service/ChattingRoomServiceTest.java
@@ -185,6 +185,16 @@ class ChattingRoomServiceTest {
     }
 
     @Test
+    void 채팅방_입장_실패_채팅방_없음() {
+        // given
+        willThrow(new NotFoundException(ApplicationError.CHATTING_ROOM_NOT_FOUND)).given(chattingRoomRepository).findById(anyLong());
+        // when & then
+        assertThatThrownBy(() -> chattingRoomService.get(ID, ID))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage(ApplicationError.CHATTING_ROOM_NOT_FOUND.getMessage());
+    }
+
+    @Test
     void 채팅방_내_미팅_화정_성공() {
         // given
         willReturn(Optional.of(chattingRoom)).given(chattingRoomRepository).findById(anyLong());

--- a/src/test/java/com/cupid/jikting/chatting/service/ChattingRoomServiceTest.java
+++ b/src/test/java/com/cupid/jikting/chatting/service/ChattingRoomServiceTest.java
@@ -206,7 +206,7 @@ class ChattingRoomServiceTest {
     }
 
     @Test
-    void 채팅방_내_미팅_화정_성공() {
+    void 채팅방_내_미팅_확정_성공() {
         // given
         willReturn(Optional.of(chattingRoom)).given(chattingRoomRepository).findById(anyLong());
         willReturn(chattingRoom).given(chattingRoomRepository).save(any(ChattingRoom.class));
@@ -225,7 +225,7 @@ class ChattingRoomServiceTest {
     }
 
     @Test
-    void 채팅방_내_미팅_화정_실패_채팅방_없음() {
+    void 채팅방_내_미팅_확정_실패_채팅방_없음() {
         // given
         willThrow(new NotFoundException(ApplicationError.CHATTING_ROOM_NOT_FOUND)).given(chattingRoomRepository).findById(anyLong());
         MeetingConfirmRequest meetingConfirmRequest = MeetingConfirmRequest.builder()
@@ -240,7 +240,7 @@ class ChattingRoomServiceTest {
     }
 
     @Test
-    void 채팅방_내_미팅_화정_실패_잘못된_미팅() {
+    void 채팅방_내_미팅_확정_실패_잘못된_미팅() {
         // given
         willReturn(Optional.of(chattingRoom)).given(chattingRoomRepository).findById(anyLong());
         MeetingConfirmRequest meetingConfirmRequest = MeetingConfirmRequest.builder()

--- a/src/test/java/com/cupid/jikting/chatting/service/ChattingRoomServiceTest.java
+++ b/src/test/java/com/cupid/jikting/chatting/service/ChattingRoomServiceTest.java
@@ -195,6 +195,17 @@ class ChattingRoomServiceTest {
     }
 
     @Test
+    void 채팅방_입장_실패_회원_프로필_없음() {
+        // given
+        willReturn(Optional.of(chattingRoom)).given(chattingRoomRepository).findById(anyLong());
+        willThrow(memberNotFoundException).given(memberProfileRepository).findById(anyLong());
+        // when & then
+        assertThatThrownBy(() -> chattingRoomService.get(ID, ID))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage(ApplicationError.MEMBER_NOT_FOUND.getMessage());
+    }
+
+    @Test
     void 채팅방_내_미팅_화정_성공() {
         // given
         willReturn(Optional.of(chattingRoom)).given(chattingRoomRepository).findById(anyLong());

--- a/src/test/java/com/cupid/jikting/chatting/service/ChattingRoomServiceTest.java
+++ b/src/test/java/com/cupid/jikting/chatting/service/ChattingRoomServiceTest.java
@@ -1,19 +1,24 @@
 package com.cupid.jikting.chatting.service;
 
+import com.cupid.jikting.chatting.dto.ChattingRoomDetailResponse;
 import com.cupid.jikting.chatting.dto.ChattingRoomResponse;
 import com.cupid.jikting.chatting.dto.MeetingConfirmRequest;
+import com.cupid.jikting.chatting.entity.Chatting;
 import com.cupid.jikting.chatting.entity.ChattingRoom;
 import com.cupid.jikting.chatting.repository.ChattingRoomRepository;
+import com.cupid.jikting.common.entity.Hobby;
+import com.cupid.jikting.common.entity.Personality;
 import com.cupid.jikting.common.error.ApplicationError;
 import com.cupid.jikting.common.error.ApplicationException;
 import com.cupid.jikting.common.error.NotFoundException;
 import com.cupid.jikting.common.error.WrongAccessException;
 import com.cupid.jikting.common.service.RedisConnector;
 import com.cupid.jikting.meeting.entity.Meeting;
-import com.cupid.jikting.member.entity.MemberProfile;
+import com.cupid.jikting.member.entity.*;
 import com.cupid.jikting.member.repository.MemberProfileRepository;
 import com.cupid.jikting.team.entity.Team;
 import com.cupid.jikting.team.entity.TeamMember;
+import com.cupid.jikting.team.entity.TeamPersonality;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,6 +26,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -31,8 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.BDDMockito.willReturn;
-import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.BDDMockito.*;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -40,14 +45,25 @@ class ChattingRoomServiceTest {
 
     private static final Long ID = 1L;
     private static final Long WRONG_ID = 2L;
-    private static final String TEAM_NAME = "팀 이름";
+    private static final String NAME = "이름";
+    private static final String KEYWORD = "키워드";
+    private static final String URL = "url";
+    private static final int YEAR = 1967;
+    private static final int MONTH = 5;
+    private static final int DATE = 10;
+    private static final int HEIGHT = 189;
+    private static final String ADDRESS = "주소";
+    private static final String COLLEGE = "대학";
+    private static final String DESCRIPTION = "한 줄 소개";
     private static final boolean LEADER = true;
     private static final LocalDateTime SCHEDULE = LocalDateTime.of(2023, 9, 10, 18, 30);
     private static final String PLACE = "장소";
     private static final String LAST_MESSAGE = "마지막 메시지";
+    private static final String CONTENT = "메시지 내용";
 
     private MemberProfile memberProfile;
     private ChattingRoom chattingRoom;
+    private Chatting chatting;
     private List<ChattingRoom> chattingRooms;
     private ApplicationException memberNotFoundException;
 
@@ -63,15 +79,44 @@ class ChattingRoomServiceTest {
     @Mock
     private RedisConnector redisConnector;
 
+    @Mock
+    private RedisMessageListener redisMessageListener;
+
     @BeforeEach
     void setUp() {
+        Personality personality = Personality.builder()
+                .keyword(KEYWORD)
+                .build();
+        TeamPersonality teamPersonality = TeamPersonality.builder()
+                .personality(personality)
+                .build();
         Team team = Team.builder()
                 .id(ID)
-                .name(TEAM_NAME)
+                .name(NAME)
+                .description(DESCRIPTION)
                 .build();
+        team.addTeamPersonalities(List.of(teamPersonality));
+        Hobby hobby = Hobby.builder()
+                .keyword(KEYWORD)
+                .build();
+        MemberPersonality memberPersonality = MemberPersonality.builder()
+                .personality(personality)
+                .build();
+        MemberHobby memberHobby = MemberHobby.builder()
+                .hobby(hobby)
+                .build();
+        List<ProfileImage> profileImages = IntStream.rangeClosed(0, 2)
+                .mapToObj(n -> ProfileImage.builder()
+                        .id(ID)
+                        .url(URL)
+                        .sequence(Sequence.MAIN)
+                        .build())
+                .collect(Collectors.toList());
         memberProfile = MemberProfile.builder()
                 .id(ID)
                 .build();
+        memberProfile.updateProfile(LocalDate.of(YEAR, MONTH, DATE), HEIGHT, Mbti.ENFJ, ADDRESS, Gender.MALE, COLLEGE, SmokeStatus.SMOKING, DrinkStatus.OFTEN, DESCRIPTION,
+                List.of(memberPersonality), List.of(memberHobby), profileImages);
         TeamMember.of(LEADER, team, memberProfile);
         chattingRoom = ChattingRoom.builder()
                 .id(ID)
@@ -80,6 +125,12 @@ class ChattingRoomServiceTest {
                         .recommendedTeam(team)
                         .acceptingTeam(team)
                         .build())
+                .build();
+        chatting = Chatting.builder()
+                .id(ID)
+                .senderId(ID)
+                .content(CONTENT)
+                .createdAt(LocalDateTime.now())
                 .build();
         chattingRooms = IntStream.range(0, 3)
                 .mapToObj(n -> chattingRoom)
@@ -107,6 +158,30 @@ class ChattingRoomServiceTest {
         assertThatThrownBy(() -> chattingRoomService.getAll(ID))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage(ApplicationError.MEMBER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    void 채팅방_입장_성공() {
+        // given
+        List<Chatting> chattings = List.of(chatting);
+        willDoNothing().given(redisMessageListener).enterChattingRoom(anyLong());
+        willReturn(Optional.of(chattingRoom)).given(chattingRoomRepository).findById(anyLong());
+        willReturn(Optional.of(memberProfile)).given(memberProfileRepository).findById(anyLong());
+        willReturn(chattings).given(redisConnector).getMessages(anyString());
+        // when
+        ChattingRoomDetailResponse chattingRoomDetailResponse = chattingRoomService.get(ID, ID);
+        // then
+        assertAll(
+                () -> verify(redisMessageListener).enterChattingRoom(anyLong()),
+                () -> verify(chattingRoomRepository).findById(anyLong()),
+                () -> verify(memberProfileRepository).findById(anyLong()),
+                () -> verify(redisConnector).getMessages(anyString()),
+                () -> assertThat(chattingRoomDetailResponse.getName()).isEqualTo(NAME),
+                () -> assertThat(chattingRoomDetailResponse.getDescription()).isEqualTo(DESCRIPTION),
+                () -> assertThat(chattingRoomDetailResponse.getKeywords().size()).isEqualTo(chattingRoom.getOppositeTeamKeywords(memberProfile.getTeam()).size()),
+                () -> assertThat(chattingRoomDetailResponse.getMembers().size()).isEqualTo(chattingRoom.getMemberProfiles().size()),
+                () -> assertThat(chattingRoomDetailResponse.getChattings().size()).isEqualTo(chattings.size())
+        );
     }
 
     @Test

--- a/src/test/java/com/cupid/jikting/recommend/controller/RecommendControllerTest.java
+++ b/src/test/java/com/cupid/jikting/recommend/controller/RecommendControllerTest.java
@@ -70,9 +70,6 @@ public class RecommendControllerTest extends ApiDocument {
 
     @BeforeEach
     void setUp() {
-        List<String> personalities = IntStream.rangeClosed(1, 3)
-                .mapToObj(n -> PERSONALITY + n)
-                .collect(Collectors.toList());
         MemberProfile tmpMemberProfile = MemberProfile.builder()
                 .id(ID)
                 .build();
@@ -107,7 +104,6 @@ public class RecommendControllerTest extends ApiDocument {
         MemberProfile memberProfile = MemberProfile.builder()
                 .member(member)
                 .nickname(NICKNAME)
-                .member(member)
                 .build();
         memberProfile.updateProfile(BIRTH, HEIGHT, Mbti.ENFJ, ADDRESS, Gender.MALE, COLLEGE, SmokeStatus.SMOKING, DrinkStatus.OFTEN, DESCRIPTION,
                 List.of(memberPersonality), List.of(memberHobby), profileImages);


### PR DESCRIPTION
## Issue

closed #192 
[SP-311](https://soma-cupid.atlassian.net/browse/SP-311?atlOrigin=eyJpIjoiNWY2OTFjYTQ2NTIwNDlmNGE2NTU1YzJlMDcwN2VkZjUiLCJwIjoiaiJ9)

## 요구사항

- [x] 채팅방 입장 API 구현

## 변경사항

- `SecurityConfig` 웹 소켓 연결 요청 접근 허용
- `WebSocketConfig` 엔드포인트 수정
- `RecommendControllerTest` 미사용 필드 삭제
- `RedisConfig` 임포트 정리
- `Chatting` 미사용 어노테이션 삭제
- `MemberResponse` 빌더 패턴 삭제 및 정적 팩토리 메소드 적용

## 리뷰 우선순위

🙂보통

[SP-311]: https://soma-cupid.atlassian.net/browse/SP-311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ