### PR TITLE
[SP-331] 팀 정보 조회 api 수정

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -561,6 +561,17 @@ include::{snippets}/send-like-fail/http-request.adoc[]
 .response
 include::{snippets}/send-like-fail/http-response.adoc[]
 
+==== 호감 넘기기
+----
+/v1/recommends/{recommendId}/pass
+----
+===== 성공
+.request
+include::{snippets}/pass-like-success/http-request.adoc[]
+
+.response
+include::{snippets}/pass-like-success/http-response.adoc[]
+
 === 호감 관련 기능
 ==== 받은 호감 목록 조회
 ----

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -571,6 +571,12 @@ include::{snippets}/pass-like-success/http-request.adoc[]
 
 .response
 include::{snippets}/pass-like-success/http-response.adoc[]
+===== 실패
+.request
+include::{snippets}/pass-like-fail/http-request.adoc[]
+
+.response
+include::{snippets}/pass-like-fail/http-response.adoc[]
 
 === 호감 관련 기능
 ==== 받은 호감 목록 조회

--- a/src/main/java/com/cupid/jikting/member/dto/MemberProfileUpdateRequest.java
+++ b/src/main/java/com/cupid/jikting/member/dto/MemberProfileUpdateRequest.java
@@ -15,7 +15,6 @@ public class MemberProfileUpdateRequest {
     private int height;
     private String mbti;
     private String address;
-    private String gender;
     private String college;
     private String smokeStatus;
     private String drinkStatus;

--- a/src/main/java/com/cupid/jikting/member/entity/Member.java
+++ b/src/main/java/com/cupid/jikting/member/entity/Member.java
@@ -55,6 +55,7 @@ public class Member extends BaseEntity {
     public void addMemberProfile(String nickname) {
         memberProfile = MemberProfile.builder()
                 .nickname(nickname)
+                .gender(gender)
                 .member(this)
                 .build();
         memberProfile.createDefaultProfileImages();

--- a/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
+++ b/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
@@ -136,14 +136,13 @@ public class MemberProfile extends BaseEntity {
         this.nickname = nickname;
     }
 
-    public void updateProfile(LocalDate birth, int height, Mbti mbti, String address, Gender gender, String college,
+    public void updateProfile(LocalDate birth, int height, Mbti mbti, String address, String college,
                               SmokeStatus smokeStatus, DrinkStatus drinkStatus, String description,
                               List<MemberPersonality> memberPersonalities, List<MemberHobby> memberHobbies) {
         this.birth = birth;
         this.height = height;
         this.mbti = mbti;
         this.address = address;
-        this.gender = gender;
         this.college = college;
         this.smokeStatus = smokeStatus;
         this.drinkStatus = drinkStatus;

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -70,7 +70,6 @@ public class MemberService {
                 memberProfileUpdateRequest.getHeight(),
                 Mbti.valueOf(memberProfileUpdateRequest.getMbti()),
                 memberProfileUpdateRequest.getAddress(),
-                Gender.find(memberProfileUpdateRequest.getGender()),
                 memberProfileUpdateRequest.getCollege(),
                 SmokeStatus.find(memberProfileUpdateRequest.getSmokeStatus()),
                 DrinkStatus.find(memberProfileUpdateRequest.getDrinkStatus()),

--- a/src/main/java/com/cupid/jikting/team/controller/TeamController.java
+++ b/src/main/java/com/cupid/jikting/team/controller/TeamController.java
@@ -29,9 +29,9 @@ public class TeamController {
         return ResponseEntity.ok().build();
     }
 
-    @GetMapping("/{teamId}")
-    public ResponseEntity<TeamResponse> get(@AuthorizedVariable Long memberProfileId, @PathVariable Long teamId) {
-        return ResponseEntity.ok().body(teamService.get(memberProfileId, teamId));
+    @GetMapping
+    public ResponseEntity<TeamResponse> get(@AuthorizedVariable Long memberProfileId) {
+        return ResponseEntity.ok().body(teamService.get(memberProfileId));
     }
 
     @PatchMapping("/{teamId}")

--- a/src/main/java/com/cupid/jikting/team/controller/TeamController.java
+++ b/src/main/java/com/cupid/jikting/team/controller/TeamController.java
@@ -30,8 +30,8 @@ public class TeamController {
     }
 
     @GetMapping("/{teamId}")
-    public ResponseEntity<TeamResponse> get(@PathVariable Long teamId) {
-        return ResponseEntity.ok().body(teamService.get(teamId));
+    public ResponseEntity<TeamResponse> get(@AuthorizedVariable Long memberProfileId, @PathVariable Long teamId) {
+        return ResponseEntity.ok().body(teamService.get(memberProfileId, teamId));
     }
 
     @PatchMapping("/{teamId}")

--- a/src/main/java/com/cupid/jikting/team/service/TeamService.java
+++ b/src/main/java/com/cupid/jikting/team/service/TeamService.java
@@ -59,7 +59,7 @@ public class TeamService {
     }
 
     @Transactional(readOnly = true)
-    public TeamResponse get(Long memberProfileId, Long teamId) {
+    public TeamResponse get(Long memberProfileId) {
         return TeamResponse.from(getMemberProfileById(memberProfileId).getTeam());
     }
 

--- a/src/main/java/com/cupid/jikting/team/service/TeamService.java
+++ b/src/main/java/com/cupid/jikting/team/service/TeamService.java
@@ -59,8 +59,8 @@ public class TeamService {
     }
 
     @Transactional(readOnly = true)
-    public TeamResponse get(Long teamId) {
-        return TeamResponse.from(getTeamById(teamId));
+    public TeamResponse get(Long memberProfileId, Long teamId) {
+        return TeamResponse.from(getMemberProfileById(memberProfileId).getTeam());
     }
 
     public void update(Long teamId, TeamUpdateRequest teamUpdateRequest) {

--- a/src/test/java/com/cupid/jikting/chatting/controller/ChattingRoomControllerTest.java
+++ b/src/test/java/com/cupid/jikting/chatting/controller/ChattingRoomControllerTest.java
@@ -15,9 +15,7 @@ import com.cupid.jikting.common.error.ApplicationException;
 import com.cupid.jikting.common.error.NotFoundException;
 import com.cupid.jikting.common.error.WrongFormException;
 import com.cupid.jikting.jwt.service.JwtService;
-import com.cupid.jikting.meeting.entity.Meeting;
 import com.cupid.jikting.member.entity.*;
-import com.cupid.jikting.team.entity.Team;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -105,7 +103,7 @@ public class ChattingRoomControllerTest extends ApiDocument {
                 .personality(personality)
                 .build();
         MemberProfile memberProfile = member.getMemberProfile();
-        memberProfile.updateProfile(BIRTH, HEIGHT, Mbti.ENFJ, ADDRESS, Gender.MALE, COLLEGE, SmokeStatus.SMOKING, DrinkStatus.OFTEN, DESCRIPTION,
+        memberProfile.updateProfile(BIRTH, HEIGHT, Mbti.ENFJ, ADDRESS, COLLEGE, SmokeStatus.SMOKING, DrinkStatus.OFTEN, DESCRIPTION,
                 List.of(memberPersonality), List.of(memberHobby));
         meetingConfirmRequest = MeetingConfirmRequest.builder()
                 .meetingId(ID)

--- a/src/test/java/com/cupid/jikting/chatting/service/ChattingRoomServiceTest.java
+++ b/src/test/java/com/cupid/jikting/chatting/service/ChattingRoomServiceTest.java
@@ -110,7 +110,7 @@ class ChattingRoomServiceTest {
         Member member = Member.builder().build();
         member.addMemberProfile(NICKNAME);
         memberProfile = member.getMemberProfile();
-        memberProfile.updateProfile(LocalDate.of(YEAR, MONTH, DATE), HEIGHT, Mbti.ENFJ, ADDRESS, Gender.MALE, COLLEGE, SmokeStatus.SMOKING, DrinkStatus.OFTEN, DESCRIPTION,
+        memberProfile.updateProfile(LocalDate.of(YEAR, MONTH, DATE), HEIGHT, Mbti.ENFJ, ADDRESS, COLLEGE, SmokeStatus.SMOKING, DrinkStatus.OFTEN, DESCRIPTION,
                 List.of(memberPersonality), List.of(memberHobby));
         TeamMember.of(LEADER, team, memberProfile);
         chattingRoom = ChattingRoom.builder()

--- a/src/test/java/com/cupid/jikting/like/controller/LikeControllerTest.java
+++ b/src/test/java/com/cupid/jikting/like/controller/LikeControllerTest.java
@@ -116,7 +116,7 @@ public class LikeControllerTest extends ApiDocument {
                 .sequence(Sequence.MAIN)
                 .url(URL)
                 .build();
-        memberProfile.updateProfile(BIRTH, HEIGHT, Mbti.ENFJ, ADDRESS, Gender.MALE, COLLEGE, SmokeStatus.SMOKING, DrinkStatus.OFTEN, DESCRIPTION,
+        memberProfile.updateProfile(BIRTH, HEIGHT, Mbti.ENFJ, ADDRESS, COLLEGE, SmokeStatus.SMOKING, DrinkStatus.OFTEN, DESCRIPTION,
                 memberPersonalities, memberHobbies);
         List<MemberProfileResponse> memberProfileResponses = IntStream.rangeClosed(1, 2)
                 .mapToObj(n -> MemberProfileResponse.from(memberProfile))

--- a/src/test/java/com/cupid/jikting/like/service/LikeServiceTest.java
+++ b/src/test/java/com/cupid/jikting/like/service/LikeServiceTest.java
@@ -103,7 +103,7 @@ class LikeServiceTest {
         MemberProfile memberProfile = MemberProfile.builder()
                 .member(member)
                 .build();
-        memberProfile.updateProfile(LocalDate.of(YEAR, MONTH, DATE), HEIGHT, Mbti.ENFJ, ADDRESS, Gender.MALE, COLLEGE, SmokeStatus.SMOKING, DrinkStatus.OFTEN, DESCRIPTION,
+        memberProfile.updateProfile(LocalDate.of(YEAR, MONTH, DATE), HEIGHT, Mbti.ENFJ, ADDRESS, COLLEGE, SmokeStatus.SMOKING, DrinkStatus.OFTEN, DESCRIPTION,
                 List.of(memberPersonality), List.of(memberHobby));
         Team sentTeam = Team.builder()
                 .id(ID)

--- a/src/test/java/com/cupid/jikting/meeting/service/InstantMeetingServiceTest.java
+++ b/src/test/java/com/cupid/jikting/meeting/service/InstantMeetingServiceTest.java
@@ -37,19 +37,15 @@ public class InstantMeetingServiceTest {
     private static final Long ID = 1L;
     private static final LocalDateTime SCHEDULE = LocalDateTime.of(2023, Month.JUNE, 30, 18, 0);
     private static final String PLACE = "장소";
-
+    @InjectMocks
+    InstantMeetingService instantMeetingService;
+    @Mock
+    InstantMeetingRepository instantMeetingRepository;
+    @Mock
+    MemberProfileRepository memberProfileRepository;
     private List<InstantMeeting> instantMeetings;
     private MemberProfile memberProfile;
     private InstantMeeting instantMeeting;
-
-    @InjectMocks
-    InstantMeetingService instantMeetingService;
-
-    @Mock
-    InstantMeetingRepository instantMeetingRepository;
-
-    @Mock
-    MemberProfileRepository memberProfileRepository;
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -136,6 +136,7 @@ public class MemberControllerTest extends ApiDocument {
                         .build())
                 .collect(Collectors.toList());
         Member member = Member.builder()
+                .gender(Gender.MALE)
                 .build();
         member.addMemberProfile(NICKNAME);
         ProfileImage profileImage = ProfileImage.builder()
@@ -144,7 +145,7 @@ public class MemberControllerTest extends ApiDocument {
                 .url(IMAGE_URL)
                 .build();
         MemberProfile memberProfile = member.getMemberProfile();
-        memberProfile.updateProfile(BIRTH, HEIGHT, Mbti.ENFJ, ADDRESS, Gender.MALE, COLLEGE, SmokeStatus.SMOKING, DrinkStatus.OFTEN, DESCRIPTION,
+        memberProfile.updateProfile(BIRTH, HEIGHT, Mbti.ENFJ, ADDRESS, COLLEGE, SmokeStatus.SMOKING, DrinkStatus.OFTEN, DESCRIPTION,
                 memberPersonalities, memberHobbies);
         MemberCompany memberCompany = MemberCompany.builder()
                 .member(member)
@@ -180,7 +181,6 @@ public class MemberControllerTest extends ApiDocument {
         MemberProfileUpdateRequest memberProfileUpdateRequest = MemberProfileUpdateRequest.builder()
                 .birth(BIRTH)
                 .height(HEIGHT)
-                .gender(Gender.MALE.getMessage())
                 .address(ADDRESS)
                 .mbti(Mbti.ENFJ.name())
                 .drinkStatus(DrinkStatus.OFTEN.getMessage())

--- a/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
+++ b/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
@@ -127,7 +127,7 @@ public class MemberServiceTest {
                         .build())
                 .collect(Collectors.toList());
         memberProfile = member.getMemberProfile();
-        memberProfile.updateProfile(BIRTH, HEIGHT, Mbti.ENFJ, ADDRESS, Gender.MALE, COLLEGE, SmokeStatus.SMOKING, DrinkStatus.OFTEN, DESCRIPTION,
+        memberProfile.updateProfile(BIRTH, HEIGHT, Mbti.ENFJ, ADDRESS, COLLEGE, SmokeStatus.SMOKING, DrinkStatus.OFTEN, DESCRIPTION,
                 memberPersonalities, memberHobbies);
         signupRequest = SignupRequest.builder()
                 .username(USERNAME)
@@ -296,7 +296,6 @@ public class MemberServiceTest {
         MemberProfileUpdateRequest memberProfileUpdateRequest = MemberProfileUpdateRequest.builder()
                 .birth(BIRTH)
                 .height(HEIGHT)
-                .gender(Gender.MALE.getMessage())
                 .address(ADDRESS)
                 .mbti(Mbti.ENFJ.name())
                 .drinkStatus(DrinkStatus.OFTEN.getMessage())
@@ -329,7 +328,6 @@ public class MemberServiceTest {
         MemberProfileUpdateRequest memberProfileUpdateRequest = MemberProfileUpdateRequest.builder()
                 .birth(BIRTH)
                 .height(HEIGHT)
-                .gender(Gender.MALE.getMessage())
                 .address(ADDRESS)
                 .mbti(Mbti.ENFJ.name())
                 .drinkStatus(DrinkStatus.OFTEN.getMessage())
@@ -359,7 +357,6 @@ public class MemberServiceTest {
         MemberProfileUpdateRequest memberProfileUpdateRequest = MemberProfileUpdateRequest.builder()
                 .birth(BIRTH)
                 .height(HEIGHT)
-                .gender(Gender.MALE.getMessage())
                 .address(ADDRESS)
                 .mbti(Mbti.ENFJ.name())
                 .drinkStatus(DrinkStatus.OFTEN.getMessage())
@@ -390,7 +387,6 @@ public class MemberServiceTest {
         MemberProfileUpdateRequest memberProfileUpdateRequest = MemberProfileUpdateRequest.builder()
                 .birth(BIRTH)
                 .height(HEIGHT)
-                .gender(Gender.MALE.getMessage())
                 .address(ADDRESS)
                 .mbti(Mbti.ENFJ.name())
                 .drinkStatus(DrinkStatus.OFTEN.getMessage())

--- a/src/test/java/com/cupid/jikting/recommend/controller/RecommendControllerTest.java
+++ b/src/test/java/com/cupid/jikting/recommend/controller/RecommendControllerTest.java
@@ -105,7 +105,7 @@ public class RecommendControllerTest extends ApiDocument {
                 .member(member)
                 .nickname(NICKNAME)
                 .build();
-        memberProfile.updateProfile(BIRTH, HEIGHT, Mbti.ENFJ, ADDRESS, Gender.MALE, COLLEGE, SmokeStatus.SMOKING, DrinkStatus.OFTEN, DESCRIPTION,
+        memberProfile.updateProfile(BIRTH, HEIGHT, Mbti.ENFJ, ADDRESS, COLLEGE, SmokeStatus.SMOKING, DrinkStatus.OFTEN, DESCRIPTION,
                 List.of(memberPersonality), List.of(memberHobby));
         List<MemberResponse> memberResponses = IntStream.rangeClosed(0, 2)
                 .mapToObj(n -> MemberResponse.from(memberProfile))

--- a/src/test/java/com/cupid/jikting/team/controller/TeamControllerTest.java
+++ b/src/test/java/com/cupid/jikting/team/controller/TeamControllerTest.java
@@ -185,7 +185,7 @@ public class TeamControllerTest extends ApiDocument {
     @Test
     void 팀_조회_성공() throws Exception {
         //given
-        willReturn(teamResponse).given(teamService).get(anyLong(), anyLong());
+        willReturn(teamResponse).given(teamService).get(anyLong());
         //when
         ResultActions resultActions = 팀_조회_요청();
         //then
@@ -196,7 +196,7 @@ public class TeamControllerTest extends ApiDocument {
     @Test
     void 팀_조회_실패() throws Exception {
         //given
-        willThrow(teamNotFoundException).given(teamService).get(anyLong(), anyLong());
+        willThrow(teamNotFoundException).given(teamService).get(anyLong());
         //when
         ResultActions resultActions = 팀_조회_요청();
         //then

--- a/src/test/java/com/cupid/jikting/team/controller/TeamControllerTest.java
+++ b/src/test/java/com/cupid/jikting/team/controller/TeamControllerTest.java
@@ -322,7 +322,7 @@ public class TeamControllerTest extends ApiDocument {
     }
 
     private ResultActions 팀_조회_요청() throws Exception {
-        return mockMvc.perform(get(CONTEXT_PATH + DOMAIN_ROOT_PATH + PATH_DELIMITER + ID)
+        return mockMvc.perform(get(CONTEXT_PATH + DOMAIN_ROOT_PATH)
                 .contextPath(CONTEXT_PATH));
     }
 

--- a/src/test/java/com/cupid/jikting/team/controller/TeamControllerTest.java
+++ b/src/test/java/com/cupid/jikting/team/controller/TeamControllerTest.java
@@ -185,7 +185,7 @@ public class TeamControllerTest extends ApiDocument {
     @Test
     void 팀_조회_성공() throws Exception {
         //given
-        willReturn(teamResponse).given(teamService).get(anyLong());
+        willReturn(teamResponse).given(teamService).get(anyLong(), anyLong());
         //when
         ResultActions resultActions = 팀_조회_요청();
         //then
@@ -196,7 +196,7 @@ public class TeamControllerTest extends ApiDocument {
     @Test
     void 팀_조회_실패() throws Exception {
         //given
-        willThrow(teamNotFoundException).given(teamService).get(anyLong());
+        willThrow(teamNotFoundException).given(teamService).get(anyLong(), anyLong());
         //when
         ResultActions resultActions = 팀_조회_요청();
         //then

--- a/src/test/java/com/cupid/jikting/team/controller/TeamControllerTest.java
+++ b/src/test/java/com/cupid/jikting/team/controller/TeamControllerTest.java
@@ -117,7 +117,7 @@ public class TeamControllerTest extends ApiDocument {
         IntStream.range(0, 3)
                 .mapToObj(n -> {
                     MemberProfile memberProfile = member.getMemberProfile();
-                    memberProfile.updateProfile(BIRTH, HEIGHT, Mbti.ENFJ, ADDRESS, Gender.MALE, COLLEGE, SmokeStatus.SMOKING, DrinkStatus.OFTEN, DESCRIPTION,
+                    memberProfile.updateProfile(BIRTH, HEIGHT, Mbti.ENFJ, ADDRESS, COLLEGE, SmokeStatus.SMOKING, DrinkStatus.OFTEN, DESCRIPTION,
                             List.of(MemberPersonality.builder().build()), List.of(MemberHobby.builder().build()));
                     return memberProfile;
                 })

--- a/src/test/java/com/cupid/jikting/team/service/TeamServiceTest.java
+++ b/src/test/java/com/cupid/jikting/team/service/TeamServiceTest.java
@@ -101,9 +101,9 @@ class TeamServiceTest {
                         .personality(personality)
                         .build())
                 .collect(Collectors.toList());
-        leader.updateProfile(BIRTH, HEIGHT, Mbti.ENFJ, ADDRESS, Gender.MALE, COLLEGE, SmokeStatus.NONSMOKING, DrinkStatus.OFTEN, DESCRIPTION,
+        leader.updateProfile(BIRTH, HEIGHT, Mbti.ENFJ, ADDRESS, COLLEGE, SmokeStatus.NONSMOKING, DrinkStatus.OFTEN, DESCRIPTION,
                 List.of(MemberPersonality.builder().build()), List.of(MemberHobby.builder().build()));
-        memberProfile.updateProfile(BIRTH, HEIGHT, Mbti.ENFJ, ADDRESS, Gender.MALE, COLLEGE, SmokeStatus.NONSMOKING, DrinkStatus.OFTEN, DESCRIPTION,
+        memberProfile.updateProfile(BIRTH, HEIGHT, Mbti.ENFJ, ADDRESS, COLLEGE, SmokeStatus.NONSMOKING, DrinkStatus.OFTEN, DESCRIPTION,
                 List.of(MemberPersonality.builder().build()), List.of(MemberHobby.builder().build()));
         team = Team.builder()
                 .id(ID)

--- a/src/test/java/com/cupid/jikting/team/service/TeamServiceTest.java
+++ b/src/test/java/com/cupid/jikting/team/service/TeamServiceTest.java
@@ -225,7 +225,7 @@ class TeamServiceTest {
         // given
         willReturn(Optional.of(memberProfile)).given(memberProfileRepository).findById(anyLong());
         // when
-        TeamResponse teamResponse = teamService.get(ID, ID);
+        TeamResponse teamResponse = teamService.get(ID);
         // then
         assertAll(
                 () -> verify(memberProfileRepository).findById(anyLong()),
@@ -240,7 +240,7 @@ class TeamServiceTest {
         // given
         willThrow(new NotFoundException(ApplicationError.MEMBER_NOT_FOUND)).given(memberProfileRepository).findById(anyLong());
         // when & then
-        assertThatThrownBy(() -> teamService.get(ID, ID))
+        assertThatThrownBy(() -> teamService.get(ID))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage(ApplicationError.MEMBER_NOT_FOUND.getMessage());
     }

--- a/src/test/java/com/cupid/jikting/team/service/TeamServiceTest.java
+++ b/src/test/java/com/cupid/jikting/team/service/TeamServiceTest.java
@@ -223,12 +223,12 @@ class TeamServiceTest {
     @Test
     void 팀_조회_성공() {
         // given
-        willReturn(Optional.of(team)).given(teamRepository).findById(anyLong());
+        willReturn(Optional.of(memberProfile)).given(memberProfileRepository).findById(anyLong());
         // when
-        TeamResponse teamResponse = teamService.get(ID);
+        TeamResponse teamResponse = teamService.get(ID, ID);
         // then
         assertAll(
-                () -> verify(teamRepository).findById(anyLong()),
+                () -> verify(memberProfileRepository).findById(anyLong()),
                 () -> assertThat(teamResponse.getDescription()).isEqualTo(DESCRIPTION),
                 () -> assertThat(teamResponse.getKeywords().size()).isEqualTo(teamPersonalities.size()),
                 () -> assertThat(teamResponse.getMembers().size()).isEqualTo(team.getTeamMembers().size())
@@ -236,13 +236,13 @@ class TeamServiceTest {
     }
 
     @Test
-    void 팀_조회_실패_팀_없음() {
+    void 팀_조회_실패_회원_없음() {
         // given
-        willThrow(new NotFoundException(ApplicationError.TEAM_NOT_FOUND)).given(teamRepository).findById(anyLong());
+        willThrow(new NotFoundException(ApplicationError.MEMBER_NOT_FOUND)).given(memberProfileRepository).findById(anyLong());
         // when & then
-        assertThatThrownBy(() -> teamService.get(ID))
+        assertThatThrownBy(() -> teamService.get(ID, ID))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessage(ApplicationError.TEAM_NOT_FOUND.getMessage());
+                .hasMessage(ApplicationError.MEMBER_NOT_FOUND.getMessage());
     }
 
     @Test


### PR DESCRIPTION
## Issue

closed #210 
[SP-331](https://soma-cupid.atlassian.net/browse/SP-331?atlOrigin=eyJpIjoiZWUzN2Y4ZDZmNWVlNDA2ZmIxNzhkZDcxMmU3YmUxMDMiLCJwIjoiaiJ9)

## 요구사항

- [x] 팀 정보 조회 api 수정

## 변경사항

- `index.adoc` 호감 넘기기 추가
- `Member` addMemberProfile 메소드 MemberProfile 생성 시 성별 추가
- `MemberProfileUpdateRequest` 성별 필드 삭제

## 리뷰 우선순위

🙂보통

[SP-331]: https://soma-cupid.atlassian.net/browse/SP-331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ