### PR TITLE
[SP-353] 로그인 시 멤버 PK 반환 로직 추가

### DIFF
--- a/src/main/java/com/cupid/jikting/common/config/SecurityConfig.java
+++ b/src/main/java/com/cupid/jikting/common/config/SecurityConfig.java
@@ -87,7 +87,7 @@ public class SecurityConfig {
         configuration.setAllowedMethods(List.of(
                 HttpMethod.GET.name(), HttpMethod.POST.name(), HttpMethod.PUT.name(), HttpMethod.DELETE.name(), HttpMethod.PATCH.name(), HttpMethod.OPTIONS.name()));
         configuration.setAllowCredentials(true);
-        configuration.setExposedHeaders(List.of("Authorization", "Authorization-refresh"));
+        configuration.setExposedHeaders(List.of("Authorization", "Authorization-refresh", "MemberProfileId"));
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;

--- a/src/main/java/com/cupid/jikting/member/handler/LoginSuccessHandler.java
+++ b/src/main/java/com/cupid/jikting/member/handler/LoginSuccessHandler.java
@@ -21,6 +21,7 @@ import java.time.Duration;
 @RequiredArgsConstructor
 public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
+    private static final String MEMBER_PROFILE_ID_HEADER_NAME = "MemberProfileId";
     private final JwtService jwtService;
     private final MemberRepository memberRepository;
     private final RedisConnector redisConnector;
@@ -36,6 +37,7 @@ public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
         String refreshToken = jwtService.createRefreshToken();
         jwtService.sendAccessAndRefreshToken(response, accessToken, refreshToken);
         redisConnector.set(refreshToken, username, Duration.ofMillis(refreshTokenExpirationPeriod));
+        response.addHeader(MEMBER_PROFILE_ID_HEADER_NAME, String.valueOf(jwtService.extractValidMemberProfileId(accessToken)));
         log.info("로그인에 성공하였습니다. 아이디 : {} AccessToken : {}", username, accessToken);
     }
 


### PR DESCRIPTION
## Issue

closed #212 
[SP-353](https://soma-cupid.atlassian.net/browse/SP-353?atlOrigin=eyJpIjoiZDkzY2VlMjU3MzM5NGU1YmFiZTMxYWZlZTRlOGE4NjgiLCJwIjoiaiJ9)

## 요구사항

- [x] 로그인 시 멤버 PK 반환 로직 추가

## 변경사항

- `LoginSuccessHandler` response에 멤버프로필 아이디 헤더 추가
- `SecurityConfig` 멤버프로필 아이디 헤더 응답 설정 추가

## 리뷰 우선순위

🙂보통

[SP-353]: https://soma-cupid.atlassian.net/browse/SP-353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ