### PR TITLE
[SP-367] 팀 등록 에러 수정

### DIFF
--- a/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
+++ b/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
@@ -69,7 +69,7 @@ public class MemberProfile extends BaseEntity {
     private MemberHobbies memberHobbies = new MemberHobbies();
 
     @Builder.Default
-    @OneToMany(mappedBy = "memberProfile", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
+    @OneToMany(mappedBy = "memberProfile")
     private List<TeamMember> teamMembers = new ArrayList<>();
 
     @Builder.Default

--- a/src/main/java/com/cupid/jikting/team/entity/Team.java
+++ b/src/main/java/com/cupid/jikting/team/entity/Team.java
@@ -33,7 +33,7 @@ public class Team extends BaseEntity {
     private TeamPersonalities teamPersonalities = new TeamPersonalities();
 
     @Builder.Default
-    @OneToMany(mappedBy = "team")
+    @OneToMany(mappedBy = "team", cascade = CascadeType.PERSIST)
     private List<TeamMember> teamMembers = new ArrayList<>();
 
     @Builder.Default

--- a/src/main/java/com/cupid/jikting/team/service/TeamService.java
+++ b/src/main/java/com/cupid/jikting/team/service/TeamService.java
@@ -48,8 +48,8 @@ public class TeamService {
                 .build();
         team.addTeamPersonalities(toTeamPersonalities(toPersonalities(teamRegisterRequest.getKeywords()), team));
         TeamMember.of(LEADER, team, memberProfile);
-        MemberProfile savedMemberProfile = memberProfileRepository.save(memberProfile);
-        return TeamRegisterResponse.from(TEAM_URL + savedMemberProfile.getTeamId() + INVITE);
+        Team savedTeam = teamRepository.save(team);
+        return TeamRegisterResponse.from(TEAM_URL + savedTeam.getId() + INVITE);
     }
 
     public void attend(Long teamId, Long memberProfileId) {

--- a/src/test/java/com/cupid/jikting/team/service/TeamServiceTest.java
+++ b/src/test/java/com/cupid/jikting/team/service/TeamServiceTest.java
@@ -129,14 +129,14 @@ class TeamServiceTest {
                 .build();
         willReturn(Optional.of(memberProfile)).given(memberProfileRepository).findById(anyLong());
         willReturn(Optional.of(personality)).given(personalityRepository).findByKeyword(anyString());
-        willReturn(leader).given(memberProfileRepository).save(any(MemberProfile.class));
+        willReturn(team).given(teamRepository).save(any(Team.class));
         // when
         TeamRegisterResponse teamRegisterResponse = teamService.register(ID, teamRegisterRequest);
         // then
         assertAll(
                 () -> verify(memberProfileRepository).findById(anyLong()),
                 () -> verify(personalityRepository).findByKeyword(anyString()),
-                () -> verify(memberProfileRepository).save(any(MemberProfile.class)),
+                () -> verify(teamRepository).save(any(Team.class)),
                 () -> assertThat(teamRegisterResponse.getInvitationUrl()).isEqualTo(INVITATION_URL)
         );
     }


### PR DESCRIPTION
## Issue

closed #230 
[SP-367](https://soma-cupid.atlassian.net/browse/SP-367?atlOrigin=eyJpIjoiNTQ3NWI4MzNhNDI3NDcwNWIxODJhZDhjZGVjZjJkZmYiLCJwIjoiaiJ9)

## 요구사항

- [x] 팀 등록 에러 수정

## 변경사항

- `TeamService` 등록 로직 MemberProfile 저장 -> Team 저장하도록 로직 수정
- `MemberProfile` TeamMember 필드 영속성 전이 속성 삭제 및 `Team` TeamMember 필드 영속성 전이 속성 추가

## 리뷰 우선순위

🙂보통

[SP-367]: https://soma-cupid.atlassian.net/browse/SP-367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ