### PR TITLE
[SP-357] 팀원 삭제 memberId -> memberProileId로 변경

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -508,7 +508,7 @@ include::{snippets}/delete-team-fail/http-response.adoc[]
 
 ==== 팀원 삭제
 ----
-/v1/teams/{teamId}/members/{memberId}
+/v1/teams/{teamId}/members/{memberProfileId}
 ----
 ===== 성공
 .request

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -92,8 +92,8 @@ public class MemberService {
         memberProfile.updatePassword(passwordEncoder.encode(passwordUpdateRequest.getNewPassword()));
     }
 
-    public void withdraw(Long memberId, WithdrawRequest withdrawRequest) {
-        Member member = getMemberProfileById(memberId).getMember();
+    public void withdraw(Long memberProfileId, WithdrawRequest withdrawRequest) {
+        Member member = getMemberProfileById(memberProfileId).getMember();
         member.validatePassword(passwordEncoder, withdrawRequest.getPassword());
         memberRepository.delete(member);
     }

--- a/src/main/java/com/cupid/jikting/recommend/dto/ImageResponse.java
+++ b/src/main/java/com/cupid/jikting/recommend/dto/ImageResponse.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 public class ImageResponse {
 
     private String sequence;
-    private Long memberId;
+    private Long memberProfileId;
     private String url;
 
     public static ImageResponse from(ProfileImage profileImage) {

--- a/src/main/java/com/cupid/jikting/team/controller/TeamController.java
+++ b/src/main/java/com/cupid/jikting/team/controller/TeamController.java
@@ -46,9 +46,9 @@ public class TeamController {
         return ResponseEntity.ok().build();
     }
 
-    @DeleteMapping("/{teamId}/members/{memberId}")
-    public ResponseEntity<Void> deleteMember(@PathVariable Long teamId, @PathVariable Long memberId) {
-        teamService.deleteMember(teamId, memberId);
+    @DeleteMapping("/{teamId}/members/{memberProfileId}")
+    public ResponseEntity<Void> deleteMember(@PathVariable Long teamId, @PathVariable Long memberProfileId) {
+        teamService.deleteMember(teamId, memberProfileId);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/cupid/jikting/team/service/TeamService.java
+++ b/src/main/java/com/cupid/jikting/team/service/TeamService.java
@@ -73,7 +73,7 @@ public class TeamService {
         teamRepository.delete(getTeamById(teamId));
     }
 
-    public void deleteMember(Long teamId, Long memberId) {
+    public void deleteMember(Long teamId, Long memberProfileId) {
     }
 
     private MemberProfile getMemberProfileById(Long memberProfileId) {


### PR DESCRIPTION
## Issue

closed #236 
[SP-357](https://soma-cupid.atlassian.net/browse/SP-357?atlOrigin=eyJpIjoiYzhiNTE3OGZmOGFhNGY5ZThlYWJiMTc0MjAyMmJmZGQiLCJwIjoiaiJ9)

## 요구사항

- [x] 팀원 삭제 memberId -> memberProileId로 변경

## 변경사항

- `MemberService` 회원 탈퇴 메소드 회원 프로필 아이디 파라미터 네이밍 수정

## 리뷰 우선순위

🙂보통

[SP-357]: https://soma-cupid.atlassian.net/browse/SP-357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ