### PR TITLE
[SP-355] Team 엔티티 성별 필드 추가

### DIFF
--- a/src/main/java/com/cupid/jikting/team/entity/Team.java
+++ b/src/main/java/com/cupid/jikting/team/entity/Team.java
@@ -2,6 +2,7 @@ package com.cupid.jikting.team.entity;
 
 import com.cupid.jikting.common.entity.BaseEntity;
 import com.cupid.jikting.meeting.entity.Meeting;
+import com.cupid.jikting.member.entity.Gender;
 import com.cupid.jikting.member.entity.MemberProfile;
 import com.cupid.jikting.recommend.entity.Recommend;
 import lombok.*;
@@ -27,6 +28,9 @@ public class Team extends BaseEntity {
     private String name;
     private String description;
     private int memberCount;
+
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
 
     @Builder.Default
     @Embedded

--- a/src/main/java/com/cupid/jikting/team/service/TeamService.java
+++ b/src/main/java/com/cupid/jikting/team/service/TeamService.java
@@ -45,6 +45,7 @@ public class TeamService {
                 .name(String.valueOf(UUID.randomUUID()))
                 .description(teamRegisterRequest.getDescription())
                 .memberCount(teamRegisterRequest.getMemberCount())
+                .gender(memberProfile.getGender())
                 .build();
         team.addTeamPersonalities(toTeamPersonalities(toPersonalities(teamRegisterRequest.getKeywords()), team));
         TeamMember.of(LEADER, team, memberProfile);

--- a/src/test/java/com/cupid/jikting/team/repository/TeamRepositoryTest.java
+++ b/src/test/java/com/cupid/jikting/team/repository/TeamRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.cupid.jikting.team.repository;
 
 import com.cupid.jikting.common.repository.PersonalityRepository;
+import com.cupid.jikting.member.entity.Gender;
 import com.cupid.jikting.team.entity.Team;
 import com.cupid.jikting.team.entity.TeamPersonality;
 import org.junit.jupiter.api.Test;
@@ -35,6 +36,7 @@ class TeamRepositoryTest {
                 .name(NAME)
                 .memberCount(MEMBER_COUNT)
                 .description(DESCRIPTION)
+                .gender(Gender.MALE)
                 .build();
         List<TeamPersonality> teamPersonalities = personalityRepository.findAll()
                 .stream()
@@ -51,6 +53,7 @@ class TeamRepositoryTest {
                 () -> assertThat(savedTeam.getName()).isEqualTo(NAME),
                 () -> assertThat(savedTeam.getMemberCount()).isEqualTo(MEMBER_COUNT),
                 () -> assertThat(savedTeam.getDescription()).isEqualTo(DESCRIPTION),
+                () -> assertThat(savedTeam.getGender()).isEqualTo(Gender.MALE),
                 () -> assertThat(savedTeam.getTeamPersonalities().size()).isEqualTo(teamPersonalities.size())
         );
     }


### PR DESCRIPTION
## Issue

closed #238 
[SP-355](https://soma-cupid.atlassian.net/browse/SP-355?atlOrigin=eyJpIjoiYzdkN2RlNmI4NjE4NDhiMWE5ZjZiNWIxMmQwOWQ2NTAiLCJwIjoiaiJ9)

## 요구사항

- [x] Team 엔티티 성별 필드 추가

## 변경사항

- `TeamService` 팀 등록 로직 성별 필드 추가
- `TeamRepositoryTest` 팀 등록 성별 필드 추가

## 리뷰 우선순위

🙂보통

[SP-355]: https://soma-cupid.atlassian.net/browse/SP-355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ