### PR TITLE
[SP-391] 같은 회사 차단 api 명세서 작성

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -420,6 +420,23 @@ include::{snippets}/login-fail/http-request.adoc[]
 .response
 include::{snippets}/login-fail/http-response.adoc[]
 
+==== 회사 차단
+----
+/v1/members/company/block
+----
+===== 성공
+.request
+include::{snippets}/block-company-success/http-request.adoc[]
+
+.response
+include::{snippets}/block-company-success/http-response.adoc[]
+===== 실패
+.request
+include::{snippets}/block-company-fail/http-request.adoc[]
+
+.response
+include::{snippets}/block-company-fail/http-response.adoc[]
+
 === 팀 관련 기능
 ==== 팀 등록
 ----

--- a/src/main/java/com/cupid/jikting/common/error/ApplicationError.java
+++ b/src/main/java/com/cupid/jikting/common/error/ApplicationError.java
@@ -23,7 +23,7 @@ public enum ApplicationError {
     WRONG_ACCESS(HttpStatus.BAD_REQUEST, "C013", "잘못된 접근입니다."),
 
     UNAUTHORIZED_MEMBER(HttpStatus.UNAUTHORIZED, "U001", "인증되지 않은 사용자입니다."),
-    FORBIDDEN_MEMBER(HttpStatus.FORBIDDEN, "U002", "권한이 없는 사용자입니다."),
+    FORBIDDEN_MEMBER(HttpStatus.BAD_REQUEST, "U002", "권한이 없는 사용자입니다."),
     MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "U003", "사용자를 찾을 수 없습니다."),
     DUPLICATE_USERNAME(HttpStatus.BAD_REQUEST, "U004", "해당 아이디가 이미 존재합니다."),
     DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "U005", "해당 닉네임이 이미 존재합니다."),
@@ -37,7 +37,6 @@ public enum ApplicationError {
     INVALID_DRINK_STATUS(HttpStatus.BAD_REQUEST, "U012", "지원하지 않는 음주 상태입니다."),
     HOBBY_NOT_FOUND(HttpStatus.BAD_REQUEST, "U013", "취미 키워드를 찾을 수 없습니다."),
     PROFILE_IMAGE_NOT_FOUND(HttpStatus.BAD_REQUEST, "U014", "프로필 이미지를 찾을 수 없습니다."),
-    COMPANY_NOT_FOUND(HttpStatus.BAD_REQUEST, "U015", "회사 인증되지 않은 사용자 입니다."),
 
     TEAM_NOT_FOUND(HttpStatus.BAD_REQUEST, "T001", "팀을 찾을 수 없습니다."),
     GENDER_MISMATCH(HttpStatus.BAD_REQUEST, "T002", "해당 성별은 팀에 참여할 수 없습니다."),

--- a/src/main/java/com/cupid/jikting/common/error/ApplicationError.java
+++ b/src/main/java/com/cupid/jikting/common/error/ApplicationError.java
@@ -23,7 +23,7 @@ public enum ApplicationError {
     WRONG_ACCESS(HttpStatus.BAD_REQUEST, "C013", "잘못된 접근입니다."),
 
     UNAUTHORIZED_MEMBER(HttpStatus.UNAUTHORIZED, "U001", "인증되지 않은 사용자입니다."),
-    FORBIDDEN_MEMBER(HttpStatus.BAD_REQUEST, "U002", "권한이 없는 사용자입니다."),
+    FORBIDDEN_MEMBER(HttpStatus.FORBIDDEN, "U002", "권한이 없는 사용자입니다."),
     MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "U003", "사용자를 찾을 수 없습니다."),
     DUPLICATE_USERNAME(HttpStatus.BAD_REQUEST, "U004", "해당 아이디가 이미 존재합니다."),
     DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "U005", "해당 닉네임이 이미 존재합니다."),

--- a/src/main/java/com/cupid/jikting/common/error/ApplicationError.java
+++ b/src/main/java/com/cupid/jikting/common/error/ApplicationError.java
@@ -37,6 +37,7 @@ public enum ApplicationError {
     INVALID_DRINK_STATUS(HttpStatus.BAD_REQUEST, "U012", "지원하지 않는 음주 상태입니다."),
     HOBBY_NOT_FOUND(HttpStatus.BAD_REQUEST, "U013", "취미 키워드를 찾을 수 없습니다."),
     PROFILE_IMAGE_NOT_FOUND(HttpStatus.BAD_REQUEST, "U014", "프로필 이미지를 찾을 수 없습니다."),
+    COMPANY_NOT_FOUND(HttpStatus.BAD_REQUEST, "U015", "회사 정보를 찾을 수 없습니다."),
 
     TEAM_NOT_FOUND(HttpStatus.BAD_REQUEST, "T001", "팀을 찾을 수 없습니다."),
     GENDER_MISMATCH(HttpStatus.BAD_REQUEST, "T002", "해당 성별은 팀에 참여할 수 없습니다."),

--- a/src/main/java/com/cupid/jikting/common/error/ApplicationError.java
+++ b/src/main/java/com/cupid/jikting/common/error/ApplicationError.java
@@ -37,7 +37,7 @@ public enum ApplicationError {
     INVALID_DRINK_STATUS(HttpStatus.BAD_REQUEST, "U012", "지원하지 않는 음주 상태입니다."),
     HOBBY_NOT_FOUND(HttpStatus.BAD_REQUEST, "U013", "취미 키워드를 찾을 수 없습니다."),
     PROFILE_IMAGE_NOT_FOUND(HttpStatus.BAD_REQUEST, "U014", "프로필 이미지를 찾을 수 없습니다."),
-    COMPANY_NOT_FOUND(HttpStatus.BAD_REQUEST, "U015", "회사 정보를 찾을 수 없습니다."),
+    COMPANY_NOT_FOUND(HttpStatus.BAD_REQUEST, "U015", "회사 인증되지 않은 사용자 입니다."),
 
     TEAM_NOT_FOUND(HttpStatus.BAD_REQUEST, "T001", "팀을 찾을 수 없습니다."),
     GENDER_MISMATCH(HttpStatus.BAD_REQUEST, "T002", "해당 성별은 팀에 참여할 수 없습니다."),

--- a/src/main/java/com/cupid/jikting/member/controller/MemberController.java
+++ b/src/main/java/com/cupid/jikting/member/controller/MemberController.java
@@ -142,4 +142,10 @@ public class MemberController {
         memberService.login(loginRequest);
         return ResponseEntity.ok().build();
     }
+
+    @PatchMapping("/company/block")
+    public ResponseEntity<Void> blockCompany(@AuthorizedVariable Long memberProfileId) {
+        memberService.blockCompany(memberProfileId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/cupid/jikting/member/controller/MemberController.java
+++ b/src/main/java/com/cupid/jikting/member/controller/MemberController.java
@@ -143,7 +143,7 @@ public class MemberController {
         return ResponseEntity.ok().build();
     }
 
-    @PatchMapping("/company/block")
+    @PostMapping("/company/block")
     public ResponseEntity<Void> blockCompany(@AuthorizedVariable Long memberProfileId) {
         memberService.blockCompany(memberProfileId);
         return ResponseEntity.ok().build();

--- a/src/main/java/com/cupid/jikting/member/entity/MemberCompany.java
+++ b/src/main/java/com/cupid/jikting/member/entity/MemberCompany.java
@@ -21,6 +21,8 @@ import javax.persistence.*;
 @Entity
 public class MemberCompany extends BaseEntity {
 
+    private boolean isBlock;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -144,6 +144,9 @@ public class MemberService {
     public void login(LoginRequest loginRequest) {
     }
 
+    public void blockCompany(Long memberProfileId) {
+    }
+
     private MemberProfile getMemberProfileById(Long memberProfileId) {
         return memberProfileRepository.findById(memberProfileId)
                 .orElseThrow(() -> new NotFoundException(ApplicationError.MEMBER_NOT_FOUND));
@@ -177,8 +180,5 @@ public class MemberService {
     private Hobby getHobbyByKeyword(String keyword) {
         return hobbyRepository.findByKeyword(keyword)
                 .orElseThrow(() -> new NotFoundException(ApplicationError.HOBBY_NOT_FOUND));
-    }
-
-    public void blockCompany(Long memberProfileId) {
     }
 }

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -178,4 +178,7 @@ public class MemberService {
         return hobbyRepository.findByKeyword(keyword)
                 .orElseThrow(() -> new NotFoundException(ApplicationError.HOBBY_NOT_FOUND));
     }
+
+    public void blockCompany(Long memberProfileId) {
+    }
 }

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -103,6 +103,7 @@ public class MemberControllerTest extends ApiDocument {
     private ApplicationException duplicatedUsernameException;
     private ApplicationException duplicatedNicknameException;
     private ApplicationException verificationCodeExpiredException;
+    private ApplicationException companyNotFoundException;
 
     @MockBean
     private JwtService jwtService;
@@ -252,6 +253,7 @@ public class MemberControllerTest extends ApiDocument {
         duplicatedUsernameException = new DuplicateException(ApplicationError.DUPLICATE_USERNAME);
         duplicatedNicknameException = new DuplicateException(ApplicationError.DUPLICATE_NICKNAME);
         verificationCodeExpiredException = new BadRequestException(ApplicationError.VERIFICATION_CODE_EXPIRED);
+        companyNotFoundException = new NotFoundException(ApplicationError.COMPANY_NOT_FOUND);
     }
 
     @Test
@@ -737,6 +739,28 @@ public class MemberControllerTest extends ApiDocument {
         로그인_요청_실패(resultActions);
     }
 
+    @WithMockUser
+    @Test
+    void 같은_회사_차단_성공() throws Exception {
+        //given
+        willDoNothing().given(memberService).blockCompany(anyLong());
+        //when
+        ResultActions resultActions = 같은_회사_차단_요청();
+        //then
+        같은_회사_차단_요청_성공(resultActions);
+    }
+
+    @WithMockUser
+    @Test
+    void 같은_회사_차단_실패() throws Exception {
+        //given
+        willThrow(companyNotFoundException).given(memberService).blockCompany(anyLong());
+        //when
+        ResultActions resultActions = 같은_회사_차단_요청();
+        //then
+        같은_회사_차단_요청_실패(resultActions);
+    }
+
     private ResultActions 회원_가입_요청() throws Exception {
         return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH)
                 .contextPath(CONTEXT_PATH)
@@ -1187,5 +1211,24 @@ public class MemberControllerTest extends ApiDocument {
                         .andExpect(status().isBadRequest())
                         .andExpect(content().json(toJson(ErrorResponse.from(idOrPasswordNotEqualException)))),
                 "login-fail");
+    }
+
+    private ResultActions 같은_회사_차단_요청() throws Exception {
+        return mockMvc.perform(patch(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/company/block")
+                .contextPath(CONTEXT_PATH)
+                .contentType(MediaType.APPLICATION_JSON));
+    }
+
+    private void 같은_회사_차단_요청_성공(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isOk()),
+                "block-company-success");
+    }
+
+    private void 같은_회사_차단_요청_실패(ResultActions resultActions) throws Exception {
+        printAndMakeSnippet(resultActions
+                        .andExpect(status().isBadRequest())
+                        .andExpect(content().json(toJson(ErrorResponse.from(companyNotFoundException)))),
+                "block-company-fail");
     }
 }

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -1214,9 +1214,8 @@ public class MemberControllerTest extends ApiDocument {
     }
 
     private ResultActions 같은_회사_차단_요청() throws Exception {
-        return mockMvc.perform(patch(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/company/block")
-                .contextPath(CONTEXT_PATH)
-                .contentType(MediaType.APPLICATION_JSON));
+        return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/company/block")
+                .contextPath(CONTEXT_PATH));
     }
 
     private void 같은_회사_차단_요청_성공(ResultActions resultActions) throws Exception {

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -253,7 +253,7 @@ public class MemberControllerTest extends ApiDocument {
         duplicatedUsernameException = new DuplicateException(ApplicationError.DUPLICATE_USERNAME);
         duplicatedNicknameException = new DuplicateException(ApplicationError.DUPLICATE_NICKNAME);
         verificationCodeExpiredException = new BadRequestException(ApplicationError.VERIFICATION_CODE_EXPIRED);
-        companyNotFoundException = new NotFoundException(ApplicationError.COMPANY_NOT_FOUND);
+        companyNotFoundException = new BadRequestException(ApplicationError.FORBIDDEN_MEMBER);
     }
 
     @Test

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -741,24 +741,24 @@ public class MemberControllerTest extends ApiDocument {
 
     @WithMockUser
     @Test
-    void 같은_회사_차단_성공() throws Exception {
+    void 재직중인_회사_차단_성공() throws Exception {
         //given
         willDoNothing().given(memberService).blockCompany(anyLong());
         //when
-        ResultActions resultActions = 같은_회사_차단_요청();
+        ResultActions resultActions = 재직중인_회사_차단_요청();
         //then
-        같은_회사_차단_요청_성공(resultActions);
+        재직중인_회사_차단_요청_성공(resultActions);
     }
 
     @WithMockUser
     @Test
-    void 같은_회사_차단_실패() throws Exception {
+    void 재직중인_회사_차단_실패() throws Exception {
         //given
         willThrow(companyNotFoundException).given(memberService).blockCompany(anyLong());
         //when
-        ResultActions resultActions = 같은_회사_차단_요청();
+        ResultActions resultActions = 재직중인_회사_차단_요청();
         //then
-        같은_회사_차단_요청_실패(resultActions);
+        재직중인_회사_차단_요청_실패(resultActions);
     }
 
     private ResultActions 회원_가입_요청() throws Exception {
@@ -1213,20 +1213,20 @@ public class MemberControllerTest extends ApiDocument {
                 "login-fail");
     }
 
-    private ResultActions 같은_회사_차단_요청() throws Exception {
+    private ResultActions 재직중인_회사_차단_요청() throws Exception {
         return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/company/block")
                 .contextPath(CONTEXT_PATH));
     }
 
-    private void 같은_회사_차단_요청_성공(ResultActions resultActions) throws Exception {
+    private void 재직중인_회사_차단_요청_성공(ResultActions resultActions) throws Exception {
         printAndMakeSnippet(resultActions
                         .andExpect(status().isOk()),
                 "block-company-success");
     }
 
-    private void 같은_회사_차단_요청_실패(ResultActions resultActions) throws Exception {
+    private void 재직중인_회사_차단_요청_실패(ResultActions resultActions) throws Exception {
         printAndMakeSnippet(resultActions
-                        .andExpect(status().isBadRequest())
+                        .andExpect(status().isForbidden())
                         .andExpect(content().json(toJson(ErrorResponse.from(companyNotFoundException)))),
                 "block-company-fail");
     }


### PR DESCRIPTION
## Issue

closed #244 
[SP-391](https://soma-cupid.atlassian.net/browse/SP-391?atlOrigin=eyJpIjoiMTI4OTZmOGE5NTIxNGVjMzk2OWY3NzgwY2Q0ZDcwNzEiLCJwIjoiaiJ9)

## 요구사항

- [x]  같은 회사 차단 api 명세서 작성

## 변경사항

- `MemberCompany` 엔티티에 isBlock 필드 추가

## 리뷰 우선순위

🙂보통

## 코멘트

- 1차 출시때는 현재 다니고 있는 회사만 차단할 수 있게 구현할 예정입니다.
- 추후에 서비스 가입 후 인증 했던 회사 목록을 보여주고 차단할 회사를 선택하도록 바꾸면 좋을 것 같습니다.

[SP-391]: https://soma-cupid.atlassian.net/browse/SP-391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ