### PR TITLE
[SP-373] 아이디 찾기 인증번호 인증 API 추가

### DIFF
--- a/src/main/java/com/cupid/jikting/common/config/SecurityConfig.java
+++ b/src/main/java/com/cupid/jikting/common/config/SecurityConfig.java
@@ -65,6 +65,7 @@ public class SecurityConfig {
                 .mvcMatchers("/members/code").permitAll()
                 .mvcMatchers("/members/verification").permitAll()
                 .mvcMatchers("/members/username/search/code").permitAll()
+                .mvcMatchers("/members/username/search/verification").permitAll()
                 .mvcMatchers("/ws/**").permitAll()
                 .anyRequest().authenticated()
                 .and()

--- a/src/main/java/com/cupid/jikting/member/dto/UsernameResponse.java
+++ b/src/main/java/com/cupid/jikting/member/dto/UsernameResponse.java
@@ -1,12 +1,19 @@
 package com.cupid.jikting.member.dto;
 
-import lombok.*;
+import com.cupid.jikting.member.entity.Member;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UsernameResponse {
 
     private String username;
+
+    public static UsernameResponse from(Member member) {
+        return new UsernameResponse(member.getUsername());
+    }
 }

--- a/src/main/java/com/cupid/jikting/member/dto/VerificationRequest.java
+++ b/src/main/java/com/cupid/jikting/member/dto/VerificationRequest.java
@@ -8,5 +8,6 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class VerificationRequest {
 
+    private String phone;
     private String verificationCode;
 }

--- a/src/main/java/com/cupid/jikting/member/entity/Member.java
+++ b/src/main/java/com/cupid/jikting/member/entity/Member.java
@@ -21,10 +21,13 @@ public class Member extends BaseEntity {
 
     private String username;
     private String password;
-    private String phone;
+
     private String name;
     private String type;
     private String socialId;
+
+    @Column(unique = true)
+    private String phone;
 
     @Enumerated(EnumType.STRING)
     private Gender gender;

--- a/src/main/java/com/cupid/jikting/member/entity/Member.java
+++ b/src/main/java/com/cupid/jikting/member/entity/Member.java
@@ -21,7 +21,6 @@ public class Member extends BaseEntity {
 
     private String username;
     private String password;
-
     private String name;
     private String type;
     private String socialId;

--- a/src/main/java/com/cupid/jikting/member/repository/MemberRepository.java
+++ b/src/main/java/com/cupid/jikting/member/repository/MemberRepository.java
@@ -15,4 +15,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByNameAndPhone(String name, String phone);
 
     Optional<Member> findBySocialTypeAndSocialId(SocialType socialType, String socialId);
+
+    Optional<Member> findByPhone(String phone);
 }

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -144,7 +144,10 @@ public class MemberService {
     }
 
     public UsernameResponse verifyForSearchUsername(VerificationRequest verificationRequest) {
-        return null;
+        validateVerificationCode(verificationRequest.getPhone(), verificationRequest.getVerificationCode());
+        return memberRepository.findByPhoneOrderByCreatedAtDesc(verificationRequest.getPhone())
+                .map(UsernameResponse::from)
+                .orElseThrow(() -> new NotFoundException(ApplicationError.MEMBER_NOT_FOUND));
     }
 
     public void createVerificationCodeForResetPassword(PasswordResetVerificationCodeRequest passwordResetVerificationCodeRequest) {
@@ -204,5 +207,11 @@ public class MemberService {
     private Hobby getHobbyByKeyword(String keyword) {
         return hobbyRepository.findByKeyword(keyword)
                 .orElseThrow(() -> new NotFoundException(ApplicationError.HOBBY_NOT_FOUND));
+    }
+
+    private void validateVerificationCode(String phone, String verificationCode) {
+        if (!redisConnector.get(phone).equals(verificationCode)) {
+            throw new BadRequestException(ApplicationError.VERIFICATION_CODE_NOT_EQUAL);
+        }
     }
 }

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -125,9 +125,7 @@ public class MemberService {
     }
 
     public void verifyPhoneForSignup(PhoneVerificationRequest verificationRequest) {
-        if (!redisConnector.get(verificationRequest.getPhone()).equals(verificationRequest.getVerificationCode())) {
-            throw new BadRequestException(ApplicationError.VERIFICATION_CODE_NOT_EQUAL);
-        }
+        validateVerificationCode(verificationRequest.getPhone(), verificationRequest.getVerificationCode());
     }
 
     public void createVerificationCodeForSearchUsername(UsernameSearchVerificationCodeRequest usernameSearchVerificationCodeRequest)

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -143,7 +143,7 @@ public class MemberService {
 
     public UsernameResponse verifyForSearchUsername(VerificationRequest verificationRequest) {
         validateVerificationCode(verificationRequest.getPhone(), verificationRequest.getVerificationCode());
-        return memberRepository.findByPhoneOrderByCreatedAtDesc(verificationRequest.getPhone())
+        return memberRepository.findByPhone(verificationRequest.getPhone())
                 .map(UsernameResponse::from)
                 .orElseThrow(() -> new NotFoundException(ApplicationError.MEMBER_NOT_FOUND));
     }

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -133,6 +133,7 @@ public class MemberControllerTest extends ApiDocument {
                         .build())
                 .collect(Collectors.toList());
         Member member = Member.builder()
+                .username(USERNAME)
                 .gender(Gender.MALE)
                 .build();
         member.addMemberProfile(NICKNAME);
@@ -235,9 +236,7 @@ public class MemberControllerTest extends ApiDocument {
                 .build();
         memberResponse = MemberResponse.of(memberProfile);
         memberProfileResponse = MemberProfileResponse.of(memberProfile);
-        usernameResponse = UsernameResponse.builder()
-                .username(USERNAME)
-                .build();
+        usernameResponse = UsernameResponse.from(member);
         companyVerificationRequestPart = new MockMultipartFile(COMPANY_VERIFICATION_REQUEST_PARAMETER_NAME, COMPANY_VERIFICATION_REQUEST_FILENAME, COMPANY_VERIFICATION_CONTENT_TYPE, toJson(companyVerificationRequest).getBytes(StandardCharsets.UTF_8));
         image = new MockMultipartFile(IMAGE_PARAMETER_NAME, IMAGE_FILENAME, IMAGE_CONTENT_TYPE, IMAGE_FILE.getBytes());
         invalidFormatException = new BadRequestException(ApplicationError.INVALID_FORMAT);

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -213,6 +213,7 @@ public class MemberControllerTest extends ApiDocument {
                 .verificationCode(VERIFICATION_CODE)
                 .build();
         verificationRequest = VerificationRequest.builder()
+                .phone(PHONE)
                 .verificationCode(VERIFICATION_CODE)
                 .build();
         passwordResetVerificationCodeRequest = PasswordResetVerificationCodeRequest.builder()

--- a/src/test/java/com/cupid/jikting/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/cupid/jikting/member/repository/MemberRepositoryTest.java
@@ -7,6 +7,7 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -15,7 +16,8 @@ public class MemberRepositoryTest {
     private static final String USERNAME = "username123";
     private static final String PASSWORD = "Password123!";
     private static final String NAME = "홍길동";
-    private static final String PHONE = "01000000000";
+    private static final String PHONE = "전화번호";
+    private static final String WRONG_PHONE = "잘못된 전화번호";
 
     @Autowired
     private MemberRepository memberRepository;
@@ -34,5 +36,19 @@ public class MemberRepositoryTest {
         memberRepository.delete(member);
         // then
         assertThat(memberRepository.findById(savedMember.getId())).isEmpty();
+    }
+
+    @Test
+    void 전화번호로_회원_조회_성공() {
+        // given
+        Member member = Member.builder()
+                .username(USERNAME)
+                .password(PASSWORD)
+                .name(NAME)
+                .phone(PHONE)
+                .build();
+        memberRepository.save(member);
+        // when & then
+        assertDoesNotThrow(() -> memberRepository.findByPhone(PHONE));
     }
 }

--- a/src/test/java/com/cupid/jikting/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/cupid/jikting/member/repository/MemberRepositoryTest.java
@@ -6,6 +6,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
+import java.util.Optional;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
@@ -50,5 +52,21 @@ public class MemberRepositoryTest {
         memberRepository.save(member);
         // when & then
         assertDoesNotThrow(() -> memberRepository.findByPhone(PHONE));
+    }
+
+    @Test
+    void 전화번호로_회원_조회_실패() {
+        // given
+        Member member = Member.builder()
+                .username(USERNAME)
+                .password(PASSWORD)
+                .name(NAME)
+                .phone(PHONE)
+                .build();
+        memberRepository.save(member);
+        // when
+        Optional<Member> memberFoundByPhone = memberRepository.findByPhone(WRONG_PHONE);
+        // then
+        assertThat(memberFoundByPhone).isEmpty();
     }
 }

--- a/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
+++ b/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
@@ -597,4 +597,18 @@ public class MemberServiceTest {
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage(ApplicationError.VERIFICATION_CODE_EXPIRED.getMessage());
     }
+
+    @Test
+    void 아이디찾기_인증번호_인증_실패_회원_없음() {
+        // given
+        VerificationRequest verificationRequest = VerificationRequest.builder()
+                .phone(PHONE)
+                .verificationCode(VERIFICATION_CODE)
+                .build();
+        willThrow(new NotFoundException(ApplicationError.MEMBER_NOT_FOUND)).given(redisConnector).get(anyString());
+        // when & then
+        assertThatThrownBy(() -> memberService.verifyForSearchUsername(verificationRequest))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage(ApplicationError.MEMBER_NOT_FOUND.getMessage());
+    }
 }

--- a/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
+++ b/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
@@ -551,4 +551,22 @@ public class MemberServiceTest {
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage(ApplicationError.VERIFICATION_CODE_EXPIRED.getMessage());
     }
+
+    @Test
+    void 아이디찾기_인증번호_인증_성공() {
+        // given
+        VerificationRequest verificationRequest = VerificationRequest.builder()
+                .phone(PHONE)
+                .verificationCode(VERIFICATION_CODE)
+                .build();
+        willReturn(VERIFICATION_CODE).given(redisConnector).get(anyString());
+        willReturn(Optional.of(member)).given(memberRepository).findByPhone(anyString());
+        // when
+        memberService.verifyForSearchUsername(verificationRequest);
+        // then
+        assertAll(
+                () -> verify(redisConnector).get(anyString()),
+                () -> verify(memberRepository).findByPhone(anyString())
+        );
+    }
 }

--- a/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
+++ b/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
@@ -569,4 +569,18 @@ public class MemberServiceTest {
                 () -> verify(memberRepository).findByPhone(anyString())
         );
     }
+
+    @Test
+    void 아이디찾기_인증번호_인증_실패_인증번호_불일치() {
+        // given
+        VerificationRequest verificationRequest = VerificationRequest.builder()
+                .phone(PHONE)
+                .verificationCode(VERIFICATION_CODE)
+                .build();
+        willReturn(WRONG_VERIFICATION_CODE).given(redisConnector).get(anyString());
+        // when & then
+        assertThatThrownBy(() -> memberService.verifyForSearchUsername(verificationRequest))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(ApplicationError.VERIFICATION_CODE_NOT_EQUAL.getMessage());
+    }
 }

--- a/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
+++ b/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
@@ -583,4 +583,18 @@ public class MemberServiceTest {
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage(ApplicationError.VERIFICATION_CODE_NOT_EQUAL.getMessage());
     }
+
+    @Test
+    void 아이디찾기_인증번호_인증_실패_인증번호_만료() {
+        // given
+        VerificationRequest verificationRequest = VerificationRequest.builder()
+                .phone(PHONE)
+                .verificationCode(VERIFICATION_CODE)
+                .build();
+        willThrow(new BadRequestException(ApplicationError.VERIFICATION_CODE_EXPIRED)).given(redisConnector).get(anyString());
+        // when & then
+        assertThatThrownBy(() -> memberService.verifyForSearchUsername(verificationRequest))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(ApplicationError.VERIFICATION_CODE_EXPIRED.getMessage());
+    }
 }


### PR DESCRIPTION
## Issue

closed #253 
[SP-373](https://soma-cupid.atlassian.net/browse/SP-373?atlOrigin=eyJpIjoiNTkxYWJiOThmZTRjNDFjMDgyMGM4NDc2NGZlZDIxYTYiLCJwIjoiaiJ9)

## 요구사항

- [x] 아이디 찾기 인증번호 인증 API 추가

## 변경사항

- `Member` 전화번호 unique 설정 추가
- `UsernameResponse` 빌더 패턴 삭제 및 정적 팩토리 메소드 적용

## 리뷰 우선순위

🙂보통

[SP-373]: https://soma-cupid.atlassian.net/browse/SP-373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ