### PR TITLE
[SP-375] 비밀번호 재설정 인증번호 인증 API 추가

### DIFF
--- a/src/main/java/com/cupid/jikting/member/dto/SendSmsRequest.java
+++ b/src/main/java/com/cupid/jikting/member/dto/SendSmsRequest.java
@@ -1,12 +1,18 @@
 package com.cupid.jikting.member.dto;
 
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SendSmsRequest {
 
     private String to;
+
+    public static SendSmsRequest from(String phone) {
+        return new SendSmsRequest(phone);
+    }
 }

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -163,6 +163,7 @@ public class MemberService {
     }
 
     public void verifyForResetPassword(VerificationRequest verificationRequest) {
+        validateVerificationCode(verificationRequest.getPhone(), verificationRequest.getVerificationCode());
     }
 
     public void resetPassword(PasswordResetRequest passwordResetRequest) {

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -2,7 +2,10 @@ package com.cupid.jikting.member.service;
 
 import com.cupid.jikting.common.entity.Hobby;
 import com.cupid.jikting.common.entity.Personality;
-import com.cupid.jikting.common.error.*;
+import com.cupid.jikting.common.error.ApplicationError;
+import com.cupid.jikting.common.error.BadRequestException;
+import com.cupid.jikting.common.error.DuplicateException;
+import com.cupid.jikting.common.error.NotFoundException;
 import com.cupid.jikting.common.repository.PersonalityRepository;
 import com.cupid.jikting.common.service.RedisConnector;
 import com.cupid.jikting.member.dto.*;
@@ -28,8 +31,6 @@ import java.util.stream.Collectors;
 @Transactional
 @Service
 public class MemberService {
-
-    private static final String SMS_SEND_SUCCESS = "202";
 
     private final FileUploadService fileUploadService;
     private final SmsService smsService;
@@ -117,12 +118,7 @@ public class MemberService {
 
     public void createVerificationCodeForSignup(SignUpVerificationCodeRequest signUpVerificationCodeRequest)
             throws JsonProcessingException, UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException {
-        SendSmsRequest sendSmsRequest = SendSmsRequest.builder()
-                .to(signUpVerificationCodeRequest.getPhone())
-                .build();
-        if (!smsService.sendSms(sendSmsRequest).getStatusCode().equals(SMS_SEND_SUCCESS)) {
-            throw new SmsSendFailException(ApplicationError.SMS_SEND_FAIL);
-        }
+        smsService.sendSms(SendSmsRequest.from(signUpVerificationCodeRequest.getPhone()));
     }
 
     public void verifyPhoneForSignup(PhoneVerificationRequest verificationRequest) {
@@ -134,12 +130,7 @@ public class MemberService {
         if (!memberRepository.existsByNameAndPhone(usernameSearchVerificationCodeRequest.getName(), usernameSearchVerificationCodeRequest.getPhone())) {
             throw new NotFoundException(ApplicationError.MEMBER_NOT_FOUND);
         }
-        SendSmsRequest sendSmsRequest = SendSmsRequest.builder()
-                .to(usernameSearchVerificationCodeRequest.getPhone())
-                .build();
-        if (!smsService.sendSms(sendSmsRequest).getStatusCode().equals(SMS_SEND_SUCCESS)) {
-            throw new SmsSendFailException(ApplicationError.SMS_SEND_FAIL);
-        }
+        smsService.sendSms(SendSmsRequest.from(usernameSearchVerificationCodeRequest.getPhone()));
     }
 
     public UsernameResponse verifyForSearchUsername(VerificationRequest verificationRequest) {
@@ -154,12 +145,7 @@ public class MemberService {
         if (!memberRepository.existsByUsernameAndNameAndPhone(passwordResetVerificationCodeRequest.getUsername(), passwordResetVerificationCodeRequest.getName(), passwordResetVerificationCodeRequest.getPhone())) {
             throw new NotFoundException(ApplicationError.MEMBER_NOT_FOUND);
         }
-        SendSmsRequest sendSmsRequest = SendSmsRequest.builder()
-                .to(passwordResetVerificationCodeRequest.getPhone())
-                .build();
-        if (!smsService.sendSms(sendSmsRequest).getStatusCode().equals(SMS_SEND_SUCCESS)) {
-            throw new SmsSendFailException(ApplicationError.SMS_SEND_FAIL);
-        }
+        smsService.sendSms(SendSmsRequest.from(passwordResetVerificationCodeRequest.getPhone()));
     }
 
     public void verifyForResetPassword(VerificationRequest verificationRequest) {

--- a/src/main/java/com/cupid/jikting/member/service/SmsService.java
+++ b/src/main/java/com/cupid/jikting/member/service/SmsService.java
@@ -1,7 +1,6 @@
 package com.cupid.jikting.member.service;
 
 import com.cupid.jikting.member.dto.SendSmsRequest;
-import com.cupid.jikting.member.dto.SmsResponse;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 import java.io.UnsupportedEncodingException;
@@ -10,5 +9,5 @@ import java.security.NoSuchAlgorithmException;
 
 public interface SmsService {
 
-    SmsResponse sendSms(SendSmsRequest sendSmsRequest) throws JsonProcessingException, NoSuchAlgorithmException, UnsupportedEncodingException, InvalidKeyException;
+    void sendSms(SendSmsRequest sendSmsRequest) throws JsonProcessingException, NoSuchAlgorithmException, UnsupportedEncodingException, InvalidKeyException;
 }

--- a/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
+++ b/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
@@ -633,7 +633,7 @@ public class MemberServiceTest {
                 .statusCode(SMS_SEND_SUCCESS)
                 .build();
         willReturn(true).given(memberRepository).existsByUsernameAndNameAndPhone(anyString(), anyString(), anyString());
-        willReturn(smsResponse).given(smsService).sendSms(any(SendSmsRequest.class));
+        willDoNothing().given(smsService).sendSms(any(SendSmsRequest.class));
         // when & then
         assertAll(
                 () -> assertDoesNotThrow(() -> memberService.createVerificationCodeForResetPassword(passwordResetVerificationCodeRequest)),

--- a/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
+++ b/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
@@ -656,4 +656,18 @@ public class MemberServiceTest {
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage(ApplicationError.MEMBER_NOT_FOUND.getMessage());
     }
+
+    @Test
+    void 비밀번호_재설정_인증번호_인증_성공() {
+        // given
+        VerificationRequest verificationRequest = VerificationRequest.builder()
+                .phone(PHONE)
+                .verificationCode(VERIFICATION_CODE)
+                .build();
+        willReturn(VERIFICATION_CODE).given(redisConnector).get(anyString());
+        // when
+        memberService.verifyForResetPassword(verificationRequest);
+        // then
+        verify(redisConnector).get(anyString());
+    }
 }

--- a/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
+++ b/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
@@ -670,4 +670,18 @@ public class MemberServiceTest {
         // then
         verify(redisConnector).get(anyString());
     }
+
+    @Test
+    void 비밀번호_재설정_인증번호_인증_실패_인증번호_불일치() {
+        // given
+        VerificationRequest verificationRequest = VerificationRequest.builder()
+                .phone(PHONE)
+                .verificationCode(VERIFICATION_CODE)
+                .build();
+        willReturn(WRONG_VERIFICATION_CODE).given(redisConnector).get(anyString());
+        // when & then
+        assertThatThrownBy(() -> memberService.verifyForResetPassword(verificationRequest))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(ApplicationError.VERIFICATION_CODE_NOT_EQUAL.getMessage());
+    }
 }

--- a/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
+++ b/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
@@ -684,4 +684,18 @@ public class MemberServiceTest {
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage(ApplicationError.VERIFICATION_CODE_NOT_EQUAL.getMessage());
     }
+
+    @Test
+    void 비밀번호_재설정_인증번호_인증_실패_인증번호_만료() {
+        // given
+        VerificationRequest verificationRequest = VerificationRequest.builder()
+                .phone(PHONE)
+                .verificationCode(VERIFICATION_CODE)
+                .build();
+        willThrow(new BadRequestException(ApplicationError.VERIFICATION_CODE_EXPIRED)).given(redisConnector).get(anyString());
+        // when & then
+        assertThatThrownBy(() -> memberService.verifyForResetPassword(verificationRequest))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(ApplicationError.VERIFICATION_CODE_EXPIRED.getMessage());
+    }
 }


### PR DESCRIPTION
## Issue

closed #263 
[SP-375](https://soma-cupid.atlassian.net/browse/SP-375?atlOrigin=eyJpIjoiMzJhYTY5M2VhM2I3NDFiYWFmOTI2Yzc1NTY2NzA4YmUiLCJwIjoiaiJ9)

## 요구사항

- [x] 비밀번호 재설정 인증번호 인증 API 추가

## 변경사항

- `NCPSmsService` sendSms() 반환 타입 void로 수정 및 API 요청 결과 확인 로직 추가
    - `MemberService` SmsService.sendSms() 호출부 결과 확인 로직 삭제

## 리뷰 우선순위

🙂보통

[SP-375]: https://soma-cupid.atlassian.net/browse/SP-375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ