### PR TITLE
[SP-376] 비밀번호 재설정 API 추가

### DIFF
--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -166,6 +166,9 @@ public class MemberService {
     }
 
     public void resetPassword(PasswordResetRequest passwordResetRequest) {
+        Member member = getMemberByUsername(passwordResetRequest.getUsername());
+        member.updatePassword(passwordResetRequest.getPassword());
+        memberRepository.save(member);
     }
 
     public void createVerificationCodeForCompany(CompanyVerificationCodeRequest companyVerificationCodeRequest) {
@@ -222,5 +225,10 @@ public class MemberService {
         if (!redisConnector.get(phone).equals(verificationCode)) {
             throw new BadRequestException(ApplicationError.VERIFICATION_CODE_NOT_EQUAL);
         }
+    }
+
+    private Member getMemberByUsername(String username) {
+        return memberRepository.findByUsername(username)
+                .orElseThrow(() -> new NotFoundException(ApplicationError.MEMBER_NOT_FOUND));
     }
 }

--- a/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
+++ b/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
@@ -656,4 +656,22 @@ public class MemberServiceTest {
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage(ApplicationError.MEMBER_NOT_FOUND.getMessage());
     }
+
+    @Test
+    void 비밀번호_재설정_성공() {
+        // given
+        PasswordResetRequest passwordResetRequest = PasswordResetRequest.builder()
+                .username(USERNAME)
+                .password(PASSWORD)
+                .build();
+        willReturn(Optional.of(member)).given(memberRepository).findByUsername(anyString());
+        willReturn(member).given(memberRepository).save(any(Member.class));
+        // when
+        memberService.resetPassword(passwordResetRequest);
+        // then
+        assertAll(
+                () -> verify(memberRepository).findByUsername(anyString()),
+                () -> verify(memberRepository).save(any(Member.class))
+        );
+    }
 }

--- a/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
+++ b/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
@@ -674,4 +674,18 @@ public class MemberServiceTest {
                 () -> verify(memberRepository).save(any(Member.class))
         );
     }
+
+    @Test
+    void 비밀번호_재설정_실패_회원_없음() {
+        // given
+        PasswordResetRequest passwordResetRequest = PasswordResetRequest.builder()
+                .username(USERNAME)
+                .password(PASSWORD)
+                .build();
+        willReturn(Optional.empty()).given(memberRepository).findByUsername(anyString());
+        // when & then
+        assertThatThrownBy(() -> memberService.resetPassword(passwordResetRequest))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage(ApplicationError.MEMBER_NOT_FOUND.getMessage());
+    }
 }


### PR DESCRIPTION
## Issue

closed #265 
[SP-376](https://soma-cupid.atlassian.net/browse/SP-376?atlOrigin=eyJpIjoiZjI3MWY4YzA2ZDJmNDVkMDk2ODRjMGE4ZjE0NzA3MzYiLCJwIjoiaiJ9)

## 요구사항

- [x] 비밀번호 재설정 API 추가

## 변경사항

- X

## 리뷰 우선순위

🙂보통

## 코멘트

- 서비스에서 조회 실패 테스트에서 레포지토리 모킹할 때 `willThrow()`를 이용해서 예외를 터트렸었는데, 레포지토리에서는 빈 Optional 객체를 반환하고 그걸 받아와서 서비스 단에서 예외를 터트리는 게 더 정확한 것 같아서 해당 이슈 테스트 코드 작성 시 `willReturn(Optional.empty()0`를 사용했습니다.
    <img width="707" alt="스크린샷 2023-09-14 오후 4 21 35" src="https://github.com/SWM-Cupid/jikting-backend/assets/62989828/19e6f4ae-8938-4f91-a68a-2f3e90950a89">


[SP-376]: https://soma-cupid.atlassian.net/browse/SP-376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ