### PR TITLE
[SP-407] 마이페이지 프로필 조회 응답 DTO 수정

### DIFF
--- a/src/main/java/com/cupid/jikting/member/dto/MemberProfileResponse.java
+++ b/src/main/java/com/cupid/jikting/member/dto/MemberProfileResponse.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -15,7 +16,7 @@ import java.util.stream.Collectors;
 public class MemberProfileResponse {
 
     private List<ImageResponse> images;
-    private int age;
+    private LocalDate birth;
     private int height;
     private String gender;
     private String address;
@@ -34,7 +35,7 @@ public class MemberProfileResponse {
                 .collect(Collectors.toList());
         return new MemberProfileResponse(
                 images,
-                memberProfile.getAge(),
+                memberProfile.getBirth(),
                 memberProfile.getHeight(),
                 memberProfile.getGender().getMessage(),
                 memberProfile.getAddress(),

--- a/src/main/java/com/cupid/jikting/member/dto/MemberProfileResponse.java
+++ b/src/main/java/com/cupid/jikting/member/dto/MemberProfileResponse.java
@@ -18,7 +18,6 @@ public class MemberProfileResponse {
     private List<ImageResponse> images;
     private LocalDate birth;
     private int height;
-    private String gender;
     private String address;
     private String mbti;
     private String smokeStatus;
@@ -37,7 +36,6 @@ public class MemberProfileResponse {
                 images,
                 memberProfile.getBirth(),
                 memberProfile.getHeight(),
-                memberProfile.getGender().getMessage(),
                 memberProfile.getAddress(),
                 memberProfile.getMbti().name(),
                 memberProfile.getSmokeStatus().getMessage(),

--- a/src/test/java/com/cupid/jikting/chatting/service/ChattingRoomServiceTest.java
+++ b/src/test/java/com/cupid/jikting/chatting/service/ChattingRoomServiceTest.java
@@ -141,7 +141,7 @@ class ChattingRoomServiceTest {
         // when
         List<ChattingRoomResponse> chattingRoomResponses = chattingRoomService.getAll(ID);
         // then
-        assertThat(chattingRoomResponses.size()).isEqualTo(chattingRooms.size());
+        assertThat(chattingRoomResponses).hasSize(chattingRooms.size());
     }
 
     @Test
@@ -172,9 +172,9 @@ class ChattingRoomServiceTest {
                 () -> verify(redisConnector).getMessages(anyString()),
                 () -> assertThat(chattingRoomDetailResponse.getName()).isEqualTo(NAME),
                 () -> assertThat(chattingRoomDetailResponse.getDescription()).isEqualTo(DESCRIPTION),
-                () -> assertThat(chattingRoomDetailResponse.getKeywords().size()).isEqualTo(chattingRoom.getOppositeTeamKeywords(memberProfile.getTeam()).size()),
-                () -> assertThat(chattingRoomDetailResponse.getMembers().size()).isEqualTo(chattingRoom.getMemberProfiles().size()),
-                () -> assertThat(chattingRoomDetailResponse.getChattings().size()).isEqualTo(chattings.size())
+                () -> assertThat(chattingRoomDetailResponse.getKeywords()).hasSize(chattingRoom.getOppositeTeamKeywords(memberProfile.getTeam()).size()),
+                () -> assertThat(chattingRoomDetailResponse.getMembers()).hasSize(chattingRoom.getMemberProfiles().size()),
+                () -> assertThat(chattingRoomDetailResponse.getChattings()).hasSize(chattings.size())
         );
     }
 

--- a/src/test/java/com/cupid/jikting/like/service/LikeServiceTest.java
+++ b/src/test/java/com/cupid/jikting/like/service/LikeServiceTest.java
@@ -141,7 +141,7 @@ class LikeServiceTest {
         // then
         assertAll(
                 () -> verify(teamMemberRepository).getTeamMemberByMemberProfileId(anyLong()),
-                () -> assertThat(likeResponses.size()).isEqualTo(teamLikes.size())
+                () -> assertThat(likeResponses).hasSize(teamLikes.size())
         );
     }
 
@@ -164,7 +164,7 @@ class LikeServiceTest {
         // then
         assertAll(
                 () -> verify(teamMemberRepository).getTeamMemberByMemberProfileId(anyLong()),
-                () -> assertThat(likeResponses.size()).isEqualTo(teamLikes.size())
+                () -> assertThat(likeResponses).hasSize(teamLikes.size())
         );
     }
 

--- a/src/test/java/com/cupid/jikting/meeting/service/InstantMeetingServiceTest.java
+++ b/src/test/java/com/cupid/jikting/meeting/service/InstantMeetingServiceTest.java
@@ -72,7 +72,7 @@ public class InstantMeetingServiceTest {
         // then
         assertAll(
                 () -> verify(instantMeetingRepository).findAll(),
-                () -> assertThat(instantMeetingResponses.size()).isEqualTo(instantMeetings.size())
+                () -> assertThat(instantMeetingResponses).hasSize(instantMeetings.size())
         );
     }
 

--- a/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
+++ b/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
@@ -211,7 +211,7 @@ public class MemberServiceTest {
         assertAll(
                 () -> verify(memberProfileRepository).findById(anyLong()),
                 () -> assertThat(memberProfileResponse.getImages().size()).isEqualTo(PROFILE_IMAGE_SIZE),
-                () -> assertThat(memberProfileResponse.getAge()).isEqualTo(memberProfile.getAge()),
+                () -> assertThat(memberProfileResponse.getBirth()).isEqualTo(memberProfile.getBirth()),
                 () -> assertThat(memberProfileResponse.getHeight()).isEqualTo(memberProfile.getHeight()),
                 () -> assertThat(memberProfileResponse.getAddress()).isEqualTo(memberProfile.getAddress()),
                 () -> assertThat(memberProfileResponse.getMbti()).isEqualTo(memberProfile.getMbti().name()),

--- a/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
+++ b/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
@@ -210,7 +210,7 @@ public class MemberServiceTest {
         // then
         assertAll(
                 () -> verify(memberProfileRepository).findById(anyLong()),
-                () -> assertThat(memberProfileResponse.getImages().size()).isEqualTo(PROFILE_IMAGE_SIZE),
+                () -> assertThat(memberProfileResponse.getImages()).hasSize(PROFILE_IMAGE_SIZE),
                 () -> assertThat(memberProfileResponse.getBirth()).isEqualTo(memberProfile.getBirth()),
                 () -> assertThat(memberProfileResponse.getHeight()).isEqualTo(memberProfile.getHeight()),
                 () -> assertThat(memberProfileResponse.getAddress()).isEqualTo(memberProfile.getAddress()),
@@ -218,8 +218,8 @@ public class MemberServiceTest {
                 () -> assertThat(memberProfileResponse.getSmokeStatus()).isEqualTo(memberProfile.getSmokeStatus().getMessage()),
                 () -> assertThat(memberProfileResponse.getDrinkStatus()).isEqualTo(memberProfile.getDrinkStatus().getMessage()),
                 () -> assertThat(memberProfileResponse.getCollege()).isEqualTo(memberProfile.getCollege()),
-                () -> assertThat(memberProfileResponse.getPersonalities().size()).isEqualTo(memberPersonalities.size()),
-                () -> assertThat(memberProfileResponse.getHobbies().size()).isEqualTo(memberHobbies.size()),
+                () -> assertThat(memberProfileResponse.getPersonalities()).hasSize(memberPersonalities.size()),
+                () -> assertThat(memberProfileResponse.getHobbies()).hasSize(memberHobbies.size()),
                 () -> assertThat(memberProfileResponse.getDescription()).isEqualTo(memberProfile.getDescription())
         );
     }

--- a/src/test/java/com/cupid/jikting/recommend/service/RecommendServiceTest.java
+++ b/src/test/java/com/cupid/jikting/recommend/service/RecommendServiceTest.java
@@ -123,7 +123,7 @@ public class RecommendServiceTest {
         //when
         List<RecommendResponse> recommendResponses = recommendService.get(ID);
         //then
-        assertThat(recommendResponses.size()).isEqualTo(memberProfile.getRecommends().size());
+        assertThat(recommendResponses).hasSize(memberProfile.getRecommends().size());
     }
 
     @Test

--- a/src/test/java/com/cupid/jikting/team/repository/TeamRepositoryTest.java
+++ b/src/test/java/com/cupid/jikting/team/repository/TeamRepositoryTest.java
@@ -54,7 +54,7 @@ class TeamRepositoryTest {
                 () -> assertThat(savedTeam.getMemberCount()).isEqualTo(MEMBER_COUNT),
                 () -> assertThat(savedTeam.getDescription()).isEqualTo(DESCRIPTION),
                 () -> assertThat(savedTeam.getGender()).isEqualTo(Gender.MALE),
-                () -> assertThat(savedTeam.getTeamPersonalities().size()).isEqualTo(teamPersonalities.size())
+                () -> assertThat(savedTeam.getTeamPersonalities()).hasSize(teamPersonalities.size())
         );
     }
 

--- a/src/test/java/com/cupid/jikting/team/service/TeamServiceTest.java
+++ b/src/test/java/com/cupid/jikting/team/service/TeamServiceTest.java
@@ -230,8 +230,8 @@ class TeamServiceTest {
         assertAll(
                 () -> verify(memberProfileRepository).findById(anyLong()),
                 () -> assertThat(teamResponse.getDescription()).isEqualTo(DESCRIPTION),
-                () -> assertThat(teamResponse.getKeywords().size()).isEqualTo(teamPersonalities.size()),
-                () -> assertThat(teamResponse.getMembers().size()).isEqualTo(team.getTeamMembers().size())
+                () -> assertThat(teamResponse.getKeywords()).hasSize(teamPersonalities.size()),
+                () -> assertThat(teamResponse.getMembers()).hasSize(team.getTeamMembers().size())
         );
     }
 


### PR DESCRIPTION
## Issue

closed #268 
[SP-407](https://soma-cupid.atlassian.net/browse/SP-407?atlOrigin=eyJpIjoiNmZjYzM1ZWEyY2Q3NDM1MGExZDBmZTg1OTNjM2ZmYzkiLCJwIjoiaiJ9)

## 요구사항

- [x] 마이페이지 프로필 조회 응답 DTO 수정

## 변경사항

- 회원 프로필 조회 응답 DTO 필드 수정
    - (int) age -> (LocalDate) birth 필드 수정
    - gender 필드 삭제
- 테스트 코드에서 리스트 사이즈 비교 로직 `assertThat(list.size()).isEqualTo(size)` -> `assertThat(list).hasSize(size)`로 수정

## 리뷰 우선순위

🙂보통

## 코멘트

- 필드 변경 후 응답 DTO

    <img width="996" alt="스크린샷 2023-09-18 오후 11 07 20" src="https://github.com/SWM-Cupid/jikting-backend/assets/62989828/facc6026-a13d-4e79-87fb-70b6a5020c32">

- 리스트 사이즈 비교 시 리스트의 사이즈를 불러와 `isEqualTo()`를 사용해 비교하여 리스트 사이즈 비교하는 구문이 한 눈에 보이지 않았는데, 변경 후 값 비교를 위한 `isEqualTo()`와 명확히 구분되는 `hasSize()`를 사용해 리스트 사이즈를 비교하여 가독성을 향상시켰습니다.

[SP-407]: https://soma-cupid.atlassian.net/browse/SP-407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ