### PR TITLE
[SP-413] 회사 이메일 인증번호 발급 기능 구현

### DIFF
--- a/src/main/java/com/cupid/jikting/common/config/SecurityConfig.java
+++ b/src/main/java/com/cupid/jikting/common/config/SecurityConfig.java
@@ -1,9 +1,9 @@
 package com.cupid.jikting.common.config;
 
 import com.cupid.jikting.common.filter.ExceptionHandlerFilter;
-import com.cupid.jikting.common.repository.JwtRepository;
 import com.cupid.jikting.common.jwt.filter.JwtAuthenticationProcessingFilter;
 import com.cupid.jikting.common.jwt.service.JwtService;
+import com.cupid.jikting.common.repository.JwtRepository;
 import com.cupid.jikting.member.filter.CustomJsonUsernamePasswordAuthenticationFilter;
 import com.cupid.jikting.member.handler.*;
 import com.cupid.jikting.member.repository.MemberRepository;

--- a/src/main/java/com/cupid/jikting/common/error/ApplicationError.java
+++ b/src/main/java/com/cupid/jikting/common/error/ApplicationError.java
@@ -22,6 +22,7 @@ public enum ApplicationError {
     SMS_SEND_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "C012", "SMS 전송 요청에 실패했습니다."),
     WRONG_ACCESS(HttpStatus.BAD_REQUEST, "C013", "잘못된 접근입니다."),
     INVALID_TOKEN_TYPE(HttpStatus.BAD_REQUEST, "C014", "Token 타입이 올바르지 않습니다."),
+    MAIL_SEND_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "C015", "메일 전송 요청에 실패했습니다."),
 
     UNAUTHORIZED_MEMBER(HttpStatus.UNAUTHORIZED, "U001", "인증되지 않은 사용자입니다."),
     FORBIDDEN_MEMBER(HttpStatus.FORBIDDEN, "U002", "권한이 없는 사용자입니다."),

--- a/src/main/java/com/cupid/jikting/common/error/MailSendFailException.java
+++ b/src/main/java/com/cupid/jikting/common/error/MailSendFailException.java
@@ -1,0 +1,8 @@
+package com.cupid.jikting.common.error;
+
+public class MailSendFailException extends ApplicationException {
+
+    public MailSendFailException(ApplicationError applicationError) {
+        super(applicationError);
+    }
+}

--- a/src/main/java/com/cupid/jikting/common/resolver/AuthorizationResolver.java
+++ b/src/main/java/com/cupid/jikting/common/resolver/AuthorizationResolver.java
@@ -1,7 +1,7 @@
 package com.cupid.jikting.common.resolver;
 
-import com.cupid.jikting.common.support.AuthorizedVariable;
 import com.cupid.jikting.common.jwt.service.JwtService;
+import com.cupid.jikting.common.support.AuthorizedVariable;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/cupid/jikting/common/service/RedisConnector.java
+++ b/src/main/java/com/cupid/jikting/common/service/RedisConnector.java
@@ -3,7 +3,6 @@ package com.cupid.jikting.common.service;
 import com.cupid.jikting.chatting.entity.Chatting;
 import com.cupid.jikting.common.error.ApplicationError;
 import com.cupid.jikting.common.error.BadRequestException;
-import com.cupid.jikting.common.error.JwtException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.HashOperations;

--- a/src/main/java/com/cupid/jikting/common/util/PasswordGenerator.java
+++ b/src/main/java/com/cupid/jikting/common/util/PasswordGenerator.java
@@ -19,7 +19,7 @@ public class PasswordGenerator extends RandomGenerator {
 
     public static String generate() {
         return String.join(DELIMITER, IntStream.range(0, PASSWORD_LENGTH)
-                .mapToObj(i -> CHARACTERS[(int) (CHARACTERS.length * RANDOM.nextDouble())])
+                .mapToObj(i -> CHARACTERS[RANDOM.nextInt(CHARACTERS.length)])
                 .toArray(String[]::new));
     }
 }

--- a/src/main/java/com/cupid/jikting/common/util/TeamNameGenerator.java
+++ b/src/main/java/com/cupid/jikting/common/util/TeamNameGenerator.java
@@ -16,10 +16,8 @@ public class TeamNameGenerator extends RandomGenerator {
     private static final int RANDOM_NUMBER_RANGE = 10000;
 
     public static String generate() {
-        StringBuilder teamName = new StringBuilder();
-        teamName.append(COLORS[RANDOM.nextInt(COLORS.length)])
-                .append(ANIMALS[RANDOM.nextInt(ANIMALS.length)])
-                .append(String.format("%04d", RANDOM.nextInt(RANDOM_NUMBER_RANGE)));
-        return teamName.toString();
+        return COLORS[RANDOM.nextInt(COLORS.length)]
+                + ANIMALS[RANDOM.nextInt(ANIMALS.length)]
+                + String.format("%04d", RANDOM.nextInt(RANDOM_NUMBER_RANGE));
     }
 }

--- a/src/main/java/com/cupid/jikting/member/controller/MemberController.java
+++ b/src/main/java/com/cupid/jikting/member/controller/MemberController.java
@@ -3,7 +3,6 @@ package com.cupid.jikting.member.controller;
 import com.cupid.jikting.common.support.AuthorizedVariable;
 import com.cupid.jikting.member.dto.*;
 import com.cupid.jikting.member.service.MemberService;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -11,9 +10,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
 
 @RequiredArgsConstructor
 @RestController
@@ -78,7 +74,7 @@ public class MemberController {
 
     @PostMapping("/code")
     public ResponseEntity<Void> createVerificationCodeForSignup(@RequestBody SignUpVerificationCodeRequest signUpVerificationCodeRequest)
-            throws UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException, JsonProcessingException {
+            throws Exception {
         memberService.createVerificationCodeForSignup(signUpVerificationCodeRequest);
         return ResponseEntity.ok().build();
     }
@@ -91,7 +87,7 @@ public class MemberController {
 
     @PostMapping("/username/search/code")
     public ResponseEntity<Void> createVerificationCodeForSearchUsername(@RequestBody UsernameSearchVerificationCodeRequest usernameSearchVerificationCodeRequest)
-            throws UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException, JsonProcessingException {
+            throws Exception {
         memberService.createVerificationCodeForSearchUsername(usernameSearchVerificationCodeRequest);
         return ResponseEntity.ok().build();
     }
@@ -103,7 +99,7 @@ public class MemberController {
 
     @PostMapping("/password/reset/code")
     public ResponseEntity<Void> createVerificationCodeForResetPassword(@RequestBody PasswordResetVerificationCodeRequest passwordResetVerificationCodeRequest)
-            throws UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException, JsonProcessingException {
+            throws Exception {
         memberService.createVerificationCodeForResetPassword(passwordResetVerificationCodeRequest);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/cupid/jikting/member/controller/MemberController.java
+++ b/src/main/java/com/cupid/jikting/member/controller/MemberController.java
@@ -120,9 +120,10 @@ public class MemberController {
         return ResponseEntity.ok().build();
     }
 
-    @PatchMapping("/company/code")
-    public ResponseEntity<Void> createVerificationCodeForCompany(@RequestBody CompanyVerificationCodeRequest companyVerificationCodeRequest) {
-        memberService.createVerificationCodeForCompany(companyVerificationCodeRequest);
+    @PostMapping("/company/code")
+    public ResponseEntity<Void> createVerificationCodeForCompany(@AuthorizedVariable Long memberProfileId, @RequestBody CompanyVerificationCodeRequest companyVerificationCodeRequest)
+            throws UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException, JsonProcessingException {
+        memberService.createVerificationCodeForCompany(memberProfileId, companyVerificationCodeRequest);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/cupid/jikting/member/controller/MemberController.java
+++ b/src/main/java/com/cupid/jikting/member/controller/MemberController.java
@@ -121,8 +121,9 @@ public class MemberController {
     }
 
     @PostMapping("/company/code")
-    public ResponseEntity<Void> createVerificationCodeForCompany(@AuthorizedVariable Long memberProfileId, @RequestBody CompanyVerificationCodeRequest companyVerificationCodeRequest)
-            throws UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException, JsonProcessingException {
+    public ResponseEntity<Void> createVerificationCodeForCompany(@AuthorizedVariable Long memberProfileId,
+                                                                 @RequestBody CompanyVerificationCodeRequest companyVerificationCodeRequest)
+            throws Exception {
         memberService.createVerificationCodeForCompany(memberProfileId, companyVerificationCodeRequest);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/cupid/jikting/member/controller/MemberController.java
+++ b/src/main/java/com/cupid/jikting/member/controller/MemberController.java
@@ -3,6 +3,7 @@ package com.cupid.jikting.member.controller;
 import com.cupid.jikting.common.support.AuthorizedVariable;
 import com.cupid.jikting.member.dto.*;
 import com.cupid.jikting.member.service.MemberService;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -10,6 +11,9 @@ import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
 
 @RequiredArgsConstructor
 @RestController
@@ -74,7 +78,7 @@ public class MemberController {
 
     @PostMapping("/code")
     public ResponseEntity<Void> createVerificationCodeForSignup(@RequestBody SignUpVerificationCodeRequest signUpVerificationCodeRequest)
-            throws Exception {
+            throws UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException, JsonProcessingException {
         memberService.createVerificationCodeForSignup(signUpVerificationCodeRequest);
         return ResponseEntity.ok().build();
     }
@@ -87,7 +91,7 @@ public class MemberController {
 
     @PostMapping("/username/search/code")
     public ResponseEntity<Void> createVerificationCodeForSearchUsername(@RequestBody UsernameSearchVerificationCodeRequest usernameSearchVerificationCodeRequest)
-            throws Exception {
+            throws UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException, JsonProcessingException {
         memberService.createVerificationCodeForSearchUsername(usernameSearchVerificationCodeRequest);
         return ResponseEntity.ok().build();
     }
@@ -99,7 +103,7 @@ public class MemberController {
 
     @PostMapping("/password/reset/code")
     public ResponseEntity<Void> createVerificationCodeForResetPassword(@RequestBody PasswordResetVerificationCodeRequest passwordResetVerificationCodeRequest)
-            throws Exception {
+            throws UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException, JsonProcessingException {
         memberService.createVerificationCodeForResetPassword(passwordResetVerificationCodeRequest);
         return ResponseEntity.ok().build();
     }
@@ -119,7 +123,7 @@ public class MemberController {
     @PostMapping("/company/code")
     public ResponseEntity<Void> createVerificationCodeForCompany(@AuthorizedVariable Long memberProfileId,
                                                                  @RequestBody CompanyVerificationCodeRequest companyVerificationCodeRequest)
-            throws Exception {
+            throws UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException, JsonProcessingException {
         memberService.createVerificationCodeForCompany(memberProfileId, companyVerificationCodeRequest);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/cupid/jikting/member/dto/CompanyVerificationCodeRequest.java
+++ b/src/main/java/com/cupid/jikting/member/dto/CompanyVerificationCodeRequest.java
@@ -8,5 +8,5 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CompanyVerificationCodeRequest {
 
-    private String companyEmail;
+    private String email;
 }

--- a/src/main/java/com/cupid/jikting/member/dto/CompanyVerificationCodeRequest.java
+++ b/src/main/java/com/cupid/jikting/member/dto/CompanyVerificationCodeRequest.java
@@ -8,6 +8,5 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CompanyVerificationCodeRequest {
 
-    private String company;
     private String companyEmail;
 }

--- a/src/main/java/com/cupid/jikting/member/dto/MailRequest.java
+++ b/src/main/java/com/cupid/jikting/member/dto/MailRequest.java
@@ -1,0 +1,18 @@
+package com.cupid.jikting.member.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MailRequest {
+
+    private String title;
+    private String senderAddress;
+    private String senderName;
+    private String body;
+    private List<MailRequestRecipient> recipients;
+}

--- a/src/main/java/com/cupid/jikting/member/dto/MailRequestRecipient.java
+++ b/src/main/java/com/cupid/jikting/member/dto/MailRequestRecipient.java
@@ -1,0 +1,20 @@
+package com.cupid.jikting.member.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MailRequestRecipient {
+
+    private String address;
+    private String name;
+    private String type;
+
+    public static MailRequestRecipient of(String name, String email, String type) {
+        return new MailRequestRecipient(email, name, type);
+    }
+}

--- a/src/main/java/com/cupid/jikting/member/dto/MailResponse.java
+++ b/src/main/java/com/cupid/jikting/member/dto/MailResponse.java
@@ -1,0 +1,13 @@
+package com.cupid.jikting.member.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MailResponse {
+
+    private String requestId;
+    private int count;
+}

--- a/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
+++ b/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
@@ -188,4 +188,8 @@ public class MemberProfile extends BaseEntity {
                 .map(MemberChattingRoom::getChattingRoom)
                 .collect(Collectors.toList());
     }
+
+    public String getMemberName() {
+        return member.getName();
+    }
 }

--- a/src/main/java/com/cupid/jikting/member/handler/CustomLogoutHandler.java
+++ b/src/main/java/com/cupid/jikting/member/handler/CustomLogoutHandler.java
@@ -1,7 +1,7 @@
 package com.cupid.jikting.member.handler;
 
-import com.cupid.jikting.common.repository.JwtRepository;
 import com.cupid.jikting.common.jwt.service.JwtService;
+import com.cupid.jikting.common.repository.JwtRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;

--- a/src/main/java/com/cupid/jikting/member/repository/CompanyRepository.java
+++ b/src/main/java/com/cupid/jikting/member/repository/CompanyRepository.java
@@ -1,0 +1,9 @@
+package com.cupid.jikting.member.repository;
+
+import com.cupid.jikting.member.entity.Company;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CompanyRepository extends JpaRepository<Company, Long> {
+
+    boolean existsByEmail(String email);
+}

--- a/src/main/java/com/cupid/jikting/member/service/MailService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MailService.java
@@ -1,0 +1,12 @@
+package com.cupid.jikting.member.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import java.io.UnsupportedEncodingException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+
+public interface MailService {
+
+    void sendMail(String name, String email) throws UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException, JsonProcessingException;
+}

--- a/src/main/java/com/cupid/jikting/member/service/MailService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MailService.java
@@ -1,6 +1,12 @@
 package com.cupid.jikting.member.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import java.io.UnsupportedEncodingException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+
 public interface MailService {
 
-    void sendMail(String name, String email) throws Exception;
+    void sendMail(String name, String email) throws UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException, JsonProcessingException;
 }

--- a/src/main/java/com/cupid/jikting/member/service/MailService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MailService.java
@@ -1,11 +1,5 @@
 package com.cupid.jikting.member.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-
-import java.io.UnsupportedEncodingException;
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
-
 public interface MailService {
 
     void sendMail(String name, String email) throws Exception;

--- a/src/main/java/com/cupid/jikting/member/service/MailService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MailService.java
@@ -8,5 +8,5 @@ import java.security.NoSuchAlgorithmException;
 
 public interface MailService {
 
-    void sendMail(String name, String email) throws UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException, JsonProcessingException;
+    void sendMail(String name, String email) throws Exception;
 }

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -164,8 +164,7 @@ public class MemberService {
         memberRepository.save(member);
     }
 
-    public void createVerificationCodeForCompany(Long memberProfileId, CompanyVerificationCodeRequest companyVerificationCodeRequest)
-            throws UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException, JsonProcessingException {
+    public void createVerificationCodeForCompany(Long memberProfileId, CompanyVerificationCodeRequest companyVerificationCodeRequest) throws Exception {
         String email = companyVerificationCodeRequest.getEmail();
         validateCompanyDomain(email);
         mailService.sendMail(getMemberProfileById(memberProfileId).getMemberName(), email);

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -14,7 +14,6 @@ import com.cupid.jikting.member.repository.CompanyRepository;
 import com.cupid.jikting.member.repository.HobbyRepository;
 import com.cupid.jikting.member.repository.MemberProfileRepository;
 import com.cupid.jikting.member.repository.MemberRepository;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -22,9 +21,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import javax.transaction.Transactional;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -122,8 +118,7 @@ public class MemberService {
         }
     }
 
-    public void createVerificationCodeForSignup(SignUpVerificationCodeRequest signUpVerificationCodeRequest)
-            throws JsonProcessingException, UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException {
+    public void createVerificationCodeForSignup(SignUpVerificationCodeRequest signUpVerificationCodeRequest) throws Exception {
         smsService.sendSms(SendSmsRequest.from(signUpVerificationCodeRequest.getPhone()));
     }
 
@@ -132,7 +127,7 @@ public class MemberService {
     }
 
     public void createVerificationCodeForSearchUsername(UsernameSearchVerificationCodeRequest usernameSearchVerificationCodeRequest)
-            throws UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException, JsonProcessingException {
+            throws Exception {
         if (!memberRepository.existsByNameAndPhone(usernameSearchVerificationCodeRequest.getName(), usernameSearchVerificationCodeRequest.getPhone())) {
             throw new NotFoundException(ApplicationError.MEMBER_NOT_FOUND);
         }
@@ -147,7 +142,7 @@ public class MemberService {
     }
 
     public void createVerificationCodeForResetPassword(PasswordResetVerificationCodeRequest passwordResetVerificationCodeRequest)
-            throws UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException, JsonProcessingException {
+            throws Exception {
         if (!memberRepository.existsByUsernameAndNameAndPhone(passwordResetVerificationCodeRequest.getUsername(), passwordResetVerificationCodeRequest.getName(), passwordResetVerificationCodeRequest.getPhone())) {
             throw new NotFoundException(ApplicationError.MEMBER_NOT_FOUND);
         }

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -14,6 +14,7 @@ import com.cupid.jikting.member.repository.CompanyRepository;
 import com.cupid.jikting.member.repository.HobbyRepository;
 import com.cupid.jikting.member.repository.MemberProfileRepository;
 import com.cupid.jikting.member.repository.MemberRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -21,6 +22,9 @@ import org.springframework.web.multipart.MultipartFile;
 
 import javax.transaction.Transactional;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -118,7 +122,8 @@ public class MemberService {
         }
     }
 
-    public void createVerificationCodeForSignup(SignUpVerificationCodeRequest signUpVerificationCodeRequest) throws Exception {
+    public void createVerificationCodeForSignup(SignUpVerificationCodeRequest signUpVerificationCodeRequest)
+            throws UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException, JsonProcessingException {
         smsService.sendSms(SendSmsRequest.from(signUpVerificationCodeRequest.getPhone()));
     }
 
@@ -127,7 +132,7 @@ public class MemberService {
     }
 
     public void createVerificationCodeForSearchUsername(UsernameSearchVerificationCodeRequest usernameSearchVerificationCodeRequest)
-            throws Exception {
+            throws UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException, JsonProcessingException {
         if (!memberRepository.existsByNameAndPhone(usernameSearchVerificationCodeRequest.getName(), usernameSearchVerificationCodeRequest.getPhone())) {
             throw new NotFoundException(ApplicationError.MEMBER_NOT_FOUND);
         }
@@ -142,7 +147,7 @@ public class MemberService {
     }
 
     public void createVerificationCodeForResetPassword(PasswordResetVerificationCodeRequest passwordResetVerificationCodeRequest)
-            throws Exception {
+            throws UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException, JsonProcessingException {
         if (!memberRepository.existsByUsernameAndNameAndPhone(passwordResetVerificationCodeRequest.getUsername(), passwordResetVerificationCodeRequest.getName(), passwordResetVerificationCodeRequest.getPhone())) {
             throw new NotFoundException(ApplicationError.MEMBER_NOT_FOUND);
         }
@@ -159,7 +164,8 @@ public class MemberService {
         memberRepository.save(member);
     }
 
-    public void createVerificationCodeForCompany(Long memberProfileId, CompanyVerificationCodeRequest companyVerificationCodeRequest) throws Exception {
+    public void createVerificationCodeForCompany(Long memberProfileId, CompanyVerificationCodeRequest companyVerificationCodeRequest)
+            throws UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException, JsonProcessingException {
         String email = companyVerificationCodeRequest.getEmail();
         validateCompanyDomain(email);
         mailService.sendMail(getMemberProfileById(memberProfileId).getMemberName(), email);

--- a/src/main/java/com/cupid/jikting/member/service/NCPMailService.java
+++ b/src/main/java/com/cupid/jikting/member/service/NCPMailService.java
@@ -23,6 +23,7 @@ import java.util.List;
 public class NCPMailService extends NCPService implements MailService {
 
     private static final String TYPE = "R";
+    private static final String MAIL_TITLE = "[" + SERVICE_NAME + "] 회사 인증번호 안내 메일";
 
     @Value("${ncp.mail.senderAddress}")
     private String senderAddress;
@@ -44,10 +45,10 @@ public class NCPMailService extends NCPService implements MailService {
 
     private MailRequest getMailRequest(String name, String email, String verificationCode) {
         return MailRequest.builder()
-                .title("[직팅] 회사 인증번호 안내 메일")
+                .title(MAIL_TITLE)
                 .body(getVerificationCodeMessage(verificationCode))
                 .senderAddress(senderAddress)
-                .senderName("직팅")
+                .senderName(SERVICE_NAME)
                 .recipients(List.of(MailRequestRecipient.of(name, email, TYPE)))
                 .build();
     }

--- a/src/main/java/com/cupid/jikting/member/service/NCPMailService.java
+++ b/src/main/java/com/cupid/jikting/member/service/NCPMailService.java
@@ -1,0 +1,54 @@
+package com.cupid.jikting.member.service;
+
+import com.cupid.jikting.common.error.ApplicationError;
+import com.cupid.jikting.common.error.MailSendFailException;
+import com.cupid.jikting.common.service.RedisConnector;
+import com.cupid.jikting.member.dto.MailRequest;
+import com.cupid.jikting.member.dto.MailRequestRecipient;
+import com.cupid.jikting.member.dto.MailResponse;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.List;
+
+@Service
+public class NCPMailService extends NCPService implements MailService {
+
+    private static final String TYPE = "R";
+
+    @Value("${ncp.mail.senderAddress}")
+    private String senderAddress;
+
+    public NCPMailService(RedisConnector redisConnector, ObjectMapper objectMapper, RestTemplate restTemplate) {
+        super(redisConnector, objectMapper, restTemplate);
+    }
+
+    @Override
+    public void sendMail(String name, String email) throws UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException, JsonProcessingException {
+        MailResponse mailResponse = restTemplate.postForObject(
+                URI.create("https://mail.apigw.ntruss.com/api/v1/mails"),
+                new HttpEntity<>(objectMapper.writeValueAsString(getMailRequest(name, email, generateVerificationCode(email))), getHttpHeaders("/api/v1/mails")),
+                MailResponse.class);
+        if (mailResponse.getCount() != 1) {
+            throw new MailSendFailException(ApplicationError.MAIL_SEND_FAIL);
+        }
+    }
+
+    private MailRequest getMailRequest(String name, String email, String verificationCode) {
+        return MailRequest.builder()
+                .title("[직팅] 회사 인증번호 안내 메일")
+                .body(getVerificationCodeMessage(verificationCode))
+                .senderAddress(senderAddress)
+                .senderName("직팅")
+                .recipients(List.of(MailRequestRecipient.of(name, email, TYPE)))
+                .build();
+    }
+}

--- a/src/main/java/com/cupid/jikting/member/service/NCPMailService.java
+++ b/src/main/java/com/cupid/jikting/member/service/NCPMailService.java
@@ -24,6 +24,7 @@ public class NCPMailService extends NCPService implements MailService {
 
     private static final String TYPE = "R";
     private static final String MAIL_TITLE = "[" + SERVICE_NAME + "] 회사 인증번호 안내 메일";
+    private static final int SUCCESS = 1;
 
     @Value("${ncp.mail.senderAddress}")
     private String senderAddress;
@@ -38,7 +39,7 @@ public class NCPMailService extends NCPService implements MailService {
                 URI.create("https://mail.apigw.ntruss.com/api/v1/mails"),
                 new HttpEntity<>(objectMapper.writeValueAsString(getMailRequest(name, email, generateVerificationCode(email))), getHttpHeaders("/api/v1/mails")),
                 MailResponse.class);
-        if (mailResponse.getCount() != 1) {
+        if (mailResponse.getCount() != SUCCESS) {
             throw new MailSendFailException(ApplicationError.MAIL_SEND_FAIL);
         }
     }

--- a/src/main/java/com/cupid/jikting/member/service/NCPService.java
+++ b/src/main/java/com/cupid/jikting/member/service/NCPService.java
@@ -27,6 +27,9 @@ public abstract class NCPService {
     protected static final String SECRET_KEY_ALGORITHM = "HmacSHA256";
     protected static final String BLANK = " ";
     protected static final String NEW_LINE = "\n";
+    protected static final String SERVICE_NAME = "직팅";
+
+    private static final String VERIFICATION_CODE_MESSAGE = "[" + SERVICE_NAME + "]\n인증번호: ";
 
     protected final RedisConnector redisConnector;
     protected final ObjectMapper objectMapper;
@@ -45,7 +48,7 @@ public abstract class NCPService {
     }
 
     protected String getVerificationCodeMessage(String verificationCode) {
-        return "[직팅]\n인증번호: " + verificationCode;
+        return VERIFICATION_CODE_MESSAGE + verificationCode;
     }
 
     protected HttpHeaders getHttpHeaders(String url) throws NoSuchAlgorithmException, UnsupportedEncodingException, InvalidKeyException {

--- a/src/main/java/com/cupid/jikting/member/service/NCPService.java
+++ b/src/main/java/com/cupid/jikting/member/service/NCPService.java
@@ -1,0 +1,72 @@
+package com.cupid.jikting.member.service;
+
+import com.cupid.jikting.common.service.RedisConnector;
+import com.cupid.jikting.common.util.VerificationCodeGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.apache.tomcat.util.codec.binary.Base64;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.web.client.RestTemplate;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.io.UnsupportedEncodingException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+
+@RequiredArgsConstructor
+public abstract class NCPService {
+
+    protected static final int VERIFICATION_CODE_LENGTH = 6;
+    protected static final int EXPIRE_TIME = 3;
+    protected static final String CHARSET_NAME = "UTF-8";
+    protected static final String SECRET_KEY_ALGORITHM = "HmacSHA256";
+    protected static final String BLANK = " ";
+    protected static final String NEW_LINE = "\n";
+
+    protected final RedisConnector redisConnector;
+    protected final ObjectMapper objectMapper;
+    protected final RestTemplate restTemplate;
+
+    @Value("${ncp.accessKey}")
+    private String accessKey;
+
+    @Value("${ncp.secretKey}")
+    private String secretKey;
+
+    protected String generateVerificationCode(String key) {
+        String verificationCode = VerificationCodeGenerator.generate(VERIFICATION_CODE_LENGTH);
+        redisConnector.set(key, verificationCode, Duration.ofMinutes(EXPIRE_TIME));
+        return verificationCode;
+    }
+
+    protected String getVerificationCodeMessage(String verificationCode) {
+        return "[직팅]\n인증번호: " + verificationCode;
+    }
+
+    protected HttpHeaders getHttpHeaders(String url) throws NoSuchAlgorithmException, UnsupportedEncodingException, InvalidKeyException {
+        String time = String.valueOf(System.currentTimeMillis());
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("x-ncp-apigw-timestamp", time);
+        headers.set("x-ncp-iam-access-key", accessKey);
+        headers.set("x-ncp-apigw-signature-v2", getSignature(url, time));
+        return headers;
+    }
+
+    private String getSignature(String url, String time) throws NoSuchAlgorithmException, UnsupportedEncodingException, InvalidKeyException {
+        Mac mac = Mac.getInstance(SECRET_KEY_ALGORITHM);
+        mac.init(new SecretKeySpec(secretKey.getBytes(CHARSET_NAME), SECRET_KEY_ALGORITHM));
+        return Base64.encodeBase64String(mac.doFinal(getMessage(url, time).getBytes(CHARSET_NAME)));
+    }
+
+    private String getMessage(String url, String time) {
+        return HttpMethod.POST.name() + BLANK + url
+                + NEW_LINE + time
+                + NEW_LINE + accessKey;
+    }
+}

--- a/src/main/java/com/cupid/jikting/member/service/NCPSmsService.java
+++ b/src/main/java/com/cupid/jikting/member/service/NCPSmsService.java
@@ -3,53 +3,27 @@ package com.cupid.jikting.member.service;
 import com.cupid.jikting.common.error.ApplicationError;
 import com.cupid.jikting.common.error.SmsSendFailException;
 import com.cupid.jikting.common.service.RedisConnector;
-import com.cupid.jikting.common.util.VerificationCodeGenerator;
 import com.cupid.jikting.member.dto.SendSmsRequest;
 import com.cupid.jikting.member.dto.SmsRequest;
 import com.cupid.jikting.member.dto.SmsResponse;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.RequiredArgsConstructor;
-import org.apache.tomcat.util.codec.binary.Base64;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
-import javax.crypto.Mac;
-import javax.crypto.spec.SecretKeySpec;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
-import java.time.Duration;
 import java.util.List;
 
-@RequiredArgsConstructor
 @Service
-public class NCPSmsService implements SmsService {
+public class NCPSmsService extends NCPService implements SmsService {
 
     private static final String SMS_SEND_SUCCESS = "202";
-    private static final int VERIFICATION_CODE_LENGTH = 6;
-    private static final int EXPIRE_TIME = 3;
     private static final String TYPE = "SMS";
-    private static final String CHARSET_NAME = "UTF-8";
-    private static final String SECRET_KEY_ALGORITHM = "HmacSHA256";
-    private static final String BLANK = " ";
-    private static final String NEW_LINE = "\n";
-
-    private final RedisConnector redisConnector;
-    private final ObjectMapper objectMapper;
-    private final RestTemplate restTemplate;
-
-    @Value("${ncp.accessKey}")
-    private String accessKey;
-
-    @Value("${ncp.secretKey}")
-    private String secretKey;
 
     @Value("${ncp.sms.serviceId}")
     private String serviceId;
@@ -57,21 +31,20 @@ public class NCPSmsService implements SmsService {
     @Value("${ncp.sms.sender}")
     private String phone;
 
+    public NCPSmsService(RedisConnector redisConnector, ObjectMapper objectMapper, RestTemplate restTemplate) {
+        super(redisConnector, objectMapper, restTemplate);
+    }
+
     @Override
     public void sendSms(SendSmsRequest sendSmsRequest) throws JsonProcessingException, NoSuchAlgorithmException, UnsupportedEncodingException, InvalidKeyException {
+        String url = "/sms/v2/services/" + serviceId + "/messages";
         SmsResponse smsResponse = restTemplate.postForObject(
-                URI.create("https://sens.apigw.ntruss.com/sms/v2/services/" + serviceId + "/messages"),
-                new HttpEntity<>(objectMapper.writeValueAsString(getSmsRequest(sendSmsRequest, generateVerificationCode(sendSmsRequest.getTo()))), getHttpHeaders()),
+                URI.create("https://sens.apigw.ntruss.com" + url),
+                new HttpEntity<>(objectMapper.writeValueAsString(getSmsRequest(sendSmsRequest, generateVerificationCode(sendSmsRequest.getTo()))), getHttpHeaders(url)),
                 SmsResponse.class);
         if (!smsResponse.getStatusCode().equals(SMS_SEND_SUCCESS)) {
             throw new SmsSendFailException(ApplicationError.SMS_SEND_FAIL);
         }
-    }
-
-    private String generateVerificationCode(String phone) {
-        String verificationCode = VerificationCodeGenerator.generate(VERIFICATION_CODE_LENGTH);
-        redisConnector.set(phone, verificationCode, Duration.ofMinutes(EXPIRE_TIME));
-        return verificationCode;
     }
 
     private SmsRequest getSmsRequest(SendSmsRequest sendSmsRequest, String verificationCode) {
@@ -81,31 +54,5 @@ public class NCPSmsService implements SmsService {
                 .content(getVerificationCodeMessage(verificationCode))
                 .messages(List.of(sendSmsRequest))
                 .build();
-    }
-
-    private String getVerificationCodeMessage(String verificationCode) {
-        return String.format("[직팅]\n인증번호: %s", verificationCode);
-    }
-
-    private HttpHeaders getHttpHeaders() throws NoSuchAlgorithmException, UnsupportedEncodingException, InvalidKeyException {
-        String time = String.valueOf(System.currentTimeMillis());
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
-        headers.set("x-ncp-apigw-timestamp", time);
-        headers.set("x-ncp-iam-access-key", accessKey);
-        headers.set("x-ncp-apigw-signature-v2", getSignature(time));
-        return headers;
-    }
-
-    private String getSignature(String time) throws NoSuchAlgorithmException, UnsupportedEncodingException, InvalidKeyException {
-        Mac mac = Mac.getInstance(SECRET_KEY_ALGORITHM);
-        mac.init(new SecretKeySpec(secretKey.getBytes(CHARSET_NAME), SECRET_KEY_ALGORITHM));
-        return Base64.encodeBase64String(mac.doFinal(getMessage(time).getBytes(CHARSET_NAME)));
-    }
-
-    private String getMessage(String time) {
-        return HttpMethod.POST.name() + BLANK + String.format("/sms/v2/services/%s/messages", serviceId)
-                + NEW_LINE + time
-                + NEW_LINE + accessKey;
     }
 }

--- a/src/main/java/com/cupid/jikting/member/service/SmsService.java
+++ b/src/main/java/com/cupid/jikting/member/service/SmsService.java
@@ -1,13 +1,8 @@
 package com.cupid.jikting.member.service;
 
 import com.cupid.jikting.member.dto.SendSmsRequest;
-import com.fasterxml.jackson.core.JsonProcessingException;
-
-import java.io.UnsupportedEncodingException;
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
 
 public interface SmsService {
 
-    void sendSms(SendSmsRequest sendSmsRequest) throws JsonProcessingException, NoSuchAlgorithmException, UnsupportedEncodingException, InvalidKeyException;
+    void sendSms(SendSmsRequest sendSmsRequest) throws Exception;
 }

--- a/src/main/java/com/cupid/jikting/member/service/SmsService.java
+++ b/src/main/java/com/cupid/jikting/member/service/SmsService.java
@@ -1,8 +1,13 @@
 package com.cupid.jikting.member.service;
 
 import com.cupid.jikting.member.dto.SendSmsRequest;
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import java.io.UnsupportedEncodingException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
 
 public interface SmsService {
 
-    void sendSms(SendSmsRequest sendSmsRequest) throws Exception;
+    void sendSms(SendSmsRequest sendSmsRequest) throws UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException, JsonProcessingException;
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -39,4 +39,6 @@ ncp.secretKey=${NCP_SECRET_KEY}
 ncp.sms.serviceId=${NCP_SMS_SERVICE_ID}
 ncp.sms.sender=${NCP_SMS_SERVICE_SENDER}
 
+ncp.mail.senderAddress=${NCP_MAIL_SENDER_ADDRESS}
+
 spring.session.store-type=redis

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -221,7 +221,7 @@ public class MemberControllerTest extends ApiDocument {
                 .password(PASSWORD)
                 .build();
         companyVerificationCodeRequest = CompanyVerificationCodeRequest.builder()
-                .companyEmail(COMPANY_EMAIL)
+                .email(COMPANY_EMAIL)
                 .build();
         loginRequest = LoginRequest.builder()
                 .username(USERNAME)

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -624,7 +624,7 @@ public class MemberControllerTest extends ApiDocument {
     @Test
     void 회사_이메일_인증번호_발급_성공() throws Exception {
         // given
-        willDoNothing().given(memberService).createVerificationCodeForCompany(any(CompanyVerificationCodeRequest.class));
+        willDoNothing().given(memberService).createVerificationCodeForCompany(anyLong(), any(CompanyVerificationCodeRequest.class));
         // when
         ResultActions resultActions = 회사_이메일_인증번호_발급_요청();
         // then
@@ -635,7 +635,7 @@ public class MemberControllerTest extends ApiDocument {
     @Test
     void 회사_이메일_인증번호_발급_실패() throws Exception {
         // given
-        willThrow(wrongFormException).given(memberService).createVerificationCodeForCompany(any(CompanyVerificationCodeRequest.class));
+        willThrow(wrongFormException).given(memberService).createVerificationCodeForCompany(anyLong(), any(CompanyVerificationCodeRequest.class));
         // when
         ResultActions resultActions = 회사_이메일_인증번호_발급_요청();
         // then
@@ -1105,7 +1105,7 @@ public class MemberControllerTest extends ApiDocument {
     }
 
     private ResultActions 회사_이메일_인증번호_발급_요청() throws Exception {
-        return mockMvc.perform(patch(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/company/code")
+        return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/company/code")
                 .header(AUTHORIZATION, BEARER + accessToken)
                 .contextPath(CONTEXT_PATH)
                 .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -150,12 +150,6 @@ public class MemberControllerTest extends ApiDocument {
                 .company(company)
                 .build();
         memberProfile.getMember().getMemberCompanies().add(memberCompany);
-        List<ImageRequest> images = IntStream.range(0, 1)
-                .mapToObj(n -> ImageRequest.builder()
-                        .url(profileImage.getUrl())
-                        .sequence(profileImage.getSequence().name())
-                        .build())
-                .collect(Collectors.toList());
         List<String> personalities = IntStream.rangeClosed(1, 3)
                 .mapToObj(n -> PERSONALITY + n)
                 .collect(Collectors.toList());
@@ -227,7 +221,6 @@ public class MemberControllerTest extends ApiDocument {
                 .password(PASSWORD)
                 .build();
         companyVerificationCodeRequest = CompanyVerificationCodeRequest.builder()
-                .company(COMPANY)
                 .companyEmail(COMPANY_EMAIL)
                 .build();
         loginRequest = LoginRequest.builder()

--- a/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
+++ b/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
@@ -622,7 +622,7 @@ public class MemberServiceTest {
     }
 
     @Test
-    void 비밀번호_재설정_인증번호_발급_성공() throws UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException, JsonProcessingException {
+    void 비밀번호_재설정_인증번호_발급_성공() throws Exception {
         // given
         PasswordResetVerificationCodeRequest passwordResetVerificationCodeRequest = PasswordResetVerificationCodeRequest.builder()
                 .username(USERNAME)

--- a/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
+++ b/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
@@ -622,7 +622,7 @@ public class MemberServiceTest {
     }
 
     @Test
-    void 비밀번호_재설정_인증번호_발급_성공() throws Exception {
+    void 비밀번호_재설정_인증번호_발급_성공() throws UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException, JsonProcessingException {
         // given
         PasswordResetVerificationCodeRequest passwordResetVerificationCodeRequest = PasswordResetVerificationCodeRequest.builder()
                 .username(USERNAME)
@@ -643,7 +643,7 @@ public class MemberServiceTest {
     }
 
     @Test
-    void 비밀번호_재설정_인증번호_발급_실패_회원_없음() throws UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException, JsonProcessingException {
+    void 비밀번호_재설정_인증번호_발급_실패_회원_없음() {
         // given
         PasswordResetVerificationCodeRequest passwordResetVerificationCodeRequest = PasswordResetVerificationCodeRequest.builder()
                 .username(USERNAME)


### PR DESCRIPTION
## Issue

closed #270 
[SP-413](https://soma-cupid.atlassian.net/browse/SP-413?atlOrigin=eyJpIjoiYTZhYjc4YmU0NGFmNGVkOGI1MzE1ZGIwNTJiODQ3OWIiLCJwIjoiaiJ9)

## 요구사항

- [x] 회사 이메일 인증번호 발급 기능 구현

## 변경사항

- `CompanyVerificationCodeRequest` 회사명 필드 삭제 및 회사 이메일 필드명 수정
- NCP 사용을 위해 사용되는 공통 로직 `NCPService`로 추출

## 리뷰 우선순위

🙂보통

## 코멘트

- 구현 정리: https://github.com/SWM-Cupid/jikting-backend/issues/270#issuecomment-1733580396

[SP-413]: https://soma-cupid.atlassian.net/browse/SP-413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ