### PR TITLE
[SP-414] 회사 이메일 인증번호 인증 기능 구현

### DIFF
--- a/src/main/java/com/cupid/jikting/member/controller/MemberController.java
+++ b/src/main/java/com/cupid/jikting/member/controller/MemberController.java
@@ -97,8 +97,8 @@ public class MemberController {
     }
 
     @PostMapping("/username/search/verification")
-    public ResponseEntity<UsernameResponse> verifyForSearchUsername(@RequestBody VerificationRequest verificationRequest) {
-        return ResponseEntity.ok().body(memberService.verifyForSearchUsername(verificationRequest));
+    public ResponseEntity<UsernameResponse> verifyForSearchUsername(@RequestBody VerificationPhoneRequest verificationPhoneRequest) {
+        return ResponseEntity.ok().body(memberService.verifyForSearchUsername(verificationPhoneRequest));
     }
 
     @PostMapping("/password/reset/code")
@@ -109,8 +109,8 @@ public class MemberController {
     }
 
     @PostMapping("/password/reset/verification")
-    public ResponseEntity<Void> verifyForResetPassword(@RequestBody VerificationRequest verificationRequest) {
-        memberService.verifyForResetPassword(verificationRequest);
+    public ResponseEntity<Void> verifyForResetPassword(@RequestBody VerificationPhoneRequest verificationPhoneRequest) {
+        memberService.verifyForResetPassword(verificationPhoneRequest);
         return ResponseEntity.ok().build();
     }
 
@@ -129,8 +129,8 @@ public class MemberController {
     }
 
     @PostMapping("/company/verification")
-    public ResponseEntity<Void> verifyForCompany(@RequestBody VerificationRequest verificationRequest) {
-        memberService.verifyForCompany(verificationRequest);
+    public ResponseEntity<Void> verifyForCompany(@RequestBody VerificationEmailRequest verificationEmailRequest) {
+        memberService.verifyForCompany(verificationEmailRequest);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/cupid/jikting/member/dto/VerificationEmailRequest.java
+++ b/src/main/java/com/cupid/jikting/member/dto/VerificationEmailRequest.java
@@ -1,0 +1,13 @@
+package com.cupid.jikting.member.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class VerificationEmailRequest {
+
+    private String email;
+    private String verificationCode;
+}

--- a/src/main/java/com/cupid/jikting/member/dto/VerificationPhoneRequest.java
+++ b/src/main/java/com/cupid/jikting/member/dto/VerificationPhoneRequest.java
@@ -6,7 +6,7 @@ import lombok.*;
 @Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class VerificationRequest {
+public class VerificationPhoneRequest {
 
     private String phone;
     private String verificationCode;

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -171,7 +171,10 @@ public class MemberService {
         mailService.sendMail(getMemberProfileById(memberProfileId).getMemberName(), email);
     }
 
-    public void verifyForCompany(VerificationRequest verificationRequest) {
+    public void verifyForCompany(VerificationEmailRequest verificationPhoneRequest) {
+        String email = verificationPhoneRequest.getEmail();
+        validateCompanyDomain(email);
+        validateVerificationCode(email, verificationPhoneRequest.getVerificationCode());
     }
 
     public void verifyCardForCompany(CompanyVerificationRequest companyVerificationRequest, MultipartFile multipartFile) {

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -222,8 +222,8 @@ public class MemberService {
                 .orElseThrow(() -> new NotFoundException(ApplicationError.HOBBY_NOT_FOUND));
     }
 
-    private void validateVerificationCode(String phone, String verificationCode) {
-        if (!redisConnector.get(phone).equals(verificationCode)) {
+    private void validateVerificationCode(String key, String verificationCode) {
+        if (!redisConnector.get(key).equals(verificationCode)) {
             throw new BadRequestException(ApplicationError.VERIFICATION_CODE_NOT_EQUAL);
         }
     }

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -139,9 +139,9 @@ public class MemberService {
         smsService.sendSms(SendSmsRequest.from(usernameSearchVerificationCodeRequest.getPhone()));
     }
 
-    public UsernameResponse verifyForSearchUsername(VerificationRequest verificationRequest) {
-        validateVerificationCode(verificationRequest.getPhone(), verificationRequest.getVerificationCode());
-        return memberRepository.findByPhone(verificationRequest.getPhone())
+    public UsernameResponse verifyForSearchUsername(VerificationPhoneRequest verificationPhoneRequest) {
+        validateVerificationCode(verificationPhoneRequest.getPhone(), verificationPhoneRequest.getVerificationCode());
+        return memberRepository.findByPhone(verificationPhoneRequest.getPhone())
                 .map(UsernameResponse::from)
                 .orElseThrow(() -> new NotFoundException(ApplicationError.MEMBER_NOT_FOUND));
     }
@@ -154,8 +154,8 @@ public class MemberService {
         smsService.sendSms(SendSmsRequest.from(passwordResetVerificationCodeRequest.getPhone()));
     }
 
-    public void verifyForResetPassword(VerificationRequest verificationRequest) {
-        validateVerificationCode(verificationRequest.getPhone(), verificationRequest.getVerificationCode());
+    public void verifyForResetPassword(VerificationPhoneRequest verificationPhoneRequest) {
+        validateVerificationCode(verificationPhoneRequest.getPhone(), verificationPhoneRequest.getVerificationCode());
     }
 
     public void resetPassword(PasswordResetRequest passwordResetRequest) {

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -82,7 +82,7 @@ public class MemberControllerTest extends ApiDocument {
     private SignUpVerificationCodeRequest signUpVerificationCodeRequest;
     private UsernameSearchVerificationCodeRequest usernameSearchVerificationCodeRequest;
     private PhoneVerificationRequest phoneVerificationRequest;
-    private VerificationRequest verificationRequest;
+    private VerificationPhoneRequest verificationPhoneRequest;
     private PasswordResetVerificationCodeRequest passwordResetVerificationCodeRequest;
     private PasswordResetRequest passwordResetRequest;
     private CompanyVerificationCodeRequest companyVerificationCodeRequest;
@@ -207,7 +207,7 @@ public class MemberControllerTest extends ApiDocument {
                 .phone(PHONE)
                 .verificationCode(VERIFICATION_CODE)
                 .build();
-        verificationRequest = VerificationRequest.builder()
+        verificationPhoneRequest = VerificationPhoneRequest.builder()
                 .phone(PHONE)
                 .verificationCode(VERIFICATION_CODE)
                 .build();
@@ -533,7 +533,7 @@ public class MemberControllerTest extends ApiDocument {
     @Test
     void 아이디_찾기_인증_성공() throws Exception {
         // given
-        willReturn(usernameResponse).given(memberService).verifyForSearchUsername(any(VerificationRequest.class));
+        willReturn(usernameResponse).given(memberService).verifyForSearchUsername(any(VerificationPhoneRequest.class));
         // when
         ResultActions resultActions = 아이디_찾기_인증_요청();
         // then
@@ -543,7 +543,7 @@ public class MemberControllerTest extends ApiDocument {
     @Test
     void 아이디_찾기_인증_실패() throws Exception {
         // given
-        willThrow(verificationCodeNotEqualException).given(memberService).verifyForSearchUsername(any(VerificationRequest.class));
+        willThrow(verificationCodeNotEqualException).given(memberService).verifyForSearchUsername(any(VerificationPhoneRequest.class));
         // when
         ResultActions resultActions = 아이디_찾기_인증_요청();
         // then
@@ -573,7 +573,7 @@ public class MemberControllerTest extends ApiDocument {
     @Test
     void 비밀번호_재설정_인증_성공() throws Exception {
         // given
-        willDoNothing().given(memberService).verifyForResetPassword(any(VerificationRequest.class));
+        willDoNothing().given(memberService).verifyForResetPassword(any(VerificationPhoneRequest.class));
         // when
         ResultActions resultActions = 비밀번호_재설정_인증_요청();
         // then
@@ -583,7 +583,7 @@ public class MemberControllerTest extends ApiDocument {
     @Test
     void 비밀번호_재설정_인증_실패() throws Exception {
         // given
-        willThrow(verificationCodeNotEqualException).given(memberService).verifyForResetPassword(any(VerificationRequest.class));
+        willThrow(verificationCodeNotEqualException).given(memberService).verifyForResetPassword(any(VerificationPhoneRequest.class));
         // when
         ResultActions resultActions = 비밀번호_재설정_인증_요청();
         // then
@@ -646,7 +646,7 @@ public class MemberControllerTest extends ApiDocument {
     @Test
     void 회사_이메일_인증_성공() throws Exception {
         // given
-        willDoNothing().given(memberService).verifyForCompany(any(VerificationRequest.class));
+        willDoNothing().given(memberService).verifyForCompany(any(VerificationEmailRequest.class));
         // when
         ResultActions resultActions = 회사_이메일_인증_요청();
         // then
@@ -657,7 +657,7 @@ public class MemberControllerTest extends ApiDocument {
     @Test
     void 회사_이메일_인증_인증번호불일치_실패() throws Exception {
         // given
-        willThrow(verificationCodeNotEqualException).given(memberService).verifyForCompany(any(VerificationRequest.class));
+        willThrow(verificationCodeNotEqualException).given(memberService).verifyForCompany(any(VerificationEmailRequest.class));
         // when
         ResultActions resultActions = 회사_이메일_인증_요청();
         // then
@@ -668,7 +668,7 @@ public class MemberControllerTest extends ApiDocument {
     @Test
     void 회사_이메일_인증_시간초과_실패() throws Exception {
         // given
-        willThrow(verificationCodeExpiredException).given(memberService).verifyForCompany(any(VerificationRequest.class));
+        willThrow(verificationCodeExpiredException).given(memberService).verifyForCompany(any(VerificationEmailRequest.class));
         // when
         ResultActions resultActions = 회사_이메일_인증_요청();
         // then
@@ -1020,7 +1020,7 @@ public class MemberControllerTest extends ApiDocument {
         return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/username/search/verification")
                 .contextPath(CONTEXT_PATH)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(toJson(verificationRequest)));
+                .content(toJson(verificationPhoneRequest)));
     }
 
     private void 아이디_찾기_인증_요청_성공(ResultActions resultActions) throws Exception {
@@ -1061,7 +1061,7 @@ public class MemberControllerTest extends ApiDocument {
         return mockMvc.perform(post(CONTEXT_PATH + DOMAIN_ROOT_PATH + "/password/reset/verification")
                 .contextPath(CONTEXT_PATH)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(toJson(verificationRequest)));
+                .content(toJson(verificationPhoneRequest)));
     }
 
     private void 비밀번호_재설정_인증_요청_성공(ResultActions resultActions) throws Exception {
@@ -1130,7 +1130,7 @@ public class MemberControllerTest extends ApiDocument {
                 .header(AUTHORIZATION, BEARER + accessToken)
                 .contextPath(CONTEXT_PATH)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(toJson(verificationRequest)));
+                .content(toJson(verificationPhoneRequest)));
     }
 
     private void 회사_이메일_인증_요청_성공(ResultActions resultActions) throws Exception {

--- a/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
+++ b/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
@@ -565,14 +565,14 @@ public class MemberServiceTest {
     @Test
     void 아이디찾기_인증번호_인증_성공() {
         // given
-        VerificationRequest verificationRequest = VerificationRequest.builder()
+        VerificationPhoneRequest verificationPhoneRequest = VerificationPhoneRequest.builder()
                 .phone(PHONE)
                 .verificationCode(VERIFICATION_CODE)
                 .build();
         willReturn(VERIFICATION_CODE).given(redisConnector).get(anyString());
         willReturn(Optional.of(member)).given(memberRepository).findByPhone(anyString());
         // when
-        memberService.verifyForSearchUsername(verificationRequest);
+        memberService.verifyForSearchUsername(verificationPhoneRequest);
         // then
         assertAll(
                 () -> verify(redisConnector).get(anyString()),
@@ -583,13 +583,13 @@ public class MemberServiceTest {
     @Test
     void 아이디찾기_인증번호_인증_실패_인증번호_불일치() {
         // given
-        VerificationRequest verificationRequest = VerificationRequest.builder()
+        VerificationPhoneRequest verificationPhoneRequest = VerificationPhoneRequest.builder()
                 .phone(PHONE)
                 .verificationCode(VERIFICATION_CODE)
                 .build();
         willReturn(WRONG_VERIFICATION_CODE).given(redisConnector).get(anyString());
         // when & then
-        assertThatThrownBy(() -> memberService.verifyForSearchUsername(verificationRequest))
+        assertThatThrownBy(() -> memberService.verifyForSearchUsername(verificationPhoneRequest))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage(ApplicationError.VERIFICATION_CODE_NOT_EQUAL.getMessage());
     }
@@ -597,13 +597,13 @@ public class MemberServiceTest {
     @Test
     void 아이디찾기_인증번호_인증_실패_인증번호_만료() {
         // given
-        VerificationRequest verificationRequest = VerificationRequest.builder()
+        VerificationPhoneRequest verificationPhoneRequest = VerificationPhoneRequest.builder()
                 .phone(PHONE)
                 .verificationCode(VERIFICATION_CODE)
                 .build();
         willThrow(new BadRequestException(ApplicationError.VERIFICATION_CODE_EXPIRED)).given(redisConnector).get(anyString());
         // when & then
-        assertThatThrownBy(() -> memberService.verifyForSearchUsername(verificationRequest))
+        assertThatThrownBy(() -> memberService.verifyForSearchUsername(verificationPhoneRequest))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage(ApplicationError.VERIFICATION_CODE_EXPIRED.getMessage());
     }
@@ -611,13 +611,13 @@ public class MemberServiceTest {
     @Test
     void 아이디찾기_인증번호_인증_실패_회원_없음() {
         // given
-        VerificationRequest verificationRequest = VerificationRequest.builder()
+        VerificationPhoneRequest verificationPhoneRequest = VerificationPhoneRequest.builder()
                 .phone(PHONE)
                 .verificationCode(VERIFICATION_CODE)
                 .build();
         willThrow(new NotFoundException(ApplicationError.MEMBER_NOT_FOUND)).given(redisConnector).get(anyString());
         // when & then
-        assertThatThrownBy(() -> memberService.verifyForSearchUsername(verificationRequest))
+        assertThatThrownBy(() -> memberService.verifyForSearchUsername(verificationPhoneRequest))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage(ApplicationError.MEMBER_NOT_FOUND.getMessage());
     }
@@ -661,13 +661,13 @@ public class MemberServiceTest {
     @Test
     void 비밀번호_재설정_인증번호_인증_성공() {
         // given
-        VerificationRequest verificationRequest = VerificationRequest.builder()
+        VerificationPhoneRequest verificationPhoneRequest = VerificationPhoneRequest.builder()
                 .phone(PHONE)
                 .verificationCode(VERIFICATION_CODE)
                 .build();
         willReturn(VERIFICATION_CODE).given(redisConnector).get(anyString());
         // when
-        memberService.verifyForResetPassword(verificationRequest);
+        memberService.verifyForResetPassword(verificationPhoneRequest);
         // then
         verify(redisConnector).get(anyString());
     }
@@ -675,13 +675,13 @@ public class MemberServiceTest {
     @Test
     void 비밀번호_재설정_인증번호_인증_실패_인증번호_불일치() {
         // given
-        VerificationRequest verificationRequest = VerificationRequest.builder()
+        VerificationPhoneRequest verificationPhoneRequest = VerificationPhoneRequest.builder()
                 .phone(PHONE)
                 .verificationCode(VERIFICATION_CODE)
                 .build();
         willReturn(WRONG_VERIFICATION_CODE).given(redisConnector).get(anyString());
         // when & then
-        assertThatThrownBy(() -> memberService.verifyForResetPassword(verificationRequest))
+        assertThatThrownBy(() -> memberService.verifyForResetPassword(verificationPhoneRequest))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage(ApplicationError.VERIFICATION_CODE_NOT_EQUAL.getMessage());
     }
@@ -689,13 +689,13 @@ public class MemberServiceTest {
     @Test
     void 비밀번호_재설정_인증번호_인증_실패_인증번호_만료() {
         // given
-        VerificationRequest verificationRequest = VerificationRequest.builder()
+        VerificationPhoneRequest verificationPhoneRequest = VerificationPhoneRequest.builder()
                 .phone(PHONE)
                 .verificationCode(VERIFICATION_CODE)
                 .build();
         willThrow(new BadRequestException(ApplicationError.VERIFICATION_CODE_EXPIRED)).given(redisConnector).get(anyString());
         // when & then
-        assertThatThrownBy(() -> memberService.verifyForResetPassword(verificationRequest))
+        assertThatThrownBy(() -> memberService.verifyForResetPassword(verificationPhoneRequest))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage(ApplicationError.VERIFICATION_CODE_EXPIRED.getMessage());
     }

--- a/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
+++ b/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
@@ -756,6 +756,20 @@ public class MemberServiceTest {
     }
 
     @Test
+    void 회사_이메일_인증번호_인증_실패_회사_없음() {
+        // given
+        VerificationEmailRequest verificationEmailRequest = VerificationEmailRequest.builder()
+                .email(EMAIL)
+                .verificationCode(VERIFICATION_CODE)
+                .build();
+        willReturn(false).given(companyRepository).existsByEmail(anyString());
+        // when & then
+        assertThatThrownBy(() -> memberService.verifyForCompany(verificationEmailRequest))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage(ApplicationError.INVALID_COMPANY.getMessage());
+    }
+
+    @Test
     void 재직중인_회사_차단_성공() {
         //given
         List<MemberCompany> memberCompanies = IntStream.range(0, 3)

--- a/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
+++ b/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
@@ -770,6 +770,21 @@ public class MemberServiceTest {
     }
 
     @Test
+    void 회사_이메일_인증번호_인증_실패_인증번호_불일치() {
+        // given
+        VerificationEmailRequest verificationEmailRequest = VerificationEmailRequest.builder()
+                .email(EMAIL)
+                .verificationCode(WRONG_VERIFICATION_CODE)
+                .build();
+        willReturn(true).given(companyRepository).existsByEmail(anyString());
+        willReturn(VERIFICATION_CODE).given(redisConnector).get(anyString());
+        // when & then
+        assertThatThrownBy(() -> memberService.verifyForCompany(verificationEmailRequest))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(ApplicationError.VERIFICATION_CODE_NOT_EQUAL.getMessage());
+    }
+
+    @Test
     void 재직중인_회사_차단_성공() {
         //given
         List<MemberCompany> memberCompanies = IntStream.range(0, 3)

--- a/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
+++ b/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
@@ -7,6 +7,7 @@ import com.cupid.jikting.common.repository.PersonalityRepository;
 import com.cupid.jikting.common.service.RedisConnector;
 import com.cupid.jikting.member.dto.*;
 import com.cupid.jikting.member.entity.*;
+import com.cupid.jikting.member.repository.CompanyRepository;
 import com.cupid.jikting.member.repository.HobbyRepository;
 import com.cupid.jikting.member.repository.MemberProfileRepository;
 import com.cupid.jikting.member.repository.MemberRepository;
@@ -63,6 +64,7 @@ public class MemberServiceTest {
     private static final String WRONG_VERIFICATION_CODE = "잘못된" + VERIFICATION_CODE;
     private static final int PROFILE_IMAGE_SIZE = 3;
     private static final String SMS_SEND_SUCCESS = "202";
+    private static final String EMAIL = "email@soma.com";
 
     private Member member;
     private MemberProfile memberProfile;
@@ -92,6 +94,9 @@ public class MemberServiceTest {
 
     @Mock
     private MemberProfileRepository memberProfileRepository;
+
+    @Mock
+    private CompanyRepository companyRepository;
 
     @Mock
     private PersonalityRepository personalityRepository;
@@ -730,6 +735,24 @@ public class MemberServiceTest {
         assertThatThrownBy(() -> memberService.resetPassword(passwordResetRequest))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage(ApplicationError.MEMBER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    void 회사_이메일_인증번호_인증_성공() {
+        // given
+        VerificationEmailRequest verificationEmailRequest = VerificationEmailRequest.builder()
+                .email(EMAIL)
+                .verificationCode(VERIFICATION_CODE)
+                .build();
+        willReturn(true).given(companyRepository).existsByEmail(anyString());
+        willReturn(VERIFICATION_CODE).given(redisConnector).get(anyString());
+        // when
+        memberService.verifyForCompany(verificationEmailRequest);
+        // then
+        assertAll(
+                () -> verify(companyRepository).existsByEmail(anyString()),
+                () -> verify(redisConnector).get(anyString())
+        );
     }
 
     @Test


### PR DESCRIPTION
## Issue

closed #280 
[SP-414](https://soma-cupid.atlassian.net/browse/SP-414?atlOrigin=eyJpIjoiY2EyNmY5NDcyMGFhNDI0OWIxNDQ3NzBlNTkzMDBhOTEiLCJwIjoiaiJ9)

## 요구사항

- [x] 회사 이메일 인증번호 인증 기능 구현

## 변경사항

- `VerificationRequest` -> `VerificationPhoneRequest` & `VerificationEmailRequest`로 분리

## 리뷰 우선순위

🙂보통

[SP-414]: https://soma-cupid.atlassian.net/browse/SP-414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ