### PR TITLE
[SP-420] 이미지 파일 확장자 제한 추가

### DIFF
--- a/src/main/java/com/cupid/jikting/member/service/FileUploadService.java
+++ b/src/main/java/com/cupid/jikting/member/service/FileUploadService.java
@@ -16,14 +16,14 @@ import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
-import java.util.Arrays;
+import java.util.List;
 import java.util.UUID;
 
 @RequiredArgsConstructor
 @Service
 public class FileUploadService {
 
-    private static final String[] VALID_EXTENSIONS = {"jpeg", "png"};
+    private static final List<String> VALID_EXTENSIONS = List.of("jpeg", "png");
     private static final String FILE_DELIMITER = ".";
 
     private final AmazonS3Client amazonS3Client;
@@ -60,10 +60,9 @@ public class FileUploadService {
     }
 
     private void validateExtension(String extension) {
-        Arrays.stream(VALID_EXTENSIONS)
-                .filter(extension::equals)
-                .findAny()
-                .orElseThrow(() -> new BadRequestException(ApplicationError.INVALID_FILE_EXTENSION));
+        if (!VALID_EXTENSIONS.contains(extension)) {
+            throw new BadRequestException(ApplicationError.INVALID_FILE_EXTENSION);
+        }
     }
 
     private void validateFace(String fileName) {


### PR DESCRIPTION
## Issue

closed #291 
[SP-420](https://soma-cupid.atlassian.net/browse/SP-420?atlOrigin=eyJpIjoiYTgzZmMxOTA0MTY5NDM1Mzg1ZGZlN2I3ZTNlOTVjOTAiLCJwIjoiaiJ9)

## 요구사항

- [x] 이미지 파일 확장자 제한 추가

## 변경사항

- X

## 리뷰 우선순위

🙂보통

## 코멘트

- AWS Rekonition에서 지원하는 이미지 형식 외의 확장자를 제한하는 기능을 추가했습니다.

[SP-420]: https://soma-cupid.atlassian.net/browse/SP-420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ