### PR TITLE
[SP-428] 회원가입 API 응답 토큰 추가

### DIFF
--- a/src/main/java/com/cupid/jikting/member/controller/MemberController.java
+++ b/src/main/java/com/cupid/jikting/member/controller/MemberController.java
@@ -2,6 +2,8 @@ package com.cupid.jikting.member.controller;
 
 import com.cupid.jikting.common.support.AuthorizedVariable;
 import com.cupid.jikting.member.dto.*;
+import com.cupid.jikting.member.entity.Member;
+import com.cupid.jikting.member.handler.LoginSuccessHandler;
 import com.cupid.jikting.member.service.MemberService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.RequiredArgsConstructor;
@@ -9,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -21,11 +24,13 @@ import java.security.NoSuchAlgorithmException;
 public class MemberController {
 
     private final MemberService memberService;
+    private final LoginSuccessHandler loginSuccessHandler;
 
     @PostMapping
-    public ResponseEntity<Void> signup(@Valid @RequestBody SignupRequest signupRequest) {
-        memberService.signup(signupRequest);
-        return ResponseEntity.ok().build();
+    public ResponseEntity<LoginResponse> signup(@Valid @RequestBody SignupRequest signupRequest, HttpServletResponse response) throws IOException {
+        Member member = memberService.signup(signupRequest);
+        loginSuccessHandler.loginAfterSignup(response, member);
+        return ResponseEntity.ok().body(LoginResponse.from(member));
     }
 
     @GetMapping

--- a/src/main/java/com/cupid/jikting/member/dto/LoginResponse.java
+++ b/src/main/java/com/cupid/jikting/member/dto/LoginResponse.java
@@ -1,9 +1,12 @@
 package com.cupid.jikting.member.dto;
 
-import lombok.*;
+import com.cupid.jikting.member.entity.Member;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class LoginResponse {
@@ -11,4 +14,8 @@ public class LoginResponse {
     private Long memberProfileId;
     private String role;
     private String socialType;
+
+    public static LoginResponse from(Member member) {
+        return new LoginResponse(member.getMemberProfileId(), member.getRole().getKey(), member.getSocialType().name());
+    }
 }

--- a/src/main/java/com/cupid/jikting/member/handler/LoginSuccessHandler.java
+++ b/src/main/java/com/cupid/jikting/member/handler/LoginSuccessHandler.java
@@ -38,12 +38,12 @@ public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
         String username = extractUsername(authentication);
         Member member = getMemberByUsername(username);
         Long memberProfileId = member.getMemberProfileId();
-        String accessToken = jwtService.issueAccessToken(memberProfileId);
-        String refreshToken = jwtService.issueRefreshToken();
-        jwtService.setAccessAndRefreshToken(response, accessToken, refreshToken);
-        jwtRepository.save(memberProfileId.toString(), refreshToken, Duration.ofMillis(refreshTokenExpirationPeriod));
+        issueAndSetTokens(response, memberProfileId);
         setResponseBody(response, member);
-        log.info("로그인에 성공하였습니다. 아이디 : {} AccessToken : {}", username, accessToken);
+    }
+
+    public void loginAfterSignup(HttpServletResponse response, Member member) {
+        issueAndSetTokens(response, member.getMemberProfileId());
     }
 
     private String extractUsername(Authentication authentication) {
@@ -54,6 +54,13 @@ public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
     private Member getMemberByUsername(String username) {
         return memberRepository.findByUsername(username)
                 .orElseThrow(() -> new NotFoundException(ApplicationError.MEMBER_NOT_FOUND));
+    }
+
+    private void issueAndSetTokens(HttpServletResponse response, Long memberProfileId) {
+        String accessToken = jwtService.issueAccessToken(memberProfileId);
+        String refreshToken = jwtService.issueRefreshToken();
+        jwtService.setAccessAndRefreshToken(response, accessToken, refreshToken);
+        jwtRepository.save(memberProfileId.toString(), refreshToken, Duration.ofMillis(refreshTokenExpirationPeriod));
     }
 
     private void setResponseBody(HttpServletResponse response, Member member) throws IOException {

--- a/src/main/java/com/cupid/jikting/member/handler/LoginSuccessHandler.java
+++ b/src/main/java/com/cupid/jikting/member/handler/LoginSuccessHandler.java
@@ -66,10 +66,6 @@ public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
     private void setResponseBody(HttpServletResponse response, Member member) throws IOException {
         response.setContentType("application/json");
         response.setCharacterEncoding("utf-8");
-        response.getWriter().write(objectMapper.writeValueAsString(LoginResponse.builder()
-                .memberProfileId(member.getMemberProfileId())
-                .role(member.getRole().getKey())
-                .socialType(member.getSocialType().name())
-                .build()));
+        response.getWriter().write(objectMapper.writeValueAsString(LoginResponse.from(member)));
     }
 }

--- a/src/main/java/com/cupid/jikting/member/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/cupid/jikting/member/handler/OAuth2LoginSuccessHandler.java
@@ -63,10 +63,6 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
     private void setResponseBody(HttpServletResponse response, Member member) throws IOException {
         response.setContentType("application/json");
         response.setCharacterEncoding("utf-8");
-        response.getWriter().write(objectMapper.writeValueAsString(LoginResponse.builder()
-                .memberProfileId(member.getMemberProfileId())
-                .role(member.getRole().getKey())
-                .socialType(member.getSocialType().name())
-                .build()));
+        response.getWriter().write(objectMapper.writeValueAsString(LoginResponse.from(member)));
     }
 }

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -45,7 +45,7 @@ public class MemberService {
     private final ReportRepository reportRepository;
     private final RedisConnector redisConnector;
 
-    public void signup(SignupRequest signupRequest) {
+    public Member signup(SignupRequest signupRequest) {
         Member member = Member.builder()
                 .username(signupRequest.getUsername())
                 .password(passwordEncoder.encode(signupRequest.getPassword()))
@@ -56,7 +56,7 @@ public class MemberService {
                 .socialType(SocialType.NORMAL)
                 .build();
         member.addMemberProfile(signupRequest.getNickname());
-        memberRepository.save(member);
+        return memberRepository.save(member);
     }
 
     public MemberResponse get(Long memberProfileId) {


### PR DESCRIPTION
## Issue

closed #301 
[SP-428](https://soma-cupid.atlassian.net/browse/SP-428?atlOrigin=eyJpIjoiYjZkMTA5YzkzMDRhNDEyZWE2NTQwZWZmZjEwYzg4ODQiLCJwIjoiaiJ9)

## 요구사항

- [x] 회원가입 API 응답 토큰 추가

## 변경사항

- `LoginResponse` 빌더 패턴 삭제 및 정적 팩토리 메소드 적용

## 리뷰 우선순위

🚨 긴급

## 코멘트

회원가입 후 자동로그인 처리를 위해

1. 헤더에 액세스 토큰, 리프레시 토큰 추가
2. body에 memberProfileId, role, socialType 추가

<img width="868" alt="스크린샷 2023-11-21 오후 6 51 42" src="https://github.com/SWM-Cupid/jikting-backend/assets/62989828/bb8b20db-99a7-427e-b74d-f11f61cb0e18">

[SP-428]: https://soma-cupid.atlassian.net/browse/SP-428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ