### PR TITLE
[SP-429] 회원 프로필 기본값 추가

### DIFF
--- a/src/main/java/com/cupid/jikting/member/dto/MemberProfileResponse.java
+++ b/src/main/java/com/cupid/jikting/member/dto/MemberProfileResponse.java
@@ -6,7 +6,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -15,34 +14,41 @@ import java.util.stream.Collectors;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberProfileResponse {
 
-    private List<ImageResponse> images;
-    private LocalDate birth;
+    private String birth;
     private int height;
     private String address;
     private String mbti;
     private String smokeStatus;
     private String drinkStatus;
     private String college;
+    private String description;
     private List<String> personalities;
     private List<String> hobbies;
-    private String description;
+    private List<ImageResponse> images;
 
     public static MemberProfileResponse of(MemberProfile memberProfile) {
         List<ImageResponse> images = memberProfile.getProfileImages()
                 .stream()
                 .map(ImageResponse::of)
                 .collect(Collectors.toList());
+        if (memberProfile.isNotFilled()) {
+            return new MemberProfileResponse(
+                    "", 0, "", "", "", "", "", "",
+                    memberProfile.getPersonalityKeywords(), memberProfile.getHobbyKeywords(), images
+            );
+        }
         return new MemberProfileResponse(
-                images,
-                memberProfile.getBirth(),
+                memberProfile.getBirth().toString(),
                 memberProfile.getHeight(),
                 memberProfile.getAddress(),
                 memberProfile.getMbti().name(),
                 memberProfile.getSmokeStatus().getMessage(),
                 memberProfile.getDrinkStatus().getMessage(),
                 memberProfile.getCollege(),
+                memberProfile.getDescription(),
                 memberProfile.getPersonalityKeywords(),
                 memberProfile.getHobbyKeywords(),
-                memberProfile.getDescription());
+                images
+        );
     }
 }

--- a/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
+++ b/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
@@ -188,4 +188,8 @@ public class MemberProfile extends BaseEntity {
     public String getMemberName() {
         return member.getName();
     }
+
+    public boolean isNotFilled() {
+        return birth == null;
+    }
 }

--- a/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
+++ b/src/main/java/com/cupid/jikting/member/entity/MemberProfile.java
@@ -167,10 +167,6 @@ public class MemberProfile extends BaseEntity {
         instantMeetingMembers.add(instantMeetingMember);
     }
 
-    public Long getTeamId() {
-        return getTeam().getId();
-    }
-
     public void validatePassword(PasswordEncoder passwordEncoder, String password) {
         member.validatePassword(passwordEncoder, password);
     }

--- a/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
+++ b/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
@@ -218,7 +218,7 @@ public class MemberServiceTest {
         assertAll(
                 () -> verify(memberProfileRepository).findById(anyLong()),
                 () -> assertThat(memberProfileResponse.getImages()).hasSize(PROFILE_IMAGE_SIZE),
-                () -> assertThat(memberProfileResponse.getBirth()).isEqualTo(memberProfile.getBirth()),
+                () -> assertThat(memberProfileResponse.getBirth()).isEqualTo(memberProfile.getBirth().toString()),
                 () -> assertThat(memberProfileResponse.getHeight()).isEqualTo(memberProfile.getHeight()),
                 () -> assertThat(memberProfileResponse.getAddress()).isEqualTo(memberProfile.getAddress()),
                 () -> assertThat(memberProfileResponse.getMbti()).isEqualTo(memberProfile.getMbti().name()),


### PR DESCRIPTION
## Issue

closed #303 
[SP-429](https://soma-cupid.atlassian.net/browse/SP-429?atlOrigin=eyJpIjoiMDhhZTlmYjQxN2EzNGRiYWExZTEyOGZmOTk2MDI3ZjEiLCJwIjoiaiJ9)

## 요구사항

- [x] 회원 프로필 기본값 추가

## 변경사항

- `MemberProfile` 미사용 메소드(`getTeamId`) 삭제

## 리뷰 우선순위

🚨 긴급

## 코멘트

- 회원 가입 후 프로필 입력 전 기본값 반환을 위해 MemberProfileResponse 수정
- 응답 예시

  ```json
  {
      "birth": "",
      "height": 0,
      "address": "",
      "mbti": "",
      "smokeStatus": "",
      "drinkStatus": "",
      "college": "",
      "description": "",
      "personalities": [],
      "hobbies": [],
      "images": [
          {
              "profileImageId": 144,
              "url": "https://cupid-images.s3.ap-northeast-2.amazonaws.com/default.png",
              "sequence": "MAIN"
          },
          {
              "profileImageId": 145,
              "url": "https://cupid-images.s3.ap-northeast-2.amazonaws.com/default.png",
              "sequence": "FIRST"
          },
          {
              "profileImageId": 146,
              "url": "https://cupid-images.s3.ap-northeast-2.amazonaws.com/default.png",
              "sequence": "SECOND"
          }
      ]
  }
  ```

[SP-429]: https://soma-cupid.atlassian.net/browse/SP-429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ