### PR TITLE
[SP-431] 마이페이지 회사 미인증 사용자 예외 처리 수정

### DIFF
--- a/src/main/java/com/cupid/jikting/member/dto/MemberResponse.java
+++ b/src/main/java/com/cupid/jikting/member/dto/MemberResponse.java
@@ -17,15 +17,8 @@ public class MemberResponse {
 
     public static MemberResponse of(Member member) {
         if (member.isNotCertifiedCompany()) {
-            return new MemberResponse(
-                    member.getNickname(),
-                    "",
-                    member.getMainImageUrl()
-            );
+            return new MemberResponse(member.getNickname(), "", member.getMainImageUrl());
         }
-        return new MemberResponse(
-                member.getNickname(),
-                member.getCompany(),
-                member.getMainImageUrl());
+        return new MemberResponse(member.getNickname(), member.getCompany(), member.getMainImageUrl());
     }
 }

--- a/src/main/java/com/cupid/jikting/member/dto/MemberResponse.java
+++ b/src/main/java/com/cupid/jikting/member/dto/MemberResponse.java
@@ -1,6 +1,6 @@
 package com.cupid.jikting.member.dto;
 
-import com.cupid.jikting.member.entity.MemberProfile;
+import com.cupid.jikting.member.entity.Member;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -15,10 +15,17 @@ public class MemberResponse {
     private String company;
     private String imageUrl;
 
-    public static MemberResponse of(MemberProfile memberProfile) {
+    public static MemberResponse of(Member member) {
+        if (member.isNotCertifiedCompany()) {
+            return new MemberResponse(
+                    member.getNickname(),
+                    "",
+                    member.getMainImageUrl()
+            );
+        }
         return new MemberResponse(
-                memberProfile.getNickname(),
-                memberProfile.getCompany(),
-                memberProfile.getMainImageUrl());
+                member.getNickname(),
+                member.getCompany(),
+                member.getMainImageUrl());
     }
 }

--- a/src/main/java/com/cupid/jikting/member/entity/Member.java
+++ b/src/main/java/com/cupid/jikting/member/entity/Member.java
@@ -79,6 +79,10 @@ public class Member extends BaseEntity {
         memberCompanies.forEach(MemberCompany::block);
     }
 
+    public boolean isNotCertifiedCompany() {
+        return role == Role.UNCERTIFIED;
+    }
+
     private void validateCompanyExists() {
         if (memberCompanies.isEmpty()) {
             throw new BadRequestException(ApplicationError.FORBIDDEN_MEMBER);

--- a/src/main/java/com/cupid/jikting/member/entity/Member.java
+++ b/src/main/java/com/cupid/jikting/member/entity/Member.java
@@ -83,6 +83,18 @@ public class Member extends BaseEntity {
         return role == Role.UNCERTIFIED;
     }
 
+    public String getNickname() {
+        return memberProfile.getNickname();
+    }
+
+    public String getCompany() {
+        return memberProfile.getCompany();
+    }
+
+    public String getMainImageUrl() {
+        return memberProfile.getMainImageUrl();
+    }
+
     private void validateCompanyExists() {
         if (memberCompanies.isEmpty()) {
             throw new BadRequestException(ApplicationError.FORBIDDEN_MEMBER);

--- a/src/main/java/com/cupid/jikting/member/service/MemberService.java
+++ b/src/main/java/com/cupid/jikting/member/service/MemberService.java
@@ -60,7 +60,7 @@ public class MemberService {
     }
 
     public MemberResponse get(Long memberProfileId) {
-        return MemberResponse.of(getMemberProfileById(memberProfileId));
+        return MemberResponse.of(getMemberById(memberProfileId));
     }
 
     public MemberProfileResponse getProfile(Long memberProfileId) {
@@ -194,6 +194,11 @@ public class MemberService {
                 .message(reportMessageRequest.getMessage())
                 .build();
         reportRepository.save(report);
+    }
+
+    private Member getMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new NotFoundException(ApplicationError.MEMBER_NOT_FOUND));
     }
 
     private MemberProfile getMemberProfileById(Long memberProfileId) {

--- a/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cupid/jikting/member/controller/MemberControllerTest.java
@@ -239,7 +239,7 @@ public class MemberControllerTest extends ApiDocument {
         companyVerificationRequestPart = new MockPart(COMPANY_VERIFICATION_REQUEST_PARAMETER_NAME, toJson(companyVerificationRequest).getBytes(StandardCharsets.UTF_8));
         companyVerificationRequestPart.getHeaders().setContentType(MediaType.APPLICATION_JSON);
         image = new MockMultipartFile(IMAGE_PARAMETER_NAME, IMAGE_FILENAME, IMAGE_CONTENT_TYPE, IMAGE_FILE.getBytes());
-        memberResponse = MemberResponse.of(memberProfile);
+        memberResponse = MemberResponse.of(member);
         memberProfileResponse = MemberProfileResponse.of(memberProfile);
         usernameResponse = UsernameResponse.from(member);
         invalidFormatException = new BadRequestException(ApplicationError.INVALID_FORMAT);

--- a/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
+++ b/src/test/java/com/cupid/jikting/member/service/MemberServiceTest.java
@@ -186,12 +186,12 @@ public class MemberServiceTest {
     @Test
     void 회원_조회_성공() {
         // given
-        willReturn(Optional.of(memberProfile)).given(memberProfileRepository).findById(anyLong());
+        willReturn(Optional.of(member)).given(memberRepository).findById(anyLong());
         // when
         MemberResponse memberResponse = memberService.get(ID);
         // then
         assertAll(
-                () -> verify(memberProfileRepository).findById(anyLong()),
+                () -> verify(memberRepository).findById(anyLong()),
                 () -> assertThat(memberResponse.getNickname()).isEqualTo(NICKNAME),
                 () -> assertThat(memberResponse.getCompany()).isEqualTo(COMPANY),
                 () -> assertThat(memberResponse.getImageUrl()).isEqualTo(IMAGE_URL)
@@ -201,7 +201,7 @@ public class MemberServiceTest {
     @Test
     void 회원_조회_실패_회원_없음() {
         //given
-        willThrow(new NotFoundException(ApplicationError.MEMBER_NOT_FOUND)).given(memberProfileRepository).findById(anyLong());
+        willThrow(new NotFoundException(ApplicationError.MEMBER_NOT_FOUND)).given(memberRepository).findById(anyLong());
         //when & then
         assertThatThrownBy(() -> memberService.get(ID))
                 .isInstanceOf(NotFoundException.class)


### PR DESCRIPTION
## Issue

closed #305 
[SP-431](https://soma-cupid.atlassian.net/browse/SP-431?atlOrigin=eyJpIjoiMGFhM2EzMjkwYzk4NGYyZGJmZWE0MzRiODk4MzYwMTUiLCJwIjoiaiJ9)

## 요구사항

- [x] 마이페이지 회사 미인증 사용자 예외 처리 수정

## 변경사항

- X

## 리뷰 우선순위

🙂보통

## 코멘트

- 현재 회사 미인증 사용자 마이페이지 접근 불가 -> 회사 인증이 마이페이지에서 할 수 있기 때문에 접근 가능하도록 응답값 수정
- 응답 예시

    ```json
    {
        "nickname": "미스포춘",
        "company": "",
        "imageUrl": "https://cupid-images.s3.ap-northeast-2.amazonaws.com/default.png"
    }
    ```

[SP-431]: https://soma-cupid.atlassian.net/browse/SP-431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ