### PR TITLE
[SP-436] 팀 등록 시 회사 미인증 사용자 제한 로직 추가

### DIFF
--- a/src/main/java/com/cupid/jikting/common/error/ApplicationError.java
+++ b/src/main/java/com/cupid/jikting/common/error/ApplicationError.java
@@ -41,6 +41,7 @@ public enum ApplicationError {
     PROFILE_IMAGE_NOT_FOUND(HttpStatus.BAD_REQUEST, "U014", "프로필 이미지를 찾을 수 없습니다."),
     PROFILE_IMAGE_NOT_FACE(HttpStatus.BAD_REQUEST, "U015", "프로필 이미지에 얼굴이 존재하지 않습니다."),
     PHONE_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "U016", "이미 회원가입된 전화번호입니다."),
+    UNCERTIFIED_MEMBER(HttpStatus.FORBIDDEN, "U017", "회사 인증을 하지 않은 사용자입니다."),
 
     TEAM_NOT_FOUND(HttpStatus.BAD_REQUEST, "T001", "팀을 찾을 수 없습니다."),
     GENDER_MISMATCH(HttpStatus.BAD_REQUEST, "T002", "해당 성별은 팀에 참여할 수 없습니다."),

--- a/src/main/java/com/cupid/jikting/team/service/TeamService.java
+++ b/src/main/java/com/cupid/jikting/team/service/TeamService.java
@@ -38,9 +38,7 @@ public class TeamService {
     public void register(Long memberProfileId, TeamRegisterRequest teamRegisterRequest) {
         MemberProfile memberProfile = getMemberProfileById(memberProfileId);
         validateCertified(memberProfile);
-        if (memberProfile.isInTeam()) {
-            throw new BadRequestException(ApplicationError.ALREADY_IN_TEAM);
-        }
+        validateTeamExists(memberProfile);
         Team team = Team.builder()
                 .name(getRandomTeamName())
                 .description(teamRegisterRequest.getDescription())
@@ -85,6 +83,12 @@ public class TeamService {
     private void validateCertified(MemberProfile memberProfile) {
         if (memberProfile.getMember().isNotCertifiedCompany()) {
             throw new WrongAccessException(ApplicationError.UNCERTIFIED_MEMBER);
+        }
+    }
+
+    private void validateTeamExists(MemberProfile memberProfile) {
+        if (memberProfile.isInTeam()) {
+            throw new BadRequestException(ApplicationError.ALREADY_IN_TEAM);
         }
     }
 

--- a/src/main/java/com/cupid/jikting/team/service/TeamService.java
+++ b/src/main/java/com/cupid/jikting/team/service/TeamService.java
@@ -4,6 +4,7 @@ import com.cupid.jikting.common.entity.Personality;
 import com.cupid.jikting.common.error.ApplicationError;
 import com.cupid.jikting.common.error.BadRequestException;
 import com.cupid.jikting.common.error.NotFoundException;
+import com.cupid.jikting.common.error.WrongAccessException;
 import com.cupid.jikting.common.repository.PersonalityRepository;
 import com.cupid.jikting.common.util.TeamNameGenerator;
 import com.cupid.jikting.member.entity.MemberProfile;
@@ -36,6 +37,7 @@ public class TeamService {
 
     public void register(Long memberProfileId, TeamRegisterRequest teamRegisterRequest) {
         MemberProfile memberProfile = getMemberProfileById(memberProfileId);
+        validateCertified(memberProfile);
         if (memberProfile.isInTeam()) {
             throw new BadRequestException(ApplicationError.ALREADY_IN_TEAM);
         }
@@ -78,6 +80,12 @@ public class TeamService {
     private MemberProfile getMemberProfileById(Long memberProfileId) {
         return memberProfileRepository.findById(memberProfileId)
                 .orElseThrow(() -> new NotFoundException(ApplicationError.MEMBER_NOT_FOUND));
+    }
+
+    private void validateCertified(MemberProfile memberProfile) {
+        if (memberProfile.getMember().isNotCertifiedCompany()) {
+            throw new WrongAccessException(ApplicationError.UNCERTIFIED_MEMBER);
+        }
     }
 
     private String getRandomTeamName() {

--- a/src/test/java/com/cupid/jikting/team/service/TeamServiceTest.java
+++ b/src/test/java/com/cupid/jikting/team/service/TeamServiceTest.java
@@ -78,6 +78,7 @@ class TeamServiceTest {
         Member member = Member.builder()
                 .memberCompanies(List.of(memberCompany))
                 .type(TYPE)
+                .role(Role.CERTIFIED)
                 .build();
         member.addMemberProfile(NICKNAME);
         MemberProfile leader = member.getMemberProfile();
@@ -114,9 +115,11 @@ class TeamServiceTest {
     @Test
     void 팀_등록_성공() {
         // given
-        MemberProfile memberProfile = MemberProfile.builder()
-                .id(ID)
+        Member member = Member.builder()
+                .role(Role.CERTIFIED)
                 .build();
+        member.addMemberProfile(NICKNAME);
+        MemberProfile memberProfile = member.getMemberProfile();
         willReturn(Optional.of(memberProfile)).given(memberProfileRepository).findById(anyLong());
         willReturn(Optional.of(personality)).given(personalityRepository).findByKeyword(anyString());
         willReturn(team).given(teamRepository).save(any(Team.class));
@@ -161,9 +164,11 @@ class TeamServiceTest {
     @Test
     void 팀_등록_실패_키워드_없음() {
         // given
-        MemberProfile memberProfile = MemberProfile.builder()
-                .id(ID)
+        Member member = Member.builder()
+                .role(Role.CERTIFIED)
                 .build();
+        member.addMemberProfile(NICKNAME);
+        MemberProfile memberProfile = member.getMemberProfile();
         willReturn(Optional.of(memberProfile)).given(memberProfileRepository).findById(anyLong());
         willThrow(new NotFoundException(ApplicationError.PERSONALITY_NOT_FOUND)).given(personalityRepository).findByKeyword(anyString());
         // when & then


### PR DESCRIPTION
## Issue

closed #315 
[SP-436](https://soma-cupid.atlassian.net/browse/SP-436?atlOrigin=eyJpIjoiMjY2NTA0NWU1MzQzNDhhMGEwMzRkNGJiMjc5Y2Q4MWIiLCJwIjoiaiJ9)

## 요구사항

- [x] 팀 등록 시 회사 미인증 사용자 제한 로직 추가

## 변경사항

- `TeamService` 팀 등록 시 팀 존재 여부 확인 로직 메소드로 추출

## 리뷰 우선순위

🙂보통

[SP-436]: https://soma-cupid.atlassian.net/browse/SP-436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ