### PR TITLE
[SP-441] 팀 구성 완료 시 추천 팀 생성 로직 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,16 @@
+buildscript {
+    ext {
+        queryDslVersion = "5.0.0"
+    }
+}
+
 plugins {
     id 'java'
     id 'org.springframework.boot' version '2.7.13'
     id 'io.spring.dependency-management' version '1.0.15.RELEASE'
     id 'org.asciidoctor.jvm.convert' version '3.3.2'
     id 'jacoco'
+    id 'com.ewerk.gradle.plugins.querydsl' version '1.0.10'
 }
 
 group = 'com.cupid'
@@ -42,6 +49,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.session:spring-session-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-aop'
+    implementation 'com.querydsl:querydsl-jpa:5.0.0'
+    implementation 'com.querydsl:querydsl-apt:5.0.0'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'
@@ -113,4 +122,26 @@ tasks.register('copyDocument', Copy) {
 
 build {
     dependsOn copyDocument
+}
+
+def querydslDir = "$buildDir/generated/querydsl"
+
+querydsl {
+    jpa = true
+    querydslSourcesDir = querydslDir
+}
+
+sourceSets {
+    main.java.srcDir querydslDir
+}
+
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+    querydsl.extendsFrom compileClasspath
+}
+
+compileQuerydsl {
+    options.annotationProcessorPath = configurations.querydsl
 }

--- a/src/main/java/com/cupid/jikting/common/config/QuerydslConfig.java
+++ b/src/main/java/com/cupid/jikting/common/config/QuerydslConfig.java
@@ -1,0 +1,20 @@
+package com.cupid.jikting.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/cupid/jikting/recommend/service/RecommendService.java
+++ b/src/main/java/com/cupid/jikting/recommend/service/RecommendService.java
@@ -10,7 +10,6 @@ import com.cupid.jikting.recommend.repository.RecommendRepository;
 import com.cupid.jikting.team.entity.AcceptStatus;
 import com.cupid.jikting.team.entity.TeamLike;
 import com.cupid.jikting.team.repository.TeamLikeRepository;
-import com.cupid.jikting.team.repository.TeamRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,7 +25,6 @@ public class RecommendService {
     private final MemberProfileRepository memberProfileRepository;
     private final RecommendRepository recommendRepository;
     private final TeamLikeRepository teamLikeRepository;
-    private final TeamRepository teamRepository;
 
     @Transactional(readOnly = true)
     public List<RecommendResponse> get(Long memberProfileId) {

--- a/src/main/java/com/cupid/jikting/team/entity/Team.java
+++ b/src/main/java/com/cupid/jikting/team/entity/Team.java
@@ -92,4 +92,8 @@ public class Team extends BaseEntity {
         this.description = description;
         this.teamPersonalities.update(teamPersonalities);
     }
+
+    public boolean isCompleted() {
+        return teamMembers.size() == memberCount;
+    }
 }

--- a/src/main/java/com/cupid/jikting/team/repository/CustomTeamRepository.java
+++ b/src/main/java/com/cupid/jikting/team/repository/CustomTeamRepository.java
@@ -1,0 +1,8 @@
+package com.cupid.jikting.team.repository;
+
+import com.cupid.jikting.team.entity.Team;
+
+public interface CustomTeamRepository {
+
+    Team findRecommendingTeamFor(Team team);
+}

--- a/src/main/java/com/cupid/jikting/team/repository/CustomTeamRepositoryImpl.java
+++ b/src/main/java/com/cupid/jikting/team/repository/CustomTeamRepositoryImpl.java
@@ -1,0 +1,26 @@
+package com.cupid.jikting.team.repository;
+
+import com.cupid.jikting.team.entity.Team;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import static com.cupid.jikting.team.entity.QTeam.team;
+
+@RequiredArgsConstructor
+@Repository
+public class CustomTeamRepositoryImpl implements CustomTeamRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Team findRecommendingTeamFor(Team recommendingTeam) {
+        return queryFactory
+                .selectFrom(team)
+                .where(
+                        team.gender.ne(recommendingTeam.getGender()),
+                        team.memberCount.eq(recommendingTeam.getMemberCount())
+                )
+                .fetchFirst();
+    }
+}

--- a/src/main/java/com/cupid/jikting/team/repository/TeamRepository.java
+++ b/src/main/java/com/cupid/jikting/team/repository/TeamRepository.java
@@ -3,7 +3,7 @@ package com.cupid.jikting.team.repository;
 import com.cupid.jikting.team.entity.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface TeamRepository extends JpaRepository<Team, Long> {
+public interface TeamRepository extends JpaRepository<Team, Long>, CustomTeamRepository {
 
     boolean existsByName(String name);
 }

--- a/src/main/java/com/cupid/jikting/team/service/TeamService.java
+++ b/src/main/java/com/cupid/jikting/team/service/TeamService.java
@@ -53,7 +53,9 @@ public class TeamService {
     public void attend(Long teamId, Long memberProfileId) {
         MemberProfile memberProfile = getMemberProfileById(memberProfileId);
         validateTeamExists(memberProfile);
-        TeamMember.of(!LEADER, getTeamById(teamId), memberProfile);
+        Team team = getTeamById(teamId);
+        validateAttendable(team);
+        TeamMember.of(!LEADER, team, memberProfile);
         memberProfileRepository.save(memberProfile);
     }
 
@@ -128,5 +130,11 @@ public class TeamService {
     private Team getTeamById(Long teamId) {
         return teamRepository.findById(teamId)
                 .orElseThrow(() -> new NotFoundException(ApplicationError.TEAM_NOT_FOUND));
+    }
+
+    private void validateAttendable(Team team) {
+        if (team.isCompleted()) {
+            throw new BadRequestException(ApplicationError.TEAM_ALREADY_FULL);
+        }
     }
 }

--- a/src/main/java/com/cupid/jikting/team/service/TeamService.java
+++ b/src/main/java/com/cupid/jikting/team/service/TeamService.java
@@ -9,6 +9,8 @@ import com.cupid.jikting.common.repository.PersonalityRepository;
 import com.cupid.jikting.common.util.TeamNameGenerator;
 import com.cupid.jikting.member.entity.MemberProfile;
 import com.cupid.jikting.member.repository.MemberProfileRepository;
+import com.cupid.jikting.recommend.entity.Recommend;
+import com.cupid.jikting.recommend.repository.RecommendRepository;
 import com.cupid.jikting.team.dto.TeamRegisterRequest;
 import com.cupid.jikting.team.dto.TeamResponse;
 import com.cupid.jikting.team.dto.TeamUpdateRequest;
@@ -34,6 +36,7 @@ public class TeamService {
     private final TeamRepository teamRepository;
     private final MemberProfileRepository memberProfileRepository;
     private final PersonalityRepository personalityRepository;
+    private final RecommendRepository recommendRepository;
 
     public void register(Long memberProfileId, TeamRegisterRequest teamRegisterRequest) {
         MemberProfile memberProfile = getMemberProfileById(memberProfileId);
@@ -56,6 +59,10 @@ public class TeamService {
         Team team = getTeamById(teamId);
         validateAttendable(team);
         TeamMember.of(!LEADER, team, memberProfile);
+        if (team.isCompleted()) {
+            Team recommendingTeam = teamRepository.findRecommendingTeamFor(team);
+            recommendRepository.save(Recommend.builder().from(recommendingTeam).to(team).build());
+        }
         memberProfileRepository.save(memberProfile);
     }
 

--- a/src/test/java/com/cupid/jikting/team/service/TeamServiceTest.java
+++ b/src/test/java/com/cupid/jikting/team/service/TeamServiceTest.java
@@ -7,6 +7,8 @@ import com.cupid.jikting.common.error.NotFoundException;
 import com.cupid.jikting.common.repository.PersonalityRepository;
 import com.cupid.jikting.member.entity.*;
 import com.cupid.jikting.member.repository.MemberProfileRepository;
+import com.cupid.jikting.recommend.entity.Recommend;
+import com.cupid.jikting.recommend.repository.RecommendRepository;
 import com.cupid.jikting.team.dto.TeamRegisterRequest;
 import com.cupid.jikting.team.dto.TeamResponse;
 import com.cupid.jikting.team.dto.TeamUpdateRequest;
@@ -67,6 +69,9 @@ class TeamServiceTest {
 
     @Mock
     private PersonalityRepository personalityRepository;
+
+    @Mock
+    private RecommendRepository recommendRepository;
 
     @BeforeEach
     void setUp() {
@@ -190,6 +195,24 @@ class TeamServiceTest {
         assertAll(
                 () -> verify(memberProfileRepository).findById(anyLong()),
                 () -> verify(teamRepository).findById(anyLong()),
+                () -> verify(memberProfileRepository).save(any(MemberProfile.class))
+        );
+    }
+
+    @Test
+    void 팀_참여_시_팀원_구성_완료_성공() {
+        // given
+        MemberProfile memberProfile = MemberProfile.builder().build();
+        willReturn(Optional.of(memberProfile)).given(memberProfileRepository).findById(anyLong());
+        willReturn(Optional.of(team)).given(teamRepository).findById(anyLong());
+        willReturn(memberProfile).given(memberProfileRepository).save(any(MemberProfile.class));
+        // when
+        teamService.attend(ID, ID);
+        // then
+        assertAll(
+                () -> verify(memberProfileRepository).findById(anyLong()),
+                () -> verify(teamRepository).findById(anyLong()),
+                () -> verify(recommendRepository).save(any(Recommend.class)),
                 () -> verify(memberProfileRepository).save(any(MemberProfile.class))
         );
     }

--- a/src/test/java/com/cupid/jikting/team/service/TeamServiceTest.java
+++ b/src/test/java/com/cupid/jikting/team/service/TeamServiceTest.java
@@ -250,6 +250,24 @@ class TeamServiceTest {
     }
 
     @Test
+    void 팀_참여_실패_팀원_구성_완료() {
+        TeamMember teamMember1 = TeamMember.of(true, team, memberProfile);
+        TeamMember teamMember2 = TeamMember.of(false, team, memberProfile);
+        Team team = Team.builder()
+                .teamMembers(List.of(teamMember1, teamMember2))
+                .memberCount(2)
+                .build();
+        // given
+        MemberProfile memberProfile = MemberProfile.builder().build();
+        willReturn(Optional.of(memberProfile)).given(memberProfileRepository).findById(anyLong());
+        willReturn(Optional.of(team)).given(teamRepository).findById(anyLong());
+        // when & then
+        assertThatThrownBy(() -> teamService.attend(ID, ID))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(ApplicationError.TEAM_ALREADY_FULL.getMessage());
+    }
+
+    @Test
     void 팀_조회_성공() {
         // given
         willReturn(Optional.of(memberProfile)).given(memberProfileRepository).findById(anyLong());


### PR DESCRIPTION
## Issue

closed #323 
[SP-441](https://soma-cupid.atlassian.net/browse/SP-441?atlOrigin=eyJpIjoiZmY4Y2QxZWZlOGZjNDQ0Yjk0ODI2MjUxMjQzZDU3MDEiLCJwIjoiaiJ9)

## 요구사항

- [x] 팀 구성 완료 시 추천 팀 생성 로직 추가

## 변경사항

- `TeamService` 팀 참여 메소드 이미 팀원 구성 완료된 경우 예외 처리

## 리뷰 우선순위

🙂보통

## 코멘트

- 추후 초기 추천 팀을 정하는 로직이 복잡해질 것을 고려해, Querydsl을 이용해 초기 추천 팀을 불러오도록 구현했습니다.

[SP-441]: https://soma-cupid.atlassian.net/browse/SP-441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ